### PR TITLE
Fix malformed date for recovery page

### DIFF
--- a/templates/Recovery/recovery_started.html.twig
+++ b/templates/Recovery/recovery_started.html.twig
@@ -2,5 +2,5 @@
 
 {% block recovery_content %}
     <p class="alert alert-success">{{ "recovery.started"|trans }}<br /><br />{{ "recovery.waiting-info"|trans }}</p>
-    <p class="alert alert-info lead">{{ "recovery.waiting-time"|trans({'%time%': active_time|format_date('medium', 'short')}) }}</p>
+    <p class="alert alert-info lead">{{ "recovery.waiting-time"|trans({'%time%': active_time|date("d.m.Y")}) }}</p>
 {% endblock %}


### PR DESCRIPTION
Same bug as in https://github.com/systemli/userli/commit/72dbbdaf733ad6a19fb56f101e1cf821fb37ebbd

Grepped for other occurrences of format_date this time to make sure...