### PR TITLE
Fix Regression in CRUD Controllers

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\Set\ValueObject\SetList;
+use Rector\Symfony\CodeQuality\Rector\ClassMethod\ActionSuffixRemoverRector;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\Config\RectorConfig;
 
@@ -13,6 +14,14 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->symfonyContainerXml(__DIR__ . '/var/cache/dev/App_KernelDevDebugContainer.xml');
     $rectorConfig->importNames();
     $rectorConfig->phpVersion(PhpVersion::PHP_80);
+
+    $rectorConfig->skip([
+        // SonataAdminBundle CRUDController needs the suffix for actions
+        ActionSuffixRemoverRector::class => [
+            __DIR__ . '/src/Controller/AliasCRUDController.php',
+            __DIR__ . '/src/Controller/UserCRUDController.php',
+        ],
+    ]);
 
     $rectorConfig->sets([
         SetList::PHP_80,

--- a/src/Controller/AliasCRUDController.php
+++ b/src/Controller/AliasCRUDController.php
@@ -15,7 +15,7 @@ class AliasCRUDController extends CRUDController
     {
     }
 
-    public function delete(Request $request): Response
+    public function deleteAction(Request $request): Response
     {
         $object = $this->assertObjectExists($request, true);
         \assert(null !== $object);

--- a/src/Controller/UserCRUDController.php
+++ b/src/Controller/UserCRUDController.php
@@ -34,7 +34,7 @@ class UserCRUDController extends CRUDController
         return $this->redirectToList();
     }
 
-    public function delete(Request $request): Response
+    public function deleteAction(Request $request): Response
     {
         $object = $this->assertObjectExists($request, true);
         \assert(null !== $object);


### PR DESCRIPTION
After #546, the CRUDController used by Admin classes was broken. The parent class has no `delete` function, so it never got triggered. This means the entities for `User` and `Alias` will be hard-deleted.