### PR TITLE
Add pt_BR translation files

### DIFF
--- a/default_translations/pt/messages.pt.yml
+++ b/default_translations/pt/messages.pt.yml
@@ -1,0 +1,257 @@
+start:
+  title: Te damos as boas-vindas a %domain%!
+  intro: Aqui você pode criar e configurar a sua conta de e-mail.
+  registration-header: Registro
+  registration-text: >
+    Ainda não tem uma conta em %domain%? Sem problemas!
+    Se você conhece alguém que já possua uma conta você pode
+    pedir um convite e começar imediatamente a criar a sua própria.
+  registration-button: Criar conta
+  account-settings: Configurar conta
+  account-settings-desc: Senhas e mais
+  account-delete: Excluir conta
+  aliases: Endereços alias
+  aliases-delete: Excluir endereço alias
+  aliases-desc: Oculte sua identidade
+  vouchers: Convites
+  vouchers-desc: Convide seus contatos
+  webmail: Webmail
+  webmail-desc: Leia e escreva e-mails
+
+index:
+  title: Configurações
+  voucher-headline: Seus convites
+  voucher-limit: Você não tem mais convites disponíveis.
+  voucher-disable: >
+    No dia %date% você vai receber três códigos de convite.
+    Isso é feito para evitar cadastros excessivos e spam.
+  voucher-sharing: Copiar o link de convite
+  voucher-explanation: >
+    Use os seus códigos para convidar seus contatos para cá.
+    Por padrão, você tem três convites.
+    Se precisar convidar mais pessoas, entre em contato com os administradores.
+    Os dados sobre os convites serão guardados por um tempo limitado como
+    proteção contra abusos.
+  alias-headline: Seus endereços alias %alias_type%
+  alias-limit: Você atingiu o limite de %alias_limit% endereços alias %alias_type% permitidos.
+  alias-deletion-custom: Entre em contato conosco para excluir endereços.
+  alias-deletion-random: Assim que excluir endereços antigos, você poderá criar novos endereços.
+  alias-empty: Você não tem nenhum endereço alias %alias_type% definido.
+  delete-headline: Excluir conta
+  delete-description: >
+    Você pode excluir sua conta %project_name%.
+    Isso irá deletar todos os seus e-mails.
+    <strong>Eles não poderão ser recuperados no futuro.</strong>
+    <br /><br />
+    Para excluir sua conta você deve inserir sua senha atual.
+  delete-button: Excluir conta
+  recovery-token-button: Configurar token de recuperação
+  logged_in_as: Você entrou como %user%.
+  alias-explanation: |
+    <p>
+      Use endereços alias para esconder o seu endereço original de
+      pessoas que você não conhece bem ou empresas em que você não confia.
+    </p>
+    <p>
+      <ul>
+        <li>All mails sent to alias addresses go to your normal mailbox.</li>
+        <li>Todas as mensagens enviadas para endereços alias chegam na sua caixa de entrada original.</li>
+        <li>Para enviar a partir de um endereço alias, you have to manually configure your mail client.</li>
+        <li>Você pode ter até %alias_limit_custom% endereços personalizados.</li>
+        <li>Você pode ter até %alias_limit_random% endereços aleatórios.</li>
+        <li>Endereços aleatórios devem ser usados para situações únicas,
+        como uma forma de evitar rastreamento entre diferentes serviços.</li>
+        <li>Entre em contato conosco para deletar endereços personalizados.</li>
+      </ul>
+    </p>
+
+form:
+  title: Cadastro
+  signin-header: Login
+  register-header: Criar conta
+  email: E-mail
+  password: Senha
+  password_confirmation: Confirme sua senha
+  remember-me: Lembrar meu login
+  signin: Login
+  recovery-link: Esqueceu sua senha?
+  roles: Roles
+  submit: Enviar
+  voucher: Código de convite
+  voucher-redeemed-on: Resgatado em
+  oclock-by: por
+  actual-password: Senha atual
+  new-custom-alias: Novo endereço alias
+  new-password: Nova senha
+  new-password_confirmation: Confime sua nova senha
+  change-password: Mudar sua senha
+  delete-account: Excluir conta
+  delete-password: Senha
+  create-voucher: Criar código de convite
+  create-custom-alias: Adicionar
+  create-random-alias: Gerar endereço alias aleatório
+  delete-alias: Deletar endereço alias
+  generate-recovery-token: Criar novo token de recuperação
+  recovery-token: Token de recuperação
+  recovery-start: Recuperar
+  registration-recovery-token-ack: Eu guardei o token de recuperação em um lugar seguro
+  registration-recovery-token-next-button: Continuar
+
+recovery:
+  header: Recuperar sua conta
+  lead: Redefina sua senha usando seu token de recuperação
+  cancel: Cancelar
+  started: |
+    Quase lá. Esse foi o primeiro passo para redefinir sua senha.
+    Agora você precisa esperar por 48 horas. Depois disso, no segundo passo, você pode criar uma nova senha.
+    Por favor mantenha seu token guardado até lá.
+  waiting-info: Esse tempo de espera é pela sua segurança e não pode ser encurtado ou ignorado.
+  waiting-time: O segundo passo começa %time%.
+  reset-lead: Agora você pode redefinir sua senha
+  token-lead: Novo token de recuperação
+
+navbar_left:
+  about-us:
+    text: Sobre nós
+    link: https://www.example.org/en/about-us
+
+navbar_right:
+  login: Entrar
+  logout: Sair
+  register: Cadastro
+  password-change: Mudar senha
+  admin: Administrador
+
+registration:
+  title: Cadastro com %project_name%
+  information: Information
+  information-intro: >
+    Gostaria de se cadastrar em <a href="%project_url%">%project_name%</a>?
+    Você só pode se cadastrar se receber um convite para o nosso serviço.
+  information-password-policy: >
+    <strong>Importante:</strong>
+    Sua senha deve ter pelo menos 12 caracteres.
+  label-email: Seu endereço de email desejado
+  recovery-token-headline: Token de recuperação
+
+welcome:
+  headline: Te damos as boas-vindas a %project_name%!
+  lead: Você criou sua conta com sucesso. E agora?
+  next-button: Seus próximos passos
+  text: >
+    <h3>Tudo pronto</h3>
+    <p>Pela web você pode encontrar guias de como configurar sua conta de e-mail com diferentes programas de e-mail.</p>
+    <p>Em uma semana você vai receber três códigos de convite, os quais você pode pegar em <a href="%app_url%">%app_url%</a>. Você pode enviá-los a seus contatos e chamá-los para se cadastrar no %project_name%.</p>
+
+closed:
+  title: Cadastros fechados
+  headline: Cadastros fechados
+  lead: >
+    De acordo com o parágrafo 3 das normas de telecomunicação TKÜV
+    decidimos manter um limite de 10.000 registros.
+    Lamentamos a inconveniência.
+
+delete:
+  alias:
+    headline: Excluir o endereço alias %alias%
+    lead: Precisamos verificar sua senha para excluir o seu endereço alias.
+  user:
+    headline: Excluir conta
+    lead: Precisamos verificar sua senha para excluir a sua conta.
+  cancel: Cancelar
+
+recovery-token:
+  headline: Gerenciar token de recuperação
+  lead: O token de recuperação pode ser usado para redefinir a sua senha se você esquecê-la.
+  set: Você já tem um token configurado.
+  set-extra: Se você criar um novo token de recuperação o seu token atual será invalidado.
+  unset: Você ainda não tem um token de recuperação configurado. Recomendamos fortemente que crie um agora mesmo.
+  created-headline: O seguinte token foi gerado para você:
+  created-info: >
+    Se você perder sua senha, o token de recuperação permite que você crie uma nova.
+    Anote e guarde-o em algum lugar seguro.
+  displayed-once: >
+    Por questão de segurança, o token de recuperação só é exibido uma vez.
+    Nós não podemos recuperar esse token por você.
+
+flashes:
+  logout-successful: Sua sessão foi encerrada!
+  password-change-successful: Sua nova senha está ativa!
+  registration-successful: Você se cadastrou com sucesso!
+  voucher-creation-successful: Você gerou um novo convite!
+  alias-creation-successful: O seu novo endereço alias foi criado!
+  alias-deletion-successful: O seu endereço alias foi excluido com sucesso!
+  recovery-token-invalid: O endereço de e-mail ou o token de recuperação está errado!
+  recovery-token-ack: Você gerou um token de recuperação com sucesso!
+  revocery-reauthenticate: Algo deu errado. Por favor se autentique novamente!
+  recovery-password-changed: Você mudou a sua senha com sucesso.
+  recovery-next-login: Inicie sua sessão agora.
+
+flash_batch_remove_vouchers_success: Códigos de convite excluidos com sucesso
+
+error:
+  title: Oops, houve um erro.
+  back_link: Voltar para o início
+  page_not_found: A página procurada não existe.
+  generic_error: Desculpe, um erro ocorreu.
+
+spam:
+  title: Conta bloqueada
+  text: |
+    Ah não! Acreditamos que a sua conta tenha sido usada por um spammer.
+    Nós bloqueamos o acesso ao e-mail por essa razão.
+    Por favor entre em contato com o suporte para desbloquear a sua conta.
+
+# internal translations
+Bad credentials.: Detalhes de login errados
+
+custom: personalizado
+random: aleatório
+
+mail:
+  welcome-subject: Te damos as boas-vindas a %domain%
+  welcome-body: |
+    Caro usuário,
+
+    Boas-vindas. Você pode encontrar guias sobre como configurar sua conta
+    em diferentes programas de e-mail pela internet.
+
+    Você tem uma cota de 1GB na sua caixa de entrada. O seu email talvez não
+    funcione corretamente se você ultrapassar essa cota.
+
+    Daqui uma semana, você receberá três convites, os quais você pode pegar
+    em %app_url%/voucher. Você pode dá-los aos seus contatos e convidá-los
+    a se cadastrar no %project_name%.
+
+    Sinceramente, time %project_name%.
+  recovery-subject: A senha do seu email %email% será redefinida
+  recovery-body: |
+    Olá %email%,
+
+    Alguém tentou redefinir a senha da sua conta. E para isso, esse alguém
+    se autenticou com o seu endereço de e-mail e token de recuperação
+    correspondente em %app_url%/recovery.
+
+    Não foi você que fez essa ativação? Pode ser que alguma outra pessoa 
+    com acesso ao seu token de recuperação esteja tentando tomar posse da sua conta.
+    Se esse for o caso, é importante que você vá até %app_url%/user/recovery_token imediatamente
+    para criar um novo token de recuperação. Dessa forma você vai invalidar o
+    token antigo e interromper o processo.
+
+    Se foi você quem ativou o processo, o período de espera de 48 horas 
+    começa agora. A espera acaba %time%. Depois disso, você poderá configurar
+    uma nova senha em %app_url%/recovery.
+
+    Esperamos que continue a tirar proveito da sua conta.
+    Time %project_name%.
+  alias-created-subject: Novo endereço alias criado
+  alias-created:body: |
+    Olá %email%,
+
+    Um novo endereço alias foi criado para o seu email %email%:
+    %alias%
+
+    Gerencie os seus endereços alias aqui: %app_url%/alias
+
+    Esperamos que continue a tirar proveito da sua conta.
+    Time %project_name%.

