### PR TITLE
Fix Filters in AliasAdmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add __toString methods to Entities
 * Improve fixture loading while increasing the number of fixtures
 * Fix Filters in User Admin
+* Fix Filters in Alias Admin
 
 # 3.3.1 (2023.11.12)
 

--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -19,7 +19,8 @@ class AliasAdmin extends Admin
 {
     use DomainGuesserAwareTrait;
 
-    protected function generateBaseRoutePattern(bool $isChildAdmin = false): string {
+    protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
+    {
         return 'alias';
     }
 
@@ -45,23 +46,10 @@ class AliasAdmin extends Admin
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
-            ->add('source', null, [
-                'show_filter' => true,
-            ])
-            ->add('user', null, [
-                'show_filter' => true,
-            ])
-            ->add('domain', null, [
-                'show_filter' => true,
-            ])
-            ->add('deleted', ChoiceFilter::class, [
-                'field_options' => [
-                    'required' => false,
-                    'choices' => [0 => 'No', 1 => 'Yes'],
-                ],
-                'field_type' => ChoiceType::class,
-                'show_filter' => true,
-            ]);
+            ->add('source')
+            ->add('user')
+            ->add('domain')
+            ->add('deleted');
     }
 
     /**


### PR DESCRIPTION
I noticed that the filter "deleted" is broken. Additionally, some of the other filters are more complex than necessary. Therefore, I simplified them a bit.
