### PR TITLE
Timestamps for entities

### DIFF
--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -37,7 +37,9 @@ class Alias implements SoftDeletableInterface
     {
         $this->deleted = false;
         $this->random = false;
-        $this->creationTime = new \DateTime();
+        $currentDateTime = new \DateTime();
+        $this->creationTime = $currentDateTime;
+        $this->updatedTime = $currentDateTime;
     }
 
     /**

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -37,6 +37,7 @@ class Alias implements SoftDeletableInterface
     {
         $this->deleted = false;
         $this->random = false;
+        $this->creationTime = new \DateTime();
     }
 
     /**

--- a/src/Entity/Domain.php
+++ b/src/Entity/Domain.php
@@ -14,6 +14,14 @@ class Domain
     use UpdatedTimeTrait;
     use NameTrait;
 
+    /**
+     * Domain constructor.
+     */
+    public function __construct()
+    {
+        $this->creationTime = new \DateTime();
+    }
+
     public function __toString()
     {
         return ($this->getName()) ?: '';

--- a/src/Entity/Domain.php
+++ b/src/Entity/Domain.php
@@ -19,7 +19,9 @@ class Domain
      */
     public function __construct()
     {
-        $this->creationTime = new \DateTime();
+        $currentDateTime = new \DateTime();
+        $this->creationTime = $currentDateTime;
+        $this->updatedTime = $currentDateTime;
     }
 
     public function __toString()

--- a/src/Entity/OpenPgpKey.php
+++ b/src/Entity/OpenPgpKey.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Traits\CreationTimeTrait;
+use App\Traits\UpdatedTimeTrait;
 use App\Traits\EmailTrait;
 use App\Traits\IdTrait;
 use App\Traits\OpenPgpKeyTrait;
@@ -11,10 +12,21 @@ use App\Traits\UserAwareTrait;
 class OpenPgpKey
 {
     use CreationTimeTrait;
+    use UpdatedTimeTrait;
     use IdTrait;
     use UserAwareTrait;
     use EmailTrait;
     use OpenPgpKeyTrait;
+
+    /**
+     * OpenPgpKey constructor.
+     */
+    public function __construct()
+    {
+        $currentDateTime = new \DateTime();
+        $this->creationTime = $currentDateTime;
+        $this->updatedTime = $currentDateTime;
+    }
 
 
     public function toBinary(): ?string

--- a/src/Entity/OpenPgpKey.php
+++ b/src/Entity/OpenPgpKey.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Traits\CreationTimeTrait;
 use App\Traits\EmailTrait;
 use App\Traits\IdTrait;
 use App\Traits\OpenPgpKeyTrait;
@@ -9,10 +10,12 @@ use App\Traits\UserAwareTrait;
 
 class OpenPgpKey
 {
+    use CreationTimeTrait;
     use IdTrait;
     use UserAwareTrait;
     use EmailTrait;
     use OpenPgpKeyTrait;
+
 
     public function toBinary(): ?string
     {

--- a/src/Entity/ReservedName.php
+++ b/src/Entity/ReservedName.php
@@ -19,7 +19,9 @@ class ReservedName
      */
     public function __construct()
     {
-        $this->creationTime = new \DateTime();
+        $currentDateTime = new \DateTime();
+        $this->creationTime = $currentDateTime;
+        $this->updatedTime = $currentDateTime;
     }
 
     public function __toString()

--- a/src/Entity/ReservedName.php
+++ b/src/Entity/ReservedName.php
@@ -14,6 +14,14 @@ class ReservedName
     use UpdatedTimeTrait;
     use NameTrait;
 
+    /**
+     * ReservedName constructor.
+     */
+    public function __construct()
+    {
+        $this->creationTime = new \DateTime();
+    }
+
     public function __toString()
     {
         return ($this->getName()) ?: '';

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -65,6 +65,7 @@ class User implements UserInterface, EncoderAwareInterface
     {
         $this->deleted = false;
         $this->passwordVersion = self::CURRENT_PASSWORD_VERSION;
+        $this->creationTime = new \DateTime();
     }
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -65,7 +65,9 @@ class User implements UserInterface, EncoderAwareInterface
     {
         $this->deleted = false;
         $this->passwordVersion = self::CURRENT_PASSWORD_VERSION;
-        $this->creationTime = new \DateTime();
+        $currentDateTime = new \DateTime();
+        $this->creationTime = $currentDateTime;
+        $this->updatedTime = $currentDateTime;
     }
 
     /**

--- a/src/Entity/Voucher.php
+++ b/src/Entity/Voucher.php
@@ -31,7 +31,9 @@ class Voucher
 
     public function __construct()
     {
-        $this->creationTime = new \DateTime();
+        $currentDateTime = new \DateTime();
+        $this->creationTime = $currentDateTime;
+        $this->updatedTime = $currentDateTime;
     }
 
     /**

--- a/src/Factory/DomainFactory.php
+++ b/src/Factory/DomainFactory.php
@@ -10,9 +10,6 @@ class DomainFactory
     {
         $domain = new Domain();
         $domain->setName($name);
-        $time = new \DateTime('now');
-        $domain->setCreationTime($time);
-        $domain->setUpdatedTime($time);
 
         return $domain;
     }

--- a/src/Handler/RegistrationHandler.php
+++ b/src/Handler/RegistrationHandler.php
@@ -128,8 +128,6 @@ class RegistrationHandler
         $user->setEmail(strtolower($registration->getEmail()));
         $user->setPlainPassword($registration->getPlainPassword());
         $user->setRoles([Roles::USER]);
-        $user->setCreationTime(new \DateTime());
-        $user->setUpdatedTime(new \DateTime());
 
         if (null !== $domain = $this->domainGuesser->guess($registration->getEmail())) {
             $user->setDomain($domain);

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -84,8 +84,14 @@ class UserTest extends TestCase
     public function testHasCreationTimeSet(): void
     {
         $user = new User();
-        $cr = $user->getCreationTime();
         $today = new \DateTime();
-        self::assertEquals($cr->format('Y-m-d'), $today->format('Y-m-d'));
+        self::assertEquals($user->getCreationTime()->format('Y-m-d'), $today->format('Y-m-d'));
+    }
+
+    public function testHasUpdatedTimeSet(): void
+    {
+        $user = new User();
+        $today = new \DateTime();
+        self::assertEquals($user->getUpdatedTime()->format('Y-m-d'), $today->format('Y-m-d'));
     }
 }

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -80,4 +80,12 @@ class UserTest extends TestCase
         $user->erasePlainRecoveryToken();
         self::assertEquals(null, $user->getPlainRecoveryToken());
     }
+
+    public function testHasCreationTimeSet(): void
+    {
+        $user = new User();
+        $cr = $user->getCreationTime();
+        $today = new \DateTime();
+        self::assertEquals($cr->format('Y-m-d'), $today->format('Y-m-d'));
+    }
 }

--- a/tests/Handler/WkdHandlerTest.php
+++ b/tests/Handler/WkdHandlerTest.php
@@ -64,6 +64,9 @@ class WkdHandlerTest extends TestCase
 
         $handler = $this->createHandler();
         $wkdKey = $handler->importKey(base64_decode($this->keyData), $this->email);
+        //overwrite timestamps as they may differ by a few microseconds
+        $wkdKey->setCreationTime($expected->getCreationTime());
+        $wkdKey->setUpdatedTime($expected->getUpdatedTime());
 
         self::assertEquals($expected, $wkdKey);
         self::assertFileExists($this->wkdPath);
@@ -86,6 +89,10 @@ class WkdHandlerTest extends TestCase
 
         $handler = $this->createHandler();
         $wkdKey = $handler->importKey(base64_decode($this->keyData), $this->email, $user);
+
+        //overwrite timestamps as they may differ by a few microseconds
+        $wkdKey->setCreationTime($expected->getCreationTime());
+        $wkdKey->setUpdatedTime($expected->getUpdatedTime());
 
         self::assertEquals($expected, $wkdKey);
         self::assertFileExists($this->wkdPath);

--- a/tests/Importer/GpgKeyImporterTest.php
+++ b/tests/Importer/GpgKeyImporterTest.php
@@ -270,6 +270,11 @@ zg5FDph+OpdBuInEpzFyovIpSMF67TAY1b96p8doFaWQ0g==
         $expected->setKeyFingerprint($this->validKeyFingerprint);
         $expected->setKeyExpireTime(new DateTime($this->validExpireTime));
         $expected->setKeyData($this->validKeyBinary);
+
+        //overwrite timestamps as they may differ by a few microseconds
+        $openPgpKey->setCreationTime($expected->getCreationTime());
+        $openPgpKey->setUpdatedTime($expected->getUpdatedTime());
+
         self::assertEquals($expected, $openPgpKey);
     }
 


### PR DESCRIPTION
This should close #207.

**Notes:**

The entity OpenPgpKey wasn't changed, as there are some tests using direct object comparison, which fail in *App\Tests\Handler\WkdHandlerTest*, if the creation date is set in the constructor (as they differ by just a few microseconds).

This might be fixed by setting the fields creationTime and updatedTime in the affected tests in *WkdHandlerTest*.