### PR TITLE
fix: Add missing default value for roles column

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -66,7 +66,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
 
     public const CURRENT_PASSWORD_VERSION = 2;
 
-    #[ORM\Column(type: 'array')]
+    #[ORM\Column(type: 'array', options: ['default' => 'a:0:{}'])]
     private array $roles = [];
 
     /**


### PR DESCRIPTION
I was unable to spin up an empty database and fill it with our data fixtures. The error was:

>  An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1364 Field 'roles' doesn't have a default value