### PR TITLE
Add `app:alias:delete` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 3.2.4 (unreleased)
+# 3.3.0 (unreleased)
 
+* Add command to delete a user alias.
 * Fix setting last_login_time on authentication through checkpassword command.
 
 # 3.2.3 (2023.10.31)

--- a/src/Command/AliasDeleteCommand.php
+++ b/src/Command/AliasDeleteCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Alias;
+use App\Entity\User;
+use App\Handler\DeleteHandler;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+
+class AliasDeleteCommand extends Command
+{
+    private EntityManagerInterface $manager;
+    private DeleteHandler $deleteHandler;
+
+    public function __construct(EntityManagerInterface $manager, DeleteHandler $deleteHandler)
+    {
+        $this->manager = $manager;
+        $this->deleteHandler = $deleteHandler;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName('app:alias:delete')
+            ->setDescription('Delete an alias')
+            ->addOption('user', 'u', InputOption::VALUE_REQUIRED, 'User who owns the alias (optional)')
+            ->addOption('alias', 'a', InputOption::VALUE_REQUIRED, 'Alias address to delete')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $email = $input->getOption('user');
+        $source = $input->getOption('alias');
+
+        $user = null;
+        if ($email && null === $user = $this->manager->getRepository(User::class)->findByEmail($email)) {
+            $output->writeln(sprintf("<error>User with email '%s' not found!</error>", $email));
+            return 1;
+        }
+
+        if (empty($source) || null === $alias = $this->manager->getRepository(Alias::class)->findOneBySource($source)) {
+            $output->writeln(sprintf("<error>Alias with address '%s' not found!</error>", $source));
+            return 1;
+        }
+
+        if ($input->getOption('dry-run')) {
+            if ($user) {
+                $output->write(sprintf("Would delete alias %s of user %s\n", $source, $email));
+            } else {
+                $output->write(sprintf("Would delete alias %s\n", $source));
+            }
+        } else {
+            if ($user) {
+                $output->write(sprintf("Deleting alias %s of user %s\n", $source, $email));
+                $this->deleteHandler->deleteAlias($alias, $user);
+            } else {
+                $output->write(sprintf("Deleting alias %s\n", $source));
+                $this->deleteHandler->deleteAlias($alias);
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Command/AliasDeleteCommandTest.php
+++ b/tests/Command/AliasDeleteCommandTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\AliasDeleteCommand;
+use App\Entity\Alias;
+use App\Entity\User;
+use App\Handler\DeleteHandler;
+use App\Repository\AliasRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+
+class AliasDeleteCommandTest extends TestCase
+{
+    private AliasDeleteCommand $command;
+
+    public function setUp(): void
+    {
+        $user = new User();
+        $user->setEmail('user@example.org');
+
+        $userRepository = $this->getMockBuilder(UserRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $userRepository->method('findByEmail')
+            ->willReturn($user);
+
+        $alias = new Alias();
+        $alias->setSource('alias@example.org');
+        $alias->setUser($user);
+
+        $aliasRepository = $this->getMockBuilder(AliasRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $aliasRepository->method('findOneBySource')
+            ->willReturn($alias);
+
+        $manager = $this->getMockBuilder(EntityManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $manager->method('getRepository')->willReturnMap([
+            [User::class, $userRepository],
+            [Alias::class, $aliasRepository],
+        ]);
+
+        $deleteHandler = $this->getMockBuilder(DeleteHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->command = new AliasDeleteCommand($manager, $deleteHandler);
+    }
+
+    public function testExecute(): void
+    {
+        $application = new Application();
+        $application->add($this->command);
+
+        $command = $application->find('app:alias:delete');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--user' => 'user@example.org', '--alias' => 'alias@example.org']);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Deleting alias alias@example.org of user user@example.org', $output);
+
+        // Test dry run alias deletion
+        $commandTester->execute(['--user' => 'user@example.org', '--alias' => 'alias@example.org', '--dry-run' => true]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Would delete alias alias@example.org of user user@example.org', $output);
+
+        // Test alias deletion without user
+        $commandTester->execute(['--alias' => 'alias@example.org']);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Deleting alias alias@example.org', $output);
+    }
+
+    public function testExecuteWithoutAlias(): void
+    {
+        $application = new Application();
+        $application->add($this->command);
+
+        $command = $application->find('app:alias:delete');
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Alias with address \'\' not found!', $output);
+        $this->assertEquals($commandTester->getStatusCode(), 1);
+    }
+}


### PR DESCRIPTION
The command requires the alias source address as argument and supports an optional user email address as second argument. If the user email is provided, only a matching alias by the respective user is deleted.