### PR TITLE
Improve fixture loading while increasing the number of fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Adjust Admin List Order
 * Add __toString methods to Entities
+* Improve fixture loading while increasing the number of fixtures
 
 # 3.3.1 (2023.11.12)
 
@@ -60,7 +61,7 @@
 
 # 2.7.17 (2021.12.30)
 
-* Set creationTime and updatedTime in all entity constructors (Fixes #207) 
+* Set creationTime and updatedTime in all entity constructors (Fixes #207)
 * Update to symfony 4.3.36
 * Update dependencies
 
@@ -145,8 +146,8 @@
 # 2.7.3 (2020.10.21)
 
 * Improve OpenPGP key import filter:
-  - Keep UIDs with valid email address but without realname
-  - Drop UIDs with invalid email address that have the valid email
+  * Keep UIDs with valid email address but without realname
+  * Drop UIDs with invalid email address that have the valid email
     address in realname
 
 # 2.7.2 (2020.10.21)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+---
+ignore:
+  - "config"
+  - "features"
+  - "hugo"
+  - "public"
+  - "src/DataFixtures"
+  - "templates"
+  - "tests"

--- a/src/DataFixtures/LoadAliasData.php
+++ b/src/DataFixtures/LoadAliasData.php
@@ -2,28 +2,14 @@
 
 namespace App\DataFixtures;
 
-use App\Entity\Domain;
 use App\Entity\User;
 use App\Factory\AliasFactory;
-use App\Repository\DomainRepository;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class LoadAliasData extends Fixture implements OrderedFixtureInterface, ContainerAwareInterface
+class LoadAliasData extends Fixture implements OrderedFixtureInterface
 {
-    private ContainerInterface $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -32,23 +18,25 @@ class LoadAliasData extends Fixture implements OrderedFixtureInterface, Containe
         $user = $manager->getRepository(User::class)->findByEmail('admin@example.org');
 
         for ($i = 1; $i < 5; ++$i) {
-            $alias = AliasFactory::create($user, 'alias'.$i);
-
-            $manager->persist($alias);
-            $manager->flush();
-        }
-
-        for ($i = 1; $i < 5; ++$i) {
             $alias = AliasFactory::create($user, null);
 
             $manager->persist($alias);
-            $manager->flush();
         }
-    }
 
-    private function getRepository(): DomainRepository
-    {
-        return $this->container->get('doctrine')->getRepository(Domain::class);
+        $users = $manager->getRepository(User::class)->findAll();
+
+        for ($i = 1; $i < 500; ++$i) {
+            $alias = AliasFactory::create($users[random_int(0, count($users) - 1)], 'alias' . $i);
+
+            $manager->persist($alias);
+
+            if (($i % 100) === 0) {
+                $manager->flush();
+            }
+        }
+
+        $manager->flush();
+        $manager->clear();
     }
 
     /**

--- a/src/DataFixtures/LoadDomainData.php
+++ b/src/DataFixtures/LoadDomainData.php
@@ -24,8 +24,10 @@ class LoadDomainData extends Fixture implements OrderedFixtureInterface
             $domain->setName($name);
 
             $manager->persist($domain);
-            $manager->flush();
         }
+
+        $manager->flush();
+        $manager->clear();
     }
 
     /**

--- a/src/DataFixtures/LoadVoucherData.php
+++ b/src/DataFixtures/LoadVoucherData.php
@@ -3,26 +3,13 @@
 namespace App\DataFixtures;
 
 use App\Entity\User;
-use App\Entity\Voucher;
 use App\Factory\VoucherFactory;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class LoadVoucherData extends Fixture implements OrderedFixtureInterface, ContainerAwareInterface
+class LoadVoucherData extends Fixture implements OrderedFixtureInterface
 {
-    private ContainerInterface $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      *
@@ -46,6 +33,10 @@ class LoadVoucherData extends Fixture implements OrderedFixtureInterface, Contai
             }
 
             $manager->persist($voucher);
+
+            if (($i % 100) === 0) {
+                $manager->flush();
+            }
         }
 
         // add redeemed voucher to a suspicious parent
@@ -58,6 +49,7 @@ class LoadVoucherData extends Fixture implements OrderedFixtureInterface, Contai
         $manager->persist($voucher);
 
         $manager->flush();
+        $manager->clear();
     }
 
     /**


### PR DESCRIPTION
I attempted to increase the fixtures to replicate the issues with "large" datasets. However, I encountered a problem where there was insufficient memory, and it took a long time. Consequently, I decided to refresh my Doctrine skills and optimize the database operations. Additionally, I optimized the password hashing for fixtures since we utilize the same password for all fixtures, eliminating the need to recalculate it for each user.