### PR TITLE
Locale switcher and internationalized routing logic

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -88,3 +88,7 @@ body {
     position: absolute;
     right: 10px;
 }
+
+.dropdown-menu {
+    min-width: unset;
+}

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -108,11 +108,13 @@ security:
 
     access_control:
       - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-      - { path: ^/recovery, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-      - { path: ^/register, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: ^/%locales%/recovery, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: ^/%locales%/register, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: ^/%locales%/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-      - { path: ^/admin, roles: ROLE_DOMAIN_ADMIN }
-      - { path: ^/voucher, roles: ROLE_USER, allow_if: "!has_role('ROLE_SUSPICIOUS')"}
-      - { path: ^/alias, roles: ROLE_USER, allow_if: "!has_role('ROLE_SPAM')"}
-      - { path: ^/account, roles: ROLE_USER, allow_if: "!has_role('ROLE_SPAM')"}
+      - { path: ^/alias$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: ^/%locales%/admin, roles: ROLE_DOMAIN_ADMIN }
+      - { path: ^/%locales%/voucher, roles: ROLE_USER, allow_if: "!has_role('ROLE_SUSPICIOUS')"}
+      - { path: ^/%locales%/alias, roles: ROLE_USER, allow_if: "!has_role('ROLE_SPAM')"}
+      - { path: ^/%locales%/account, roles: ROLE_USER, allow_if: "!has_role('ROLE_SPAM')"}
       - { path: ^/, roles: ROLE_USER }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -108,13 +108,13 @@ security:
 
     access_control:
       - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-      - { path: ^/%locales%/recovery, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-      - { path: ^/%locales%/register, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-      - { path: ^/%locales%/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: "^/[a-z]{2}/login", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: "^/[a-z]{2}/recovery", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: "^/[a-z]{2}/register", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: "^/[a-z]{2}/$", roles: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-      - { path: ^/alias$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-      - { path: ^/%locales%/admin, roles: ROLE_DOMAIN_ADMIN }
-      - { path: ^/%locales%/voucher, roles: ROLE_USER, allow_if: "!has_role('ROLE_SUSPICIOUS')"}
-      - { path: ^/%locales%/alias, roles: ROLE_USER, allow_if: "!has_role('ROLE_SPAM')"}
-      - { path: ^/%locales%/account, roles: ROLE_USER, allow_if: "!has_role('ROLE_SPAM')"}
+      - { path: ^/admin, roles: ROLE_DOMAIN_ADMIN }
+      - { path: "^/[a-z]{2}/voucher", roles: ROLE_USER, allow_if: "!has_role('ROLE_SUSPICIOUS')"}
+      - { path: "^/[a-z]{2}/alias", roles: ROLE_USER, allow_if: "!has_role('ROLE_SPAM')"}
+      - { path: "^/[a-z]{2}/account", roles: ROLE_USER, allow_if: "!has_role('ROLE_SPAM')"}
       - { path: ^/, roles: ROLE_USER }

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -9,3 +9,4 @@ twig:
         project_url:  "%env(PROJECT_URL)%"
         domain:       "%env(DOMAIN)%"
         webmail_url:  "%env(WEBMAIL_URL)%"
+        locales:      "%supported_locales%"

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,36 +1,109 @@
 # StartController
 
 index:
-    path:     /
+    path:     /{_locale}/
     controller: App\Controller\StartController::indexAction
+    requirements:
+        _locale: '%locales%'
 
 aliases:
-    path:     /alias
+    path:     /{_locale}/alias
     controller: App\Controller\StartController::aliasAction
+    requirements:
+        _locale: '%locales%'
 
 vouchers:
-    path:     /voucher
+    path:     /{_locale}/voucher
     controller: App\Controller\StartController::voucherAction
+    requirements:
+        _locale: '%locales%'
 
 account:
-    path:     /account
+    path:     /{_locale}/account
     controller: App\Controller\StartController::accountAction
+    requirements:
+        _locale: '%locales%'
 
 # DeleteController
 
 alias_delete:
-    path:     /alias/delete/{aliasId}
+    path:     /{_locale}/alias/delete/{aliasId}
     controller: App\Controller\DeleteController::deleteAliasAction
+    requirements:
+        _locale: '%locales%'
 
 user_delete:
-    path:     /user/delete
+    path:     /{_locale}/user/delete
     controller: App\Controller\DeleteController::deleteUserAction
+    requirements:
+        _locale: '%locales%'
+
+
+# RegistrationController
+
+register:
+    path:     /{_locale}/register
+    controller: App\Controller\RegistrationController::registerAction
+    requirements:
+        _locale: '%locales%'
+
+register_recovery_token:
+    path:     /{_locale}/register/recovery_token
+    controller: App\Controller\RegistrationController::registerRecoveryTokenAckAction
+    requirements:
+        _locale: '%locales%'
+
+register_welcome:
+    path:     /{_locale}/register/welcome
+    controller: App\Controller\RegistrationController::welcomeAction
+    requirements:
+        _locale: '%locales%'
+
+register_voucher:
+    path:     /{_locale}/register/{voucher}
+    controller: App\Controller\RegistrationController::registerAction
+    requirements:
+        _locale: '%locales%'
+
+# RecoveryController
+
+recovery:
+    path:     /{_locale}/recovery
+    controller: App\Controller\RecoveryController::recoveryProcessAction
+    requirements:
+        _locale: '%locales%'
+
+recovery_reset_password:
+    path:     /{_locale}/recovery/reset_password
+    controller: App\Controller\RecoveryController::recoveryResetPasswordAction
+    requirements:
+        _locale: '%locales%'
+
+recovery_recovery_token_ack:
+    path:     /{_locale}/recovery/recovery_token/ack
+    controller: App\Controller\RecoveryController::recoveryRecoveryTokenAckAction
+    requirements:
+        _locale: '%locales%'
+
+user_recovery_token:
+    path:     /{_locale}/user/recovery_token
+    controller: App\Controller\RecoveryController::recoveryTokenAction
+    requirements:
+        _locale: '%locales%'
+
+user_recovery_token_ack:
+    path:     /{_locale}/user/recovery_token/ack
+    controller: App\Controller\RecoveryController::recoveryTokenAckAction
+    requirements:
+        _locale: '%locales%'
 
 # SecurityController
 
 login:
-    path:     /login
+    path:     /{_locale}/login
     controller: App\Controller\SecurityController::loginAction
+    requirements:
+        _locale: '%locales%'
 
 login_check:
     path:     /login_check
@@ -38,42 +111,68 @@ login_check:
 logout:
     path:     /logout
 
-# RegistrationController
+# fallback without locale
 
-register:
+index_fallback:
+    path:     /
+    controller: App\Controller\StartController::indexAction
+
+aliases_fallback:
+    path:     /alias
+    controller: App\Controller\StartController::aliasAction
+
+vouchers_fallback:
+    path:     /voucher
+    controller: App\Controller\StartController::voucherAction
+
+account_fallback:
+    path:     /account
+    controller: App\Controller\StartController::accountAction
+
+alias_delete_fallback:
+    path:     /alias/delete/{aliasId}
+    controller: App\Controller\DeleteController::deleteAliasAction
+
+user_delete_fallback:
+    path:     /user/delete
+    controller: App\Controller\DeleteController::deleteUserAction
+
+register_fallback:
     path:     /register
     controller: App\Controller\RegistrationController::registerAction
 
-register_recovery_token:
+register_recovery_token_fallback:
     path:     /register/recovery_token
     controller: App\Controller\RegistrationController::registerRecoveryTokenAckAction
 
-register_welcome:
+register_welcome_fallback:
     path:     /register/welcome
     controller: App\Controller\RegistrationController::welcomeAction
 
-register_voucher:
+register_voucher_fallback:
     path:     /register/{voucher}
     controller: App\Controller\RegistrationController::registerAction
 
-# RecoveryController
-
-recovery:
+recovery_fallback:
     path:     /recovery
     controller: App\Controller\RecoveryController::recoveryProcessAction
 
-recovery_reset_password:
+recovery_reset_password_fallback:
     path:     /recovery/reset_password
     controller: App\Controller\RecoveryController::recoveryResetPasswordAction
 
-recovery_recovery_token_ack:
+recovery_recovery_token_ack_fallback:
     path:     /recovery/recovery_token/ack
     controller: App\Controller\RecoveryController::recoveryRecoveryTokenAckAction
 
-user_recovery_token:
+user_recovery_token_fallback:
     path:     /user/recovery_token
     controller: App\Controller\RecoveryController::recoveryTokenAction
 
-user_recovery_token_ack:
+user_recovery_token_ack_fallback:
     path:     /user/recovery_token/ack
     controller: App\Controller\RecoveryController::recoveryTokenAckAction
+
+login_fallback:
+    path:     /login
+    controller: App\Controller\SecurityController::loginAction

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -99,14 +99,14 @@ user_recovery_token_ack:
 
 # SecurityController
 
+login_check:
+    path:     /login_check
+
 login:
     path:     /{_locale}/login
     controller: App\Controller\SecurityController::loginAction
     requirements:
         _locale: '%locales%'
-
-login_check:
-    path:     /login_check
 
 logout:
     path:     /logout

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,7 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: 'en'
+    locales: en|de|es|pt|nb
     supported_locales: ['en', 'de', 'es', 'pt', 'nb']
     navbar_left:
         -

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -25,7 +25,7 @@ Feature: Admin
   @admin
   Scenario: Access to Admin Interface as Admin
     When I am on "/admin/dashboard"
-    Then I should be on "/login"
+    Then I should be on "/en/login"
     And the response status code should be 200
 
     When I am authenticated as "louis@example.org"

--- a/features/login.feature
+++ b/features/login.feature
@@ -20,7 +20,7 @@ Feature: Login
       | password | asdasd            |
     And I press "Sign in"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And I should see text matching "Log out"
     And the response status code should not be 403
 
@@ -32,7 +32,7 @@ Feature: Login
       | password | asdasd            |
     And I press "Sign in"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And I should see text matching "Log out"
     And the response status code should not be 403
 
@@ -54,7 +54,7 @@ Feature: Login
       | password | asdasd           |
     And I press "Sign in"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And the response status code should not be 403
 
   @login
@@ -65,7 +65,7 @@ Feature: Login
       | password | asdasd              |
     And I press "Sign in"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And the response status code should not be 403
 
   @login
@@ -76,7 +76,7 @@ Feature: Login
       | password | asdasd |
     And I press "Sign in"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And the response status code should not be 403
 
   @login
@@ -90,7 +90,7 @@ Feature: Login
       | password | paßwort             |
     And I press "Sign in"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And the response status code should not be 403
 
   @logout
@@ -99,7 +99,7 @@ Feature: Login
     And I am on "/logout"
 
     When I am on "/admin/dashboard"
-    Then I should be on "/login"
+    Then I should be on "/en/login"
 
   @logout
   Scenario: Logout
@@ -116,6 +116,6 @@ Feature: Login
       | password | asdasd              |
     And I press "Sign in"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And the response status code should be 200
     And I should see text matching "Email access has been turned off"

--- a/features/recovery.feature
+++ b/features/recovery.feature
@@ -18,7 +18,7 @@ Feature: Recovery
       | recovery_process[recoveryToken] | bbde593d-8a9e-4d0e-a3ab-9fdd9f5c3237 |
     And I press "recovery_process[submit]"
 
-    Then I should be on "/recovery"
+    Then I should be on "/en/recovery"
     And I should see text matching "Second step starts at"
     And the response status code should be 200
 
@@ -30,7 +30,7 @@ Feature: Recovery
       | recovery_process[recoveryToken] | bbde593d-8a9e-4d0e-a3ab-9fdd9f5c3237 |
     And I press "recovery_process[submit]"
 
-    Then I should be on "/recovery"
+    Then I should be on "/en/recovery"
     And I should see text matching "You're now allowed to reset your password"
     And the response status code should be 200
 
@@ -39,13 +39,13 @@ Feature: Recovery
     When I have the request params for "recovery_reset_password":
       | email         | user2@example.org                    |
       | recoveryToken | bbde593d-8a9e-4d0e-a3ab-9fdd9f5c3237 |
-    And I request "POST /recovery/reset_password"
+    And I request "POST /en/recovery/reset_password"
     And I fill in the following:
       | recovery_reset_password[newPassword][first]  | passwordabcd |
       | recovery_reset_password[newPassword][second] | passwordabcd |
     And I press "recovery_reset_password[submit]"
 
-    Then I should be on "/recovery/reset_password"
+    Then I should be on "/en/recovery/reset_password"
     And I should see text matching "You changed your password."
     And the response status code should be 200
 
@@ -53,12 +53,12 @@ Feature: Recovery
   Scenario: Acknowledge new recovery token in recovery process as user (#4)
     When I have the request params for "recovery_token_ack":
       | recoveryToken | bbde593d-8a9e-4d0e-a3ab-9fdd9f5c3237 |
-    And I request "POST /recovery/recovery_token/ack"
+    And I request "POST /en/recovery/recovery_token/ack"
     And I fill in the following:
       | recovery_token_ack[ack]           | 1                                    |
     And I press "recovery_token_ack[submit]"
 
-    Then I should be on "/login"
+    Then I should be on "/en/login"
     And I should see text matching "Go on with the login."
     And the response status code should be 200
 
@@ -70,7 +70,7 @@ Feature: Recovery
       | recovery_process[recoveryToken] | bbde593d-8a9e-4d0e-a3ab-9fdd9f5c3237 |
     And I press "recovery_process[submit]"
 
-    Then I should be on "/recovery"
+    Then I should be on "/en/recovery"
     And I should see text matching "Email address and/or recovery token are wrong!"
 
   @recovery
@@ -81,7 +81,7 @@ Feature: Recovery
       | recovery_process[recoveryToken] | bbde593d-8a9e-4d0e-a3ab-9fdd9f5c3237 |
     And I press "recovery_process[submit]"
 
-    Then I should be on "/recovery"
+    Then I should be on "/en/recovery"
     And I should see text matching "Second step starts at"
     And the response status code should be 200
 
@@ -93,5 +93,5 @@ Feature: Recovery
       | recovery_process[recoveryToken] | broken_token     |
     And I press "recovery_process[submit]"
 
-    Then I should be on "/recovery"
+    Then I should be on "/en/recovery"
     And I should see text matching "This token has an invalid format."

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -28,11 +28,11 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see text matching "The following recovery token got created for you"
 
     When I am on "/logout"
-    Then I should be on "/"
+    Then I should be on "/en/"
 
     When I am on "/login"
     And I fill in the following:
@@ -40,7 +40,7 @@ Feature: registration
       | password | P4ssW0rt!!!1      |
     And I press "Sign in"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And I should see text matching "Log out"
 
   @registration
@@ -53,7 +53,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The invite code is invalid."
 
   @registration
@@ -66,7 +66,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1         |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The email is invalid."
 
   @registration
@@ -79,7 +79,7 @@ Feature: registration
       | registration[plainPassword][second] | password |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The password comply not with our security policy."
 
   @registration
@@ -92,7 +92,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!2 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "Password and confirmation does not match"
 
   @registration
@@ -105,7 +105,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The email address is already taken."
 
   @registration
@@ -118,7 +118,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The email address is already taken."
 
   @registration
@@ -131,7 +131,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The email address is already taken."
 
   @registration
@@ -144,7 +144,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The email address is already taken."
 
   @registration
@@ -157,7 +157,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The username must contain at least 3 characters."
 
   @registration
@@ -170,7 +170,7 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1                         |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The username must contain at most 32 characters."
 
   @registration
@@ -183,5 +183,5 @@ Feature: registration
       | registration[plainPassword][second] | P4ssW0rt!!!1 |
     And I press "Submit"
 
-    Then I should be on "/register"
+    Then I should be on "/en/register"
     And I should see "The username contains unexpected characters. Only valid: Letters and numbers, as well as -, _ and ."

--- a/features/user.feature
+++ b/features/user.feature
@@ -27,7 +27,7 @@ Feature: User
       | password_change_newPassword_second | P4ssW0rd!!!1 |
     And I press "Submit"
 
-    Then I should be on "/account"
+    Then I should be on "/en/account"
     And I should see text matching "Your new password is now active!"
     And the response status code should not be 403
 
@@ -37,7 +37,7 @@ Feature: User
     And I am on "/alias"
     And I press "Generate random alias"
 
-    Then I should be on "/alias"
+    Then I should be on "/en/alias"
     And I should see text matching "Your new alias address was created."
     And the response status code should be 200
 
@@ -49,7 +49,7 @@ Feature: User
       | create_custom_alias_alias | test_alias |
     And I press "Add"
 
-    Then I should be on "/alias"
+    Then I should be on "/en/alias"
     And I should see text matching "Your new alias address was created."
     And the response status code should be 200
 
@@ -58,7 +58,7 @@ Feature: User
     When I am authenticated as "user@example.org"
     And I am on "/alias/delete/1"
 
-    Then I should be on "/alias"
+    Then I should be on "/en/alias"
     And the response status code should not be 403
 
   @delete-alias
@@ -69,7 +69,7 @@ Feature: User
       | delete_alias_password | asdasd |
     And I press "Delete alias"
 
-    Then I should be on "/alias"
+    Then I should be on "/en/alias"
     And I should see text matching "Your alias address was deleted."
     And the response status code should not be 403
 
@@ -77,21 +77,21 @@ Feature: User
   Scenario: Deleted alias redirect
     When I am authenticated as "user@example.org"
     And I am on "/alias/delete/2"
-    Then I should be on "/alias"
+    Then I should be on "/en/alias"
     And the response status code should not be 403
 
   @delete-alias
   Scenario: Foreign alias redirect
     When I am authenticated as "user@example.org"
     And I am on "/alias/delete/3"
-    Then I should be on "/alias"
+    Then I should be on "/en/alias"
     And the response status code should not be 403
 
   @delete-alias
   Scenario: Nonexistent alias redirect
     When I am authenticated as "user@example.org"
     And I am on "/alias/delete/200"
-    Then I should be on "/alias"
+    Then I should be on "/en/alias"
     And the response status code should not be 403
 
   @delete-user
@@ -102,7 +102,7 @@ Feature: User
       | delete_user_password | asdasd |
     And I press "Delete account"
 
-    Then I should be on "/"
+    Then I should be on "/en/"
     And the response status code should not be 403
 
     And I fill in the following:
@@ -110,7 +110,7 @@ Feature: User
       | password | asdasd           |
     And I press "Sign in"
 
-    Then I should be on "/login"
+    Then I should be on "/en/login"
     Then I should see text matching "Wrong login details"
     And the response status code should not be 403
 
@@ -120,7 +120,7 @@ Feature: User
     And I am on "/voucher"
     And I press "Create invite code"
 
-    Then I should be on "/voucher"
+    Then I should be on "/en/voucher"
     And I should see text matching "New invite code created."
     And the response status code should be 200
 
@@ -130,7 +130,7 @@ Feature: User
     And I am on "/voucher"
     And I press "Create invite code"
 
-    Then I should be on "/voucher"
+    Then I should be on "/en/voucher"
     And I should see text matching "New invite code created."
     And the response status code should be 200
 

--- a/features/voucherCreationCommand.feature
+++ b/features/voucherCreationCommand.feature
@@ -15,4 +15,4 @@ Feature: VoucherCreationCommand
     Then I should see regex "|^[a-z_\-0-9]{6}$|i" in the console output
 
     When I run console command "app:voucher:create -u user@example.org -c 1 -l"
-    Then I should see regex "|^https://users.example.org/register/[a-z_\-0-9]{6}$|i" in the console output
+    Then I should see regex "|^https://users.example.org/en/register/[a-z_\-0-9]{6}$|i" in the console output

--- a/src/Builder/MenuBuilder.php
+++ b/src/Builder/MenuBuilder.php
@@ -51,9 +51,7 @@ class MenuBuilder
      */
     public function createNavbarLeft()
     {
-        $menu = $this->factory->createItem('root', array(
-            'navbar' => true,
-        ));
+        $menu = $this->factory->createItem('root', ['navbar' => true]);
 
         if (!empty($this->navbarLeft)) {
             $menu = $this->menuHelper->build($this->navbarLeft, $menu);
@@ -71,13 +69,13 @@ class MenuBuilder
         $menu->setChildrenAttribute('class', 'nav navbar-nav navbar-right');
 
         if (!$this->authChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
-            $menu->addChild('navbar_right.login', array('route' => 'login'));
+            $menu->addChild('navbar_right.login', ['route' => 'login']);
         } else {
             if ($this->authChecker->isGranted(Roles::DOMAIN_ADMIN)) {
-                $menu->addChild('navbar_right.admin', array('route' => 'sonata_admin_dashboard'));
+                $menu->addChild('navbar_right.admin', ['route' => 'sonata_admin_dashboard']);
             }
 
-            $menu->addChild('navbar_right.logout', array('route' => 'logout'));
+            $menu->addChild('navbar_right.logout', ['route' => 'logout']);
         }
 
         return $menu;

--- a/src/Command/VoucherCreationCommand.php
+++ b/src/Command/VoucherCreationCommand.php
@@ -71,7 +71,10 @@ class VoucherCreationCommand extends Command
         for ($i = 1; $i <= $input->getOption('count'); ++$i) {
             $voucher = VoucherFactory::create($user);
             if (true === $input->getOption('print-links')) {
-                $output->write(sprintf("%s\n", $this->router->generate('register_voucher', ['voucher' => $voucher->getCode()])));
+                $output->write(sprintf("%s\n", $this->router->generate(
+                    'register_voucher',
+                    ['_locale' => 'en', 'voucher' => $voucher->getCode()]
+                )));
             } elseif (true === $input->getOption('print')) {
                 $output->write(sprintf("%s\n", $voucher->getCode()));
             }

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -8,7 +8,6 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
-use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
 /**
@@ -22,13 +21,14 @@ class LocaleListener implements EventSubscriberInterface
     private $supportedLocales;
 
     /**
-     * @var UrlMatcher
+     * @var UrlMatcherInterface
      */
     private $urlMatcher;
 
     /**
      * LocaleListener constructor.
-     * @param string[] $supportedLocales
+     *
+     * @param string[]            $supportedLocales
      * @param UrlMatcherInterface $urlMatcher
      */
     public function __construct(array $supportedLocales, UrlMatcherInterface $urlMatcher)
@@ -46,7 +46,9 @@ class LocaleListener implements EventSubscriberInterface
         $route = $request->getRequestUri();
 
         // Check if we are already on localized path
-        if (null !== $this->checkLanguage($route)) return;
+        if (null !== $this->checkLanguage($route)) {
+            return;
+        }
 
         // Make sure _locale is set
         if (null === $request->attributes->get('_locale')) {
@@ -62,19 +64,25 @@ class LocaleListener implements EventSubscriberInterface
             $this->urlMatcher->match($newRoute);
             $event->setResponse(new RedirectResponse($newRoute));
         } catch (ResourceNotFoundException $e) {
+            // ignore errors, we just redirect if there was none
         } catch (MethodNotAllowedException $e) {
+            // ignore errors, we just redirect if there was none
         }
     }
 
     /**
      * @param $route
-     * @return null|string
+     *
+     * @return string|null
      */
-    private function checkLanguage($route){
-        foreach($this->supportedLocales as $locale){
-            if(preg_match_all("/^\/$locale\//", $route))
+    private function checkLanguage($route)
+    {
+        foreach ($this->supportedLocales as $locale) {
+            if (preg_match_all("/^\/$locale\//", $route)) {
                 return $locale;
+            }
         }
+
         return null;
     }
 

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -3,6 +3,7 @@
 namespace App\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -31,12 +32,39 @@ class LocaleListener implements EventSubscriberInterface
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
+        $route = $request->getRequestUri();
 
+        // Check if we are already on localized path
+        if (null !== $this->checkLanguage($route)) return;
+
+        // Make sure _locale is set
         if (null === $request->attributes->get('_locale')) {
             if (null !== $locale = $request->getPreferredLanguage($this->supportedLocales)) {
                 $request->attributes->set('_locale', $locale);
             }
         }
+
+        // Don't redirect specific urls
+        if ("/login_check" === $route) return;
+        if (strpos($route, 'logout') !== false) return;
+        if (strpos($route, '/admin/') !== false) return;
+
+        // redirect
+        $newLocale = $request->attributes->get('_locale');
+        $newRoute = '/'.$newLocale.$route;
+        $event->setResponse(new RedirectResponse(($newRoute)));
+    }
+
+    /**
+     * @param $route
+     * @return null|string
+     */
+    private function checkLanguage($route){
+        foreach($this->supportedLocales as $locale){
+            if(preg_match_all("/^\/$locale\//", $route))
+                return $locale;
+        }
+        return null;
     }
 
     /**

--- a/templates/_locale_switcher.html.twig
+++ b/templates/_locale_switcher.html.twig
@@ -2,16 +2,21 @@
 {% set route_params = app.request.attributes.get('_route_params') %}
 {% set params = route_params|merge(app.request.query.all) %}
 
-<li class="dropdown">
-  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ app.request.locale|upper }}<span class="caret"></span></a>
-  <ul class="dropdown-menu">
-{% for locale in locales if locale != app.request.locale %}
-    <li>
-        <a href="{{ path(route, params|merge({ _locale: locale })) }}">
-           {{ locale|upper }}
+<ul id=navbar-locale class="nav navbar-nav navbar-right">
+    <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown" >
+            {{ app.request.locale|upper }}
+            <span class="caret"></span>
         </a>
-    </li>
+        <ul class="dropdown-menu menu_level_1" role="menu">
+{% for locale in locales if locale != app.request.locale %}
+          <li>
+                <a href="{{ path(route, params|merge({ _locale: locale })) }}">
+                    {{ locale|upper }}
+                </a>
+            </li>
 {% endfor %}
-  </ul>
-</li>
+        </ul>
+    </li>
+</ul>
 

--- a/templates/_locale_switcher.html.twig
+++ b/templates/_locale_switcher.html.twig
@@ -1,0 +1,17 @@
+{% set route = app.request.attributes.get('_route') %}
+{% set route_params = app.request.attributes.get('_route_params') %}
+{% set params = route_params|merge(app.request.query.all) %}
+
+<li class="dropdown">
+  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ app.request.locale|upper }}<span class="caret"></span></a>
+  <ul class="dropdown-menu">
+{% for locale in locales if locale != app.request.locale %}
+    <li>
+        <a href="{{ path(route, params|merge({ _locale: locale })) }}">
+           {{ locale|upper }}
+        </a>
+    </li>
+{% endfor %}
+  </ul>
+</li>
+

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -22,8 +22,8 @@
 
         {% block menu %}
             {{ mopa_bootstrap_menu('navbar-left') }}
-            {% include '_locale_switcher.html.twig' %}
             {{ mopa_bootstrap_menu('navbar-right') }}
+            {% include '_locale_switcher.html.twig' %}
         {% endblock %}
     {% endembed %}
 {% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -22,6 +22,7 @@
 
         {% block menu %}
             {{ mopa_bootstrap_menu('navbar-left') }}
+            {% include '_locale_switcher.html.twig' %}
             {{ mopa_bootstrap_menu('navbar-right') }}
         {% endblock %}
     {% endembed %}


### PR DESCRIPTION
This PR implements a manual locale switcher and internationalized routing logic.

If you visit one of the old urls like `/alias` you will be redirected to `/_locale/alias (if this route exits)`, where `_locale` is either given by your browser or fallback locale.
If you visit the new urls like `/de/alias`, the locale is defined by the path. Browser settings are then ignored.
You can switch languages with the locale switcher in the navbar. (Beautification needed).

`/admin` doesn't have the locale switcher. I didn't have time to figure out how to do it with sonata admin bundle. We could fix this in a later PR.

Any feedback or improvements very welcome.