### PR TITLE
:bug: Fix nullable $domain in WelcomeMessage*.php

### DIFF
--- a/src/Builder/WelcomeMessageBuilder.php
+++ b/src/Builder/WelcomeMessageBuilder.php
@@ -33,7 +33,8 @@ class WelcomeMessageBuilder
     public function __construct(TranslatorInterface $translator, ObjectManager $manager, string $appUrl, string $projectName)
     {
         $this->translator = $translator;
-        $this->domain = $manager->getRepository('App:Domain')->getDefaultDomain()->getName();
+        $domain = $manager->getRepository('App:Domain')->getDefaultDomain();
+        $this->domain = null !== $domain ? $domain->getName() : '';
         $this->appUrl = $appUrl;
         $this->projectName = $projectName;
     }

--- a/src/Sender/WelcomeMessageSender.php
+++ b/src/Sender/WelcomeMessageSender.php
@@ -32,7 +32,8 @@ class WelcomeMessageSender
     {
         $this->handler = $handler;
         $this->builder = $builder;
-        $this->domain = $manager->getRepository('App:Domain')->getDefaultDomain()->getName();
+        $domain = $manager->getRepository('App:Domain')->getDefaultDomain();
+        $this->domain = null !== $domain ? $domain->getName() : '';
     }
 
     /**

--- a/templates/Init/domain.html.twig
+++ b/templates/Init/domain.html.twig
@@ -2,6 +2,8 @@
 
 {% form_theme form 'Form/fields.html.twig' %}
 
+{% block title %}{{ "init.title"|trans }}{% endblock %}
+
 {% block subtitle %}{{ "init.title"|trans }}{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
I received this errors when I started a empty userli instance and wants to bootstrap the system.

```
In WelcomeMessageSender.php line 35:
                                               
  Call to a member function getName() on null  
                                               
```

```
In WelcomeMessageBuilder.php line 36:
                                               
  Call to a member function getName() on null  
                                               
```