### PR TITLE
Add console command to reset a user

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -68,6 +68,10 @@ services:
         arguments:
             $mailLocation: "%env(DOVECOT_MAIL_LOCATION)%"
 
+    App\Command\UsersResetCommand:
+        arguments:
+            $mailLocation: "%env(DOVECOT_MAIL_LOCATION)%"
+
     App\Command\VoucherCreationCommand:
         arguments:
             $appUrl: "%env(APP_URL)%"

--- a/src/Command/UsersResetCommand.php
+++ b/src/Command/UsersResetCommand.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Handler\MailCryptKeyHandler;
+use App\Handler\PasswordStrengthHandler;
+use App\Handler\RecoveryTokenHandler;
+use App\Helper\PasswordUpdater;
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+
+class UsersResetCommand extends Command
+{
+    /** @var ObjectManager */
+    private $manager;
+
+    /** @var PasswordUpdater */
+    private $passwordUpdater;
+
+    /** @var MailCryptKeyHandler */
+    private $mailCryptKeyHandler;
+
+    /** @var RecoveryTokenHandler */
+    private $recoveryTokenHandler;
+
+    /** @var string */
+    private $mailLocation;
+
+    /**
+     * RegistrationMailCommand constructor.
+     */
+    public function __construct(ObjectManager $manager,
+                                PasswordUpdater $passwordUpdater,
+                                MailCryptKeyHandler $mailCryptKeyHandler,
+                                RecoveryTokenHandler $recoveryTokenHandler,
+                                string $mailLocation)
+    {
+        $this->manager = $manager;
+        $this->passwordUpdater = $passwordUpdater;
+        $this->mailCryptKeyHandler = $mailCryptKeyHandler;
+        $this->recoveryTokenHandler = $recoveryTokenHandler;
+        $this->mailLocation = $mailLocation;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName('app:users:reset')
+            ->setDescription('Reset a user')
+            ->addOption('user', 'u', InputOption::VALUE_REQUIRED, 'User to reset')
+            ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'User to reset')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $email = $input->getOption('user');
+
+        if (empty($email) || null === $user = $this->manager->getRepository(User::class)->findByEmail($email)) {
+            throw new UsernameNotFoundException(sprintf('User with email %s not found!', $email));
+        }
+
+        $questionHelper = $this->getHelper('question');
+        $confirmQuest = new ConfirmationQuestion('Really reset user? This will clear their mailbox: (yes|no) ', false);
+        if (!$questionHelper->ask($input, $output, $confirmQuest)) {
+            return 0;
+        }
+
+        $passwordQuest = new Question('New password: ');
+        $passwordQuest->setValidator(function ($value) {
+            $validator = new PasswordStrengthHandler();
+            if ($validator->validate($value)) {
+                throw new \Exception('The password doesn\'t comply with our security policy.');
+            }
+
+            return $value;
+        });
+        $passwordQuest->setHidden(true);
+        $passwordQuest->setHiddenFallback(false);
+        $passwordQuest->setMaxAttempts(5);
+
+        $password = $questionHelper->ask($input, $output, $passwordQuest);
+
+        $passwordConfirmQuest = new Question('Repeat password: ');
+        $passwordConfirmQuest->setHidden(true);
+        $passwordConfirmQuest->setHiddenFallback(false);
+
+        $passwordConfirm = $questionHelper->ask($input, $output, $passwordConfirmQuest);
+
+        if ($password !== $passwordConfirm) {
+            throw new \Exception('The passwords don\'t match');
+        }
+
+        if ($input->getOption('dry-run')) {
+            $output->write(sprintf("\nWould reset user %s\n\n", $email));
+
+            return 0;
+        }
+
+        $output->write(sprintf("\nResetting user %s ...\n\n", $email));
+
+        // Set new password
+        $user->setPlainPassword($password);
+        $this->passwordUpdater->updatePassword($user);
+
+        // Generate MailCrypt key with new password (overwrites old MailCrypt key)
+        if ($user->hasMailCryptSecretBox()) {
+            $this->mailCryptKeyHandler->create($user);
+
+            // Reset recovery token
+            $this->recoveryTokenHandler->create($user);
+            $output->write(sprintf("<info>New recovery token (please hand over to user): %s</info>\n\n", $user->getPlainRecoveryToken()));
+        }
+
+        // Clear plain password and flush changes to database
+        $user->eraseCredentials();
+        $user->erasePlainMailCryptPrivateKey();
+        $user->erasePlainRecoveryToken();
+        $this->manager->flush();
+
+        // Clear users mailbox
+        [$localPart, $domain] = explode('@', $email);
+        $path = $this->mailLocation.DIRECTORY_SEPARATOR.$domain.DIRECTORY_SEPARATOR.$localPart.DIRECTORY_SEPARATOR.'Maildir';
+        $filesystem = new Filesystem();
+        if ($filesystem->exists($path)) {
+            $output->writeln(sprintf('Delete directory for user: %s', $email));
+
+            try {
+                $filesystem->remove($path);
+            } catch (IOException $e) {
+                $output->writeln('<error>'.$e->getMessage().'</error>');
+                $output->writeln(sprintf("<comment>Please manually clear the mailbox at '%s'</comment>", $path));
+
+                return 1;
+            }
+        } else {
+            $output->writeln(sprintf("<error>Error:</error> Directory for user '%s' not found (e.g. due to missing permissions).", $email));
+            $output->writeln(sprintf("<comment>Please manually clear the mailbox at '%s'</comment>", $path));
+
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/Handler/RecoveryTokenHandler.php
+++ b/src/Handler/RecoveryTokenHandler.php
@@ -45,7 +45,6 @@ class RecoveryTokenHandler
         if (null === $plainPassword = $user->getPlainPassword()) {
             throw new \Exception('plainPassword should not be null');
         }
-        $user->eraseCredentials();
 
         if (null === $user->getPlainMailCryptPrivateKey()) {
             throw new \Exception('plainMailCryptPrivateKey should not be null');

--- a/tests/Command/UsersResetCommandTest.php
+++ b/tests/Command/UsersResetCommandTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\UsersResetCommand;
+use App\Command\VoucherUnlinkCommand;
+use App\Entity\User;
+use App\Handler\MailCryptKeyHandler;
+use App\Handler\RecoveryTokenHandler;
+use App\Helper\PasswordUpdater;
+use App\Repository\UserRepository;
+use Doctrine\Common\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+
+class UsersResetCommandTest extends TestCase
+{
+    /**
+     * @var VoucherUnlinkCommand
+     */
+    private $command;
+
+    public function setUp(): void
+    {
+        $user = new User();
+        $user->setEmail('user@example.org');
+
+        $repository = $this->getMockBuilder(UserRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $repository->method('findByEmail')
+            ->willReturn($user);
+
+        $manager = $this->getMockBuilder(ObjectManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $manager->method('getRepository')->willReturn($repository);
+
+        $passwordUpdater = $this->getMockBuilder(PasswordUpdater::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailCryptKeyHandler = $this->getMockBuilder(MailCryptKeyHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $recoveryTokenHandler = $this->getMockBuilder(RecoveryTokenHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailLocation = '/tmp/vmail';
+
+        $this->command = new UsersResetCommand($manager, $passwordUpdater, $mailCryptKeyHandler, $recoveryTokenHandler, $mailLocation);
+    }
+
+    public function testExecute(): void
+    {
+        $application = new Application();
+        $application->add($this->command);
+
+        $command = $application->find('app:users:reset');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs(['yes', 'longtestpassword1234', 'longtestpassword1234']);
+
+        // Test dry run
+        $commandTester->execute(['--user' => 'user@example.org', '--dry-run' => true]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Would reset user user@example.org', $output);
+
+        // Test real run
+        $commandTester->execute(['--user' => 'user@example.org']);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Resetting user user@example.org', $output);
+    }
+
+    public function testExecuteShortPassword(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("The password doesn't comply with our security policy.");
+
+        $application = new Application();
+        $application->add($this->command);
+
+        $command = $application->find('app:users:reset');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs(['yes', 'short', 'short', 'short', 'short', 'short']);
+
+        $commandTester->execute(['--user' => 'user@example.org']);
+    }
+
+    public function testExecutePasswordsDontMatch(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("The passwords don't match");
+
+        $application = new Application();
+        $application->add($this->command);
+
+        $command = $application->find('app:users:reset');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs(['yes', 'longtestpassword1234', 'different']);
+
+        $commandTester->execute(['--user' => 'user@example.org']);
+    }
+
+    public function testExecuteWithoutUser(): void
+    {
+        $this->expectException(UsernameNotFoundException::class);
+
+        $application = new Application();
+        $application->add($this->command);
+
+        $command = $application->find('app:users:reset');
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+    }
+}


### PR DESCRIPTION
The command resets password, MailCrypt key and recovery token of a user.
It also removes the users' mailbox (or warns in case of insufficient
permissions to do so).