### PR TITLE
adjust font & size for pgp-key-input

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -92,3 +92,7 @@ body {
 .dropdown-menu {
     min-width: unset;
 }
+
+.ascii {
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}

--- a/templates/Start/openpgp.html.twig
+++ b/templates/Start/openpgp.html.twig
@@ -10,12 +10,12 @@
 {% endblock %}
 {% block content %}
     <div class="row">
-        <div class="col-xs-12 col-sm-12 col-md-12">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
             <h3>{{ "start.openpgp-settings-title"|trans }}</h3>
         </div>
     </div>
     <div class="row">
-        <div class="col-xs-12 col-sm-6 col-md-6">
+        <div class="col-xs-12 col-sm-12 col-md-8 col-lg-7">
             {% form_theme openpgp_form 'Form/fields.html.twig' %}
             {{ form_start(openpgp_form) }}
             <div class="form-group">
@@ -35,7 +35,7 @@
             <div class="form-group">
                 {{ form_label(openpgp_form.keyText) }}
                 {{ form_errors(openpgp_form.keyText) }}
-                {{ form_widget(openpgp_form.keyText, {'attr': {'class': 'form-control' }}) }}
+                {{ form_widget(openpgp_form.keyText, {'attr': {'class': 'form-control ascii', 'rows':'15'}}) }}
             </div>
 
             <div class="form-group">
@@ -45,7 +45,7 @@
             {{ form_end(openpgp_form) }}
         </div>
 
-        <div class="col-xs-12 col-sm-6 col-md-6">
+        <div class="col-xs-12 col-sm-6 col-md-4 col-lg-5">
             <div class="alert alert-info">
                 <p class="lead">{{ "openpgp.information"|trans }}</p>
                 <p>{{ "openpgp.information-details"|trans|raw }}</p>
@@ -53,7 +53,7 @@
         </div>
 
         {% if openpgp_id and openpgp_fingerprint %}
-            <div class="col-xs-12 col-sm-6 col-md-6">
+            <div class="col-xs-12 col-sm-6 col-md-4 col-lg-5">
                 <h4>{{ "openpgp.key-info"|trans }}</h4>
                 <div class="alert alert-info">
                     <div>


### PR DESCRIPTION
should do #261

A little unsure what would be the best way to set the width for the input box. adding a minimum width to the app.css file makes the boxes overlap, so i changed the relative column width instead.