### PR TITLE
Change input type to make css work

### DIFF
--- a/templates/Security/login.html.twig
+++ b/templates/Security/login.html.twig
@@ -11,7 +11,7 @@
                 {% if error %}
                     <div class="alert alert-danger" role="alert">{{ error.message|trans }}</div>
                 {% endif %}
-                <input type="text" id="username" class="form-control" name="_username" placeholder="{{ "form.email"|trans }}" value="{{ last_username }}" required="" autofocus="" />
+                <input type="email" id="username" class="form-control" name="_username" placeholder="{{ "form.email"|trans }}" value="{{ last_username }}" required="" autofocus="" />
                 <input type="password" id="password" class="form-control" name="_password" placeholder="{{ "form.password"|trans }}" required="">
                 <div class="form-group"><a href="{{ path('recovery') }}">{{  "form.recovery-link"|trans }}</a></div>
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">


### PR DESCRIPTION
The css file uses `.form-signin input[type="email"]` - [app.css](https://github.com/systemli/userli/blob/57cbe34a7bcb3f00324977a4f45b299c3562b631/assets/css/app.css#L35)