### PR TITLE
Add cron job and link to maildirs-remove script

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,7 @@ jobs:
         run: bin/phpunit --coverage-clover=coverage.xml
 
       - name: Upload Test Coverage
-        uses: codecov/codecov-action@v2.0.2
+        uses: codecov/codecov-action@v2.1.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/hugo/content/installation/finalize.md
+++ b/hugo/content/installation/finalize.md
@@ -27,10 +27,13 @@ the `mail_location` in `10-mail.conf` to something like this:
 
 ## Cronjobs
 
-Some cronjobs are needed in order to run regular tasks:
+Some cronjobs are needed in order to run regular tasks. As Userli does not have write permissions at Dovecot's maildir (usually this directory belongs to the system user `vmail`) you have to use a [script](https://github.com/systemli/ansible-role-userli/blob/master/templates/userli-maildirs-remove.sh.j2) to delete a  maildir from a removed Userli account:
 
-	# Daily purge data from deleted mail users
-	@daily userli cd /path/to/userli && bin/console app:users:remove -q
+	# Daily create lists of removed mail accounts
+	@daily userli cd /path/to/userli && bin/console app:users:remove --list --env=prod >/usr/local/share/userli/maildirs-remove.txt
+
+	# Daily delete maildirs of removed accounts
+	@daily /usr/local/bin/userli-maildirs-remove.sh
 
 	# Daily unlink old redeemed vouchers
 	@daily userli cd /path/to/userli && bin/console app:voucher:unlink


### PR DESCRIPTION
This addition explains how to delete maildirs from removed users. Taken from the Userli Ansible role.