### PR TITLE
WIP: add a button to copy random aliases to clipbard

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,16 +3,24 @@ require('../../vendor/twbs/bootstrap/dist/js/bootstrap.min.js');
 require('../css/app.css');
 
 $(function () {
-    $('[data-toggle="tooltip"]').tooltip();
-    $('[data-toggle="popover"]').popover();
-
-    // We create a non visible textarea with the link,
-    // select them and tell the browser to copy the selected content
-    // after we copied the link the element will removed from DOM.
-    $('.invite-share-link').click(function (element) {
+    // Event handler that copies the value of element's [data-link]
+    // attribute to clipboard.
+    //
+    // Usage example:
+    //
+    //   <button data-value="foo">Copy foo to clickboard</button>
+    //
+    //   let el = document.querySelector('button');
+    //   el.addEventListener('click', copyToClipboard);
+    //
+    // To do so it creates a non visible textarea with the value,
+    // selects it and tell the browser to copy the selected content.
+    // After the value has been copied, the textarea is removed from
+    // DOM again.
+    function copyToClipboard(event) {
         let el = document.createElement('textarea');
 
-        el.value = element.target.dataset.link;
+        el.value = event.currentTarget.dataset.value;
         el.setAttribute('readonly', '');
         el.style.position = 'absolute';
         el.style.left = '-9999px';
@@ -22,7 +30,18 @@ $(function () {
         document.execCommand('copy');
 
         document.body.removeChild(el);
-    });
+    }
+
+    // initialize Bootstrap's tooltip and popover
+    $('[data-toggle="tooltip"]').tooltip();
+    $('[data-toggle="popover"]').popover();
+
+    // initialize copy-to-clickboard buttons
+    document.querySelectorAll('[data-button="copy-to-clipboard"]')
+        .forEach(function(el) {
+            el.addEventListener('click', copyToClipboard);
+        });
+
     setTimeout(function () {
         $('.flash-notification').fadeOut();
     }, 10000);

--- a/templates/Start/aliases.html.twig
+++ b/templates/Start/aliases.html.twig
@@ -72,6 +72,12 @@
                         <li class="list-group-item list-group-item-primary">
                             {{ alias.source }}
                             <span class="pull-right">
+                                <button type="button" class="btn btn-default btn-xs"
+                                        data-button="copy-to-clipboard" data-value="{{ alias.source }}"
+                                        title="{{ "index.alias-copy"|trans }}"
+                                        data-toggle="tooltip" data-placement="top">
+                                    <span class="glyphicon glyphicon-copy"></span>
+                                </button>
                                 <a class="btn btn-danger btn-xs" href="{{ url('alias_delete', {'aliasId': alias.id}) }}">x</a>
                             </span>
                         </li>

--- a/templates/Start/vouchers.html.twig
+++ b/templates/Start/vouchers.html.twig
@@ -36,13 +36,12 @@
                                 <p class="voucher-box">
                                     <span>{{ voucher.code }}</span>
                                     <span class="pull-right">
-                                        <button type="button" class="btn btn-default invite-share-link"
+                                        <button type="button" class="btn btn-default"
                                                 title="{{ "index.voucher-sharing"|trans }}"
-                                                data-link="{{ url('register_voucher', {'voucher': voucher.code}) }}"
+                                                data-button="copy-to-clipboard"
+                                                data-value="{{ url('register_voucher', {'voucher': voucher.code}) }}"
                                                 data-toggle="tooltip" data-placement="top">
-                                            <span class="glyphicon glyphicon-copy"
-                                                data-link="{{ url('register_voucher', {'voucher': voucher.code}) }}">
-                                            </span>
+                                            <span class="glyphicon glyphicon-copy"></span>
                                         </button>
                                     </span>
                                 </p>


### PR DESCRIPTION
Also refactors the existing logic to copy content to clipboard for reusability. A copy button could be created with `<button data-button="copy-to-clipboard" data-value="foo">`. This will copy `"foo"` to clipboard when user clicks the button. `[data-button="copy-to-clipboard"]` is used as selector to attach the event listener.

This also addresses #165 in another way. b5ba3f9a341f1fbab5cbb19ea5fafcad65770d32 required to duplicate the content that should be copied on each child element. This could be avoided by using `Event.currentTarget` instead of `Event.target`. `Event.currentTarget` is supported by IE9 and above.

Closes #181