### PR TITLE
Try to reactive Dependabot for PHP Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,37 @@
+---
 version: 2
 updates:
-
-  # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
 
-  ## Maintain dependencies for Composer
-  #- package-ecosystem: "composer"
-  #  directory: "/"
-  #  schedule:
-  #    interval: "weekly"
-  #  ignore:
-  #    - dependency-name: "symfony/http-client"
-  #      versions:
-  #        - "4.5.*"
-  #        - "5.*"
-  #    - dependency-name: "symfony/debug-bundle"
-  #      versions:
-  #        - "4.5.*"
-  #        - "5.*"
-  #    - dependency-name: "symfony/dotenv"
-  #      versions:
-  #        - "4.5.*"
-  #        - "5.*"
-  #    - dependency-name: "symfony/var-dumper"
-  #      versions:
-  #        - "4.5.*"
-  #        - "5.*"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+    allow:
+      - dependency-name: "endroid/qr-code"
+      - dependency-name: "ircmaxell/password-compat"
+      - dependency-name: "mopa/bootstrap-bundle"
+      - dependency-name: "nelmio/security-bundle"
+      - dependency-name: "pear/crypt_gpg"
+      - dependency-name: "ramsey/uuid"
+      - dependency-name: "scheb/*"
+      - dependency-name: "sonata-project/*"
+      - dependency-name: "tuupola/base32"
+    groups:
+      php-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I was not happy to disable Dependabot for PHP at all. I understand that Symfony updates are a special case, and according to our upgrading policy, this will not work. However, for other dependencies, we can use Dependabot, and therefore, I activated it again and grouped the upgrades.

This is more or less a test and can result in failed PRs. But I am convinced that it helps to have automated updates and newer versions.