### PR TITLE
fix: Split index route in public (index) and authenticated (start)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -75,6 +75,7 @@ security:
 
         # Spam account is always suspicious
         ROLE_SPAM:
+            - ROLE_USER
             - ROLE_SUSPICIOUS
 
         ROLE_PERMANENT:
@@ -113,6 +114,7 @@ security:
                 require_previous_session: false
                 login_path: login
                 check_path: login
+                default_target_path: start
             logout:
                 path: logout
                 invalidate_session: false
@@ -140,6 +142,7 @@ security:
       - { path: "^/[a-z]{2,3}/register", roles: PUBLIC_ACCESS }
       - { path: "^/[a-z]{2,3}/$", roles: PUBLIC_ACCESS }
       - { path: "^/[a-z]{2,3}/2fa", roles: IS_AUTHENTICATED_2FA_IN_PROGRESS }
+      - { path: "^/[a-z]{2,3}/start", roles: ROLE_USER }
       - { path: "^/[a-z]{2,3}/voucher", roles: ROLE_USER, allow_if: "!is_granted('ROLE_SUSPICIOUS')"}
       - { path: "^/[a-z]{2,3}/alias", roles: ROLE_USER, allow_if: "!is_granted('ROLE_SPAM')"}
       - { path: "^/[a-z]{2,3}/account", roles: ROLE_USER, allow_if: "!is_granted('ROLE_SPAM')"}

--- a/features/login.feature
+++ b/features/login.feature
@@ -20,7 +20,7 @@ Feature: Login
       | password | asdasd            |
     And I press "Sign in"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And I should see text matching "Log out"
     And the response status code should not be 403
 
@@ -32,7 +32,7 @@ Feature: Login
       | password | asdasd            |
     And I press "Sign in"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And I should see text matching "Log out"
     And the response status code should not be 403
 
@@ -54,7 +54,7 @@ Feature: Login
       | password | asdasd           |
     And I press "Sign in"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And the response status code should not be 403
 
   @login
@@ -65,7 +65,7 @@ Feature: Login
       | password | asdasd              |
     And I press "Sign in"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And the response status code should not be 403
 
   @login
@@ -76,7 +76,7 @@ Feature: Login
       | password | asdasd |
     And I press "Sign in"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And the response status code should not be 403
 
   @login
@@ -90,7 +90,7 @@ Feature: Login
       | password | paßwort             |
     And I press "Sign in"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And the response status code should not be 403
 
   @logout
@@ -116,7 +116,7 @@ Feature: Login
       | password | asdasd              |
     And I press "Sign in"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And the response status code should be 200
     And I should see text matching "E-mail access has been turned off"
 
@@ -161,5 +161,5 @@ Feature: Login
     And I enter TOTP backup code
     And I press "Verify"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And the response status code should be 200

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -41,7 +41,7 @@ Feature: registration
       | password | P4ssW0rt!!!1      |
     And I press "Sign in"
 
-    Then I should be on "/en/"
+    Then I should be on "/en/start"
     And I should see text matching "Log out"
 
   @registration