--- a/default_translations/pt/validators.pt.yml
+++ b/default_translations/pt/validators.pt.yml
@@ -1,0 +1,20 @@
+form:
+  weak_password: "A senha não está de acordo com a nossa política de segurança."
+  forbidden_char: "A senha contém caracteres inválidos."
+  different-password: "A senha e a confirmação de senha não são iguais."
+  invalid-email: "O email é inválido."
+  wrong-password: "Senha errada"
+  identical-passwords: "A nova senha é idêntica à antiga."
+  missing-domain: "O domínio não é gerenciado dentro deste sistema."
+  registration-recovery-token-noack: "Esse campo precisa ser verificado."
+  invalid-token: "Este token tem um formato inválido."
+
+registration:
+  voucher-invalid: "O código de convite é invalido."
+  email-domain-not-exists: "O e-mail é inválido."
+  voucher-already-redeemed: "O código de convite já foi usado."
+  email-domain-invalid: "O e-mail é inválido."
+  email-already-taken: "Este endereço de e-mail já foi usado."
+  email-too-short: "O nome de usuário deve conter pelo menos %min% caracteres."
+  email-too-long: "O nome de usuário deve conter no máximo %max% caracteres."
+  email-unexpected-characters: "O nome de usuário contém caracteres não permitidos. Válido apenas: Letras e números, assim como -, _ e ."


### PR DESCRIPTION
Addressing issue https://github.com/systemli/userli/issues/168

This adds the translation files for Brazilian Portuguese. I've made an effort to keep the translation as gender neutral as possible. 

Notes:

I've placed the translation files in a new `default_translations/pt_br` folder, but I'm actually not sure if thats the right folder of if it should be called `pt_br` or just `pt`, I figure it's better to just open the PR and then ask than trying to figure it out on my own.