### PR TITLE
Add documentation about update workflow

### DIFF
--- a/hugo/content/update/_index.md
+++ b/hugo/content/update/_index.md
@@ -1,0 +1,16 @@
++++
+title = "Update"
+description = ""
+alwaysopen = true
++++
+
+To update Userli just download the latest version and run these commands:
+
+    # Warm up cache
+    bin/console cache:warmup
+
+    # Show database schema updates
+    bin/console doctrine:schema:update --dump-sql
+
+    # If necessary update the database schema
+    bin/console doctrine:schema:update --force


### PR DESCRIPTION
The latest Userli update requires a database schema update. Then document describes all the necessary steps.