--- a/src/Controller/RecoveryController.php
+++ b/src/Controller/RecoveryController.php
@@ -315,7 +315,7 @@ class RecoveryController extends AbstractController
             if ($recoveryTokenAckForm->isSubmitted() and $recoveryTokenAckForm->isValid()) {
                 $request->getSession()->getFlashBag()->add('success', 'flashes.recovery-token-ack');
 
-                return $this->redirect($this->generateUrl('index'));
+                return $this->redirect($this->generateUrl('start'));
             }
 
             return $this->render('User/recovery_token.html.twig',

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -3,12 +3,28 @@
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController
 {
+    /**
+     * @param Request $request
+     * @return RedirectResponse
+     */
+    #[Route(path: '/login', name: 'login_no_locale')]
+    public function indexNoLocale(Request $request): RedirectResponse
+    {
+        $supportedLocales = (array)$this->getParameter('supported_locales');
+        $preferredLanguage = $request->getPreferredLanguage($supportedLocales);
+        $locale = $preferredLanguage ?: $request->getLocale();
+
+        return $this->redirectToRoute('login', ['_locale' => $locale]);
+    }
+
     /**
      * @param AuthenticationUtils $authenticationUtils
      * @return Response

--- a/src/DataFixtures/LoadUserData.php
+++ b/src/DataFixtures/LoadUserData.php
@@ -23,6 +23,7 @@ class LoadUserData extends Fixture implements OrderedFixtureInterface, Container
     private array $users = [
         ['email' => 'admin@example.org', 'roles' => [Roles::ADMIN]],
         ['email' => 'user@example.org', 'roles' => [Roles::USER]],
+        ['email' => 'spam@example.org', 'roles' => [Roles::SPAM]],
         ['email' => 'support@example.org', 'roles' => [Roles::MULTIPLIER]],
         ['email' => 'suspicious@example.org', 'roles' => [Roles::SUSPICIOUS]],
         ['email' => 'domain@example.com', 'roles' => [Roles::DOMAIN_ADMIN]],

--- a/templates/Admin/user_block.html.twig
+++ b/templates/Admin/user_block.html.twig
@@ -1,7 +1,7 @@
 {% block user_block %}
     <li role="presentation" class="dropdown-header">Mail</li>
     <li role="presentation">
-        <a role="menuitem" tabindex="-1" href="{{ path('index') }}">Return to Index</a>
+        <a role="menuitem" tabindex="-1" href="{{ path('start') }}">Return to Index</a>
     </li>
     <li role="presentation">
         <a role="menuitem" tabindex="-1" href="{{ path('logout') }}">Logout</a>

--- a/templates/Alias/delete.html.twig
+++ b/templates/Alias/delete.html.twig
@@ -4,7 +4,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li><a href="{{ path('aliases') }}">{{ "start.aliases"|trans }}</a></li>
         <li class="active">{{ "start.aliases-delete"|trans }}</li>
     </ol>
@@ -24,7 +24,7 @@
 
             <div class="form-group">
                 {{ form_widget(form.submit, {'attr': {'class': 'btn btn-danger' }}) }}
-                <a href="{{ url('index') }}" class="btn btn-default">{{ "delete.cancel"|trans }}</a>
+                <a href="{{ url('start') }}" class="btn btn-default">{{ "delete.cancel"|trans }}</a>
             </div>
 
             {{ form_end(form) }}

--- a/templates/Exception/show.html.twig
+++ b/templates/Exception/show.html.twig
@@ -23,7 +23,7 @@
             {% else %}
             <p class="lead">{{ "error.generic_error"|trans }}</p>
             {% endif %}
-            <p><a class="btn btn-primary" href="{{ url('index') }}">{{ "error.back_link"|trans }}</a></p>
+            <p><a class="btn btn-primary" href="{{ url('start') }}">{{ "error.back_link"|trans }}</a></p>
         </div>
     </div>
 {% endblock %}

--- a/templates/OpenPgp/delete.html.twig
+++ b/templates/OpenPgp/delete.html.twig
@@ -4,7 +4,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li><a href="{{ path('openpgp') }}">{{ "start.openpgp-settings"|trans }}</a></li>
         <li class="active">{{ "start.openpgp-delete"|trans }}</li>
     </ol>
@@ -24,7 +24,7 @@
 
             <div class="form-group">
                 {{ form_widget(form.submit, {'attr': {'class': 'btn btn-danger' }}) }}
-                <a href="{{ url('index') }}" class="btn btn-default">{{ "delete.cancel"|trans }}</a>
+                <a href="{{ url('start') }}" class="btn btn-default">{{ "delete.cancel"|trans }}</a>
             </div>
 
             {{ form_end(form) }}

--- a/templates/Registration/welcome.html.twig
+++ b/templates/Registration/welcome.html.twig
@@ -12,7 +12,7 @@
 
             {{ "welcome.text"|trans({'%project_name%': project_name, '%app_url%': app_url})|raw }}
 
-            <p><a href="{{ path('index') }}" class="btn btn-lg btn-primary pull-right">{{ "welcome.next-button"|trans }}</a></p>
+            <p><a href="{{ path('start') }}" class="btn btn-lg btn-primary pull-right">{{ "welcome.next-button"|trans }}</a></p>
         </div>
     </div>
 

--- a/templates/Start/account.html.twig
+++ b/templates/Start/account.html.twig
@@ -4,7 +4,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li class="active">{{ "start.account-settings"|trans }}</li>
     </ol>
 {% endblock %}

--- a/templates/Start/aliases.html.twig
+++ b/templates/Start/aliases.html.twig
@@ -4,7 +4,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li class="active">{{ "start.aliases"|trans }}</li>
     </ol>
 {% endblock %}

--- a/templates/Start/openpgp.html.twig
+++ b/templates/Start/openpgp.html.twig
@@ -4,7 +4,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li class="active">{{ "start.openpgp-settings"|trans }}</li>
     </ol>
 {% endblock %}

--- a/templates/Start/vouchers.html.twig
+++ b/templates/Start/vouchers.html.twig
@@ -4,7 +4,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li class="active">{{ "start.vouchers"|trans }}</li>
     </ol>
 {% endblock %}

--- a/templates/User/delete.html.twig
+++ b/templates/User/delete.html.twig
@@ -4,7 +4,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li><a href="{{ path('account') }}">{{ "start.account-settings"|trans }}</a></li>
         <li class="active">{{ "start.account-delete"|trans }}</li>
     </ol>

--- a/templates/User/recovery_token.html.twig
+++ b/templates/User/recovery_token.html.twig
@@ -6,7 +6,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li><a href="{{ path('account') }}">{{ "start.account-settings"|trans }}</a></li>
         <li class="active">{{ "recovery-token.headline"|trans }}</li>
     </ol>

--- a/templates/User/twofactor.html.twig
+++ b/templates/User/twofactor.html.twig
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('index') }}">Start</a></li>
+        <li><a href="{{ path('start') }}">Start</a></li>
         <li><a href="{{ path('account') }}">{{ "start.account-settings"|trans }}</a></li>
         <li class="active">{{ "account.twofactor.headline"|trans }}</li>
     </ol>


### PR DESCRIPTION
So far, `StartController::index()` rendered different content depending on whether a user is authenticated or not. In the symfony security firewall, the endpoint was marked as `PUBLIC_ACCESS`, which meant we exposed content that requires authentication via a public endpoint.

This is now splitted:
* `index` remains the publically available index page
* `start` is the account overview page that requires authentication

Along the way, a few minor issues were fixed.