### PR TITLE
Subscribe to correct LoginEvent name

### DIFF
--- a/.env
+++ b/.env
@@ -50,5 +50,5 @@ MAILER_DELIVERY_ADDRESS="admin@example.org"
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=14&charset=utf8"
-DATABASE_URL="mysql://mail:password@127.0.0.1:3306/mail?serverVersion=mariadb-10.3.23&charset=utf8mb4"
+DATABASE_URL="mysql://mail:password@127.0.0.1:3306/mail?charset=utf8mb4"
 ###< doctrine/doctrine-bundle ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.4 (unreleased)
+
+* Fix setting last_login_time on authentication through checkpassword command.
+
 # 3.2.3 (2023.10.31)
 
 * Update dependencies

--- a/src/Command/UsersRegistrationMailCommand.php
+++ b/src/Command/UsersRegistrationMailCommand.php
@@ -40,7 +40,7 @@ class UsersRegistrationMailCommand extends Command
      *
      * @throws \Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $email = $input->getOption('user');
         $locale = $input->getOption('locale');
@@ -50,5 +50,7 @@ class UsersRegistrationMailCommand extends Command
         }
 
         $this->welcomeMessageSender->send($user, $locale);
+
+        return 0;
     }
 }

--- a/src/Event/RecoveryProcessEvent.php
+++ b/src/Event/RecoveryProcessEvent.php
@@ -7,7 +7,7 @@ use App\Traits\UserAwareTrait;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * Class LoginEvent.
+ * Class RecoveryProcessEvent.
  */
 class RecoveryProcessEvent extends Event
 {

--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -62,7 +62,7 @@ class LoginListener implements EventSubscriberInterface
     {
         return [
             SecurityEvents::INTERACTIVE_LOGIN => 'onSecurityInteractiveLogin',
-            LoginEvent::class => 'onLogin',
+            LoginEvent::NAME => 'onLogin',
         ];
     }
 }

--- a/tests/EventListener/LoginListenerTest.php
+++ b/tests/EventListener/LoginListenerTest.php
@@ -97,7 +97,7 @@ class LoginListenerTest extends TestCase
     {
         $this->assertEquals([
             SecurityEvents::INTERACTIVE_LOGIN => 'onSecurityInteractiveLogin',
-            LoginEvent::class => 'onLogin',
+            LoginEvent::NAME => 'onLogin',
         ],
             $this->listener::getSubscribedEvents());
     }


### PR DESCRIPTION
This fixes the `last_login_time` record being updated when authenticating through the `app:users:checkpassword` command.