### PR TITLE
Disable Mosaic List in Admin

### DIFF
--- a/config/packages/sonata_admin.yaml
+++ b/config/packages/sonata_admin.yaml
@@ -1,6 +1,7 @@
 sonata_admin:
     title: Userli
     title_logo: 'build/images/logo_small.png'
+    show_mosaic_button: false
     dashboard:
         blocks:
           - position: left


### PR DESCRIPTION
We don't need the mosaic-style list. It does not bring any benefit.

**Before**

<img width="430" alt="grafik" src="https://github.com/systemli/userli/assets/363667/09b527d2-3408-42a4-a63b-387d418c7da4">

**After**

<img width="482" alt="grafik" src="https://github.com/systemli/userli/assets/363667/18adcfba-271d-4981-9834-e2de5ac922db">
