### PR TITLE
[Provisioner] Require Node v18.x

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -37,7 +37,7 @@
         host: localhost
         password: password
         priv: "mail_test.*:ALL"
-    nodejs_version: "16.x"
+    nodejs_version: "18.x"
     php_default_version_debian: 8.2
     php_packages:
       # necessary


### PR DESCRIPTION
fixes:
```
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
error @symfony/webpack-encore@4.6.1: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "16.20.2"
error Found incompatible module.

```