### PR TITLE
Load Users with Autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix Filters in User Admin
 * Fix Filters in Alias Admin
 * Improve Performance for Alias and Voucher Admin
+* Use Autocomplete for loading Users in Alias and Voucher Admin
 
 # 3.3.1 (2023.11.12)
 

--- a/config/packages/dev/nelmio_security.yaml
+++ b/config/packages/dev/nelmio_security.yaml
@@ -1,6 +1,3 @@
 nelmio_security:
     csp:
-        enabled: true
-        enforce:
-            default-src:
-              - 'self'
+        enabled: false

--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -9,6 +9,7 @@ use App\Traits\DomainGuesserAwareTrait;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -29,7 +30,7 @@ class AliasAdmin extends Admin
     {
         $form
             ->add('source', EmailType::class)
-            ->add('user', EntityType::class, ['class' => User::class, 'required' => false])
+            ->add('user', ModelAutocompleteType::class, ['property' => 'email', 'required' => false])
             ->add('deleted', CheckboxType::class, ['disabled' => true]);
 
         if ($this->security->isGranted(Roles::ADMIN)) {

--- a/src/Admin/VoucherAdmin.php
+++ b/src/Admin/VoucherAdmin.php
@@ -6,17 +6,12 @@ use App\Helper\RandomStringGenerator;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter;
 use Sonata\Form\Type\DateRangePickerType;
 
 class VoucherAdmin extends Admin
 {
-    protected array $datagridValues = [
-        '_page' => 1,
-        '_sort_order' => 'DESC',
-        '_sort_by' => 'creationTime',
-    ];
-
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
         return 'voucher';
@@ -42,7 +37,7 @@ class VoucherAdmin extends Admin
         }
 
         $form
-            ->add('user', null, ['disabled' => $disabled])
+            ->add('user', ModelAutocompleteType::class, ['disabled' => $disabled, 'property' => 'email'])
             ->add('code', null, ['disabled' => !$this->isNewObject()]);
     }
 


### PR DESCRIPTION
Now, not all users are fetched and put into the dropdown. You need to type something, and the users will be loaded dynamically. This significantly improves performance.

<img width="902" alt="grafik" src="https://github.com/systemli/userli/assets/363667/2c5f40ce-b478-4fe6-9953-1b9959efc343">

<img width="906" alt="grafik" src="https://github.com/systemli/userli/assets/363667/3b1aff44-05bd-4dd3-9eb8-aba94ed77b52">
