### PR TITLE
Improve Performance for Alias and Voucher Admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Improve fixture loading while increasing the number of fixtures
 * Fix Filters in User Admin
 * Fix Filters in Alias Admin
+* Improve Performance for Alias and Voucher Admin
 
 # 3.3.1 (2023.11.12)
 

--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -9,10 +9,8 @@ use App\Traits\DomainGuesserAwareTrait;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 
 class AliasAdmin extends Admin
@@ -47,7 +45,7 @@ class AliasAdmin extends Admin
     {
         $filter
             ->add('source')
-            ->add('user')
+            ->add('user.email', null, ['label' => 'User'])
             ->add('domain')
             ->add('deleted');
     }

--- a/src/Admin/VoucherAdmin.php
+++ b/src/Admin/VoucherAdmin.php
@@ -6,9 +6,8 @@ use App\Helper\RandomStringGenerator;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
-use Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter;
+use Sonata\Form\Type\DateRangePickerType;
 
 class VoucherAdmin extends Admin
 {
@@ -18,7 +17,8 @@ class VoucherAdmin extends Admin
         '_sort_by' => 'creationTime',
     ];
 
-    protected function generateBaseRoutePattern(bool $isChildAdmin = false): string {
+    protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
+    {
         return 'voucher';
     }
 
@@ -69,35 +69,23 @@ class VoucherAdmin extends Admin
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
-            ->add('user')
+            ->add('user.email', null, ['label' => 'User'])
             ->add('code')
-            ->add('created_since', CallbackFilter::class, [
-                'callback' => function (ProxyQuery $proxyQuery, $alias, $field, $value) {
-                    if (isset($value['value']) && null !== $value = $value['value']) {
-                        $qb = $proxyQuery->getQueryBuilder();
-                        $field = sprintf('%s.creationTime', $alias);
-                        $qb->andWhere(sprintf('%s >= :datetime', $field))
-                            ->setParameter('datetime', new \DateTime($value))
-                            ->orderBy($field, 'DESC');
-                    }
-
-                    return true;
-                },
-                'field_type' => TextType::class,
+            ->add('creationTime', DateTimeRangeFilter::class, [
+                'field_type' => DateRangePickerType::class,
+                'field_options' => [
+                    'field_options' => [
+                        'format' => 'dd.MM.yyyy'
+                    ]
+                ]
             ])
-            ->add('redeemed_since', CallbackFilter::class, [
-                'callback' => function (ProxyQuery $proxyQuery, $alias, $field, $value) {
-                    if (isset($value['value']) && null !== $value = $value['value']) {
-                        $qb = $proxyQuery->getQueryBuilder();
-                        $field = sprintf('%s.redeemedTime', $alias);
-                        $qb->andWhere(sprintf('%s >= :datetime', $field))
-                            ->setParameter('datetime', new \DateTime($value))
-                            ->orderBy($field, 'DESC');
-                    }
-
-                    return true;
-                },
-                'field_type' => TextType::class,
+            ->add('redeemedTime', DateTimeRangeFilter::class, [
+                'field_type' => DateRangePickerType::class,
+                'field_options' => [
+                    'field_options' => [
+                        'format' => 'dd.MM.yyyy'
+                    ]
+                ]
             ]);
     }
 


### PR DESCRIPTION
On larger datasets, querying all users in Voucher and Alias Admin took a very long time or resulted in a timeout. Therefore, I replaced the filter that had preloaded all entities with a simple text filter, which works quite fast.