### PR TITLE
Repair js copying of invite codes (Fixes: #165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.3 (UNRELEASED)
+
+* Repair js copying of invite codes (Fixes: #165)
+
 # 2.2.2 (2019.06.14)
 
 * Delete aliases when deleting user (Fixes: #121)

--- a/templates/Start/vouchers.html.twig
+++ b/templates/Start/vouchers.html.twig
@@ -40,7 +40,9 @@
                                                 title="{{ "index.voucher-sharing"|trans }}"
                                                 data-link="{{ url('register_voucher', {'voucher': voucher.code}) }}"
                                                 data-toggle="tooltip" data-placement="top">
-                                            <span class="glyphicon glyphicon-copy"></span>
+                                            <span class="glyphicon glyphicon-copy"
+                                                data-link="{{ url('register_voucher', {'voucher': voucher.code}) }}">
+                                            </span>
                                         </button>
                                     </span>
                                 </p>


### PR DESCRIPTION
Is it okay to fix it like this or do you prefer a js solution?