### PR TITLE
Further improvements to suspicious user handling

### DIFF
--- a/features/registration.feature
+++ b/features/registration.feature
@@ -8,9 +8,11 @@ Feature: registration
     And the following User exists:
       | email             | password | roles      |
       | louis@example.org | asdasd   | ROLE_ADMIN |
+      | suspicious@example.org | asdasd   | ROLE_SUSPICIOUS |
     And the following Voucher exists:
       | code | user              |
       | TEST | louis@example.org |
+      | ABCD | suspicious@example.org |
     And the following Alias exists:
       | source            | destination       |
       | alias@example.org | goto@example.org |
@@ -43,6 +45,19 @@ Feature: registration
 
     Then I should be on "/start"
     And I should see text matching "Log out"
+
+  @registration
+  Scenario: Register with voucher from suspicious user
+    When I am on "/register"
+    And I fill in the following:
+      | registration[voucher]               | ABCD         |
+      | registration[email]                 | user1        |
+      | registration[plainPassword][first]  | P4ssW0rt!!!1 |
+      | registration[plainPassword][second] | P4ssW0rt!!!1 |
+    And I press "Submit"
+
+    Then I should be on "/register"
+    And I should see "The invite code is invalid."
 
   @registration
   Scenario: Register with invalid voucher

--- a/src/Entity/Voucher.php
+++ b/src/Entity/Voucher.php
@@ -26,6 +26,7 @@ class Voucher implements Stringable
     #[ORM\Column(unique: true)]
     protected ?string $code = null;
 
+    #[ORM\OneToOne(targetEntity: User::class, mappedBy: 'invitationVoucher')]
     protected ?User $invitedUser = null;
 
     public function __construct()

--- a/src/EntityListener/UserChangedListener.php
+++ b/src/EntityListener/UserChangedListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\EntityListener;
+
+use App\Entity\User;
+use App\Entity\Voucher;
+use App\Enum\Roles;
+use App\Handler\SuspiciousChildrenHandler;
+use App\Repository\VoucherRepository;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Events;
+
+#[AsEntityListener(event: Events::preUpdate, method: 'preUpdate', entity: User::class)]
+class UserChangedListener
+{
+    private VoucherRepository $voucherRepository;
+
+    public function __construct(
+        private readonly EntityManagerInterface $manager,
+        private readonly SuspiciousChildrenHandler $suspiciousChildrenHandler,
+    )
+    {
+        $this->voucherRepository = $this->manager->getRepository(Voucher::class);
+    }
+
+    public function preUpdate(User $user, PreUpdateEventArgs $args): void
+    {
+        // Get changed roles from user.
+        $changeArray = $args->getEntityChangeSet();
+        if (array_key_exists('roles', $changeArray)) {
+            [$rolesBefore, $rolesAfter] = $changeArray['roles'];
+
+            // If `ROLE_SUSPICIOUS` is added, check if other users got invited by that user
+            if (!in_array(Roles::SUSPICIOUS, $rolesBefore, true)
+                && in_array(Roles::SUSPICIOUS, $rolesAfter, true)) {
+                $suspiciousChildren = [];
+                $redeemedVouchers = $this->voucherRepository->getRedeemedVouchersByUser($user);
+                foreach ($redeemedVouchers as $voucher) {
+                    if ($invitedUser = $voucher->getInvitedUser()) {
+                        $suspiciousChildren[$invitedUser->getUserIdentifier()] = $user->getUserIdentifier();
+                    }
+                }
+
+                $this->suspiciousChildrenHandler->sendReport($suspiciousChildren);
+            }
+        }
+    }
+}

--- a/src/Repository/VoucherRepository.php
+++ b/src/Repository/VoucherRepository.php
@@ -12,7 +12,7 @@ class VoucherRepository extends EntityRepository
 {
     /**
      * Finds a voucher by its code.
-     * 
+     *
      * @param $code
      * @return Voucher|null
      */
@@ -23,7 +23,7 @@ class VoucherRepository extends EntityRepository
 
     /**
      * Returns the number of redeemed vouchers.
-     * 
+     *
      * @return int
      */
     public function countRedeemedVouchers(): int
@@ -33,7 +33,7 @@ class VoucherRepository extends EntityRepository
 
     /**
      * Returns the number of unredeemed vouchers.
-     * 
+     *
      * @return int
      */
     public function countUnredeemedVouchers(): int
@@ -43,7 +43,7 @@ class VoucherRepository extends EntityRepository
 
     /**
      * Finds all vouchers for a given user.
-     * 
+     *
      * @return array|Voucher[]
      */
     public function findByUser(User $user): array
@@ -52,8 +52,25 @@ class VoucherRepository extends EntityRepository
     }
 
     /**
+     * Get all redeemed vouchers for a user.
+     *
+     * @return Voucher[]|array
+     */
+    public function getRedeemedVouchersByUser(User $user): array
+    {
+        return $this->createQueryBuilder('voucher')
+            ->join('voucher.invitedUser', 'invitedUser')
+            ->where('voucher.user = :user')
+            ->setParameter('user', $user)
+            ->andWhere('voucher.redeemedTime IS NOT NULL')
+            ->orderBy('voucher.redeemedTime')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Get all redeemed vouchers that are older than 3 months.
-     * 
+     *
      * @return Voucher[]|array
      */
     public function getOldVouchers(): array

--- a/src/Traits/DomainAwareTrait.php
+++ b/src/Traits/DomainAwareTrait.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 trait DomainAwareTrait
 {
-    #[ORM\ManyToOne(targetEntity: \Domain::class)]
+    #[ORM\ManyToOne(targetEntity: Domain::class)]
     #[ORM\JoinColumn(nullable: false)]
     private ?Domain $domain = null;
 

--- a/src/Traits/InvitationVoucherTrait.php
+++ b/src/Traits/InvitationVoucherTrait.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 trait InvitationVoucherTrait
 {
-    #[ORM\OneToOne(targetEntity: \Voucher::class)]
+    #[ORM\OneToOne(targetEntity: Voucher::class)]
     private ?Voucher $invitationVoucher = null;
 
     public function getInvitationVoucher(): ?Voucher

--- a/src/Traits/UserAwareTrait.php
+++ b/src/Traits/UserAwareTrait.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 trait UserAwareTrait
 {
-    #[ORM\ManyToOne(targetEntity: \User::class)]
+    #[ORM\ManyToOne(targetEntity: User::class)]
     private ?User $user = null;
 
     public function getUser(): ?User

--- a/src/Validator/Constraints/VoucherExistsValidator.php
+++ b/src/Validator/Constraints/VoucherExistsValidator.php
@@ -2,7 +2,9 @@
 
 namespace App\Validator\Constraints;
 
+use App\Entity\User;
 use App\Entity\Voucher;
+use App\Enum\Roles;
 use App\Repository\VoucherRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Validator\Constraint;
@@ -39,10 +41,17 @@ class VoucherExistsValidator extends ConstraintValidator
         if (true === $constraint->exists) {
             if (null === $voucher = $this->voucherRepository->findByCode($stringValue)) {
                 $this->context->addViolation('registration.voucher-invalid');
+                return;
             }
 
-            if (null !== $voucher && $voucher->isRedeemed()) {
+            if ($voucher->isRedeemed()) {
                 $this->context->addViolation('registration.voucher-already-redeemed');
+            }
+
+            /** @var User $user */
+            $user = $voucher->getUser();
+            if ($user->hasRole(Roles::SUSPICIOUS)) {
+                $this->context->addViolation('registration.voucher-invalid');
             }
         } elseif (null !== $this->voucherRepository->findByCode($stringValue)) {
             $this->context->addViolation('registration.voucher-exists');

--- a/tests/EntityListener/UserChangedListenerTest.php
+++ b/tests/EntityListener/UserChangedListenerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Tests\EntityListener;
+
+use App\Entity\User;
+use App\Entity\Voucher;
+use App\EntityListener\UserChangedListener;
+use App\Enum\Roles;
+use App\Handler\SuspiciousChildrenHandler;
+use App\Repository\VoucherRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+class UserChangedListenerTest extends TestCase
+{
+    private SuspiciousChildrenHandler $suspiciousChildrenHandler;
+    private VoucherRepository $voucherRepository;
+    private UserChangedListener $listener;
+
+    public function setUp(): void
+    {
+        $this->voucherRepository = $this->createMock(VoucherRepository::class);
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->method('getRepository')
+            ->willReturn($this->voucherRepository);
+        $this->suspiciousChildrenHandler = $this->createMock(SuspiciousChildrenHandler::class);
+        $this->listener = new UserChangedListener($manager, $this->suspiciousChildrenHandler);
+
+        $this->session = $this->createMock(Session::class);
+        $this->request = $this->createMock(Request::class);
+        $this->request->method('getSession')
+            ->willReturn($this->session);
+        $this->request->query = new InputBag();
+        $this->event = $this->createMock(RequestEvent::class);
+        $this->event->method('getRequest')
+            ->willReturn($this->request);
+    }
+
+    public function testPreUpdateNoRoleChanges(): void
+    {
+        $user = new User();
+        $args = $this->createMock(PreUpdateEventArgs::class);
+        $args->method('getEntityChangeSet')
+            ->willReturn(['someField' => [0, 1]]);
+
+        $this->suspiciousChildrenHandler
+            ->expects(self::never())
+            ->method('sendReport');
+        $this->listener->preUpdate($user, $args);
+    }
+
+    public function testPreUpdateOtherRoleChanges(): void
+    {
+        $user = new User();
+        $args = $this->createMock(PreUpdateEventArgs::class);
+        $args->method('getEntityChangeSet')
+            ->willReturn(['roles' => [[Roles::USER], [Roles::USER, Roles::PERMANENT]]]);
+
+        $this->suspiciousChildrenHandler
+            ->expects(self::never())
+            ->method('sendReport');
+        $this->listener->preUpdate($user, $args);
+    }
+
+    public function testPreUpdateRoleSuspiciousRemoved(): void
+    {
+        $user = new User();
+        $args = $this->createMock(PreUpdateEventArgs::class);
+        $args->method('getEntityChangeSet')
+            ->willReturn(['roles' => [[Roles::USER, Roles::SUSPICIOUS], [Roles::USER]]]);
+
+        $this->suspiciousChildrenHandler
+            ->expects(self::never())
+            ->method('sendReport');
+        $this->listener->preUpdate($user, $args);
+    }
+
+    public function testPreUpdateRoleSuspiciousAdded(): void
+    {
+        $user = new User();
+        $user->setEmail('user@example.org');
+        $args = $this->createMock(PreUpdateEventArgs::class);
+        $args->method('getEntityChangeSet')
+            ->willReturn(['roles' => [[Roles::USER], [Roles::USER, Roles::SUSPICIOUS]]]);
+
+        $invitedUser1 = new User();
+        $invitedUser1->setEmail('invited1@example.org');
+        $voucher1 = new Voucher();
+        $voucher1->setInvitedUser($invitedUser1);
+        $invitedUser2 = new User();
+        $invitedUser2->setEmail('invited2@example.org');
+        $voucher2 = new Voucher();
+        $voucher2->setInvitedUser($invitedUser2);
+        $this->voucherRepository->method('getRedeemedVouchersByUser')
+            ->willReturn([$voucher1, $voucher2]);
+
+        $this->suspiciousChildrenHandler
+            ->expects(self::once())
+            ->method('sendReport')
+            ->with([$invitedUser1->getEmail() => $user->getEmail(), $invitedUser2->getEmail() => $user->getEmail()]);
+        $this->listener->preUpdate($user, $args);
+    }
+}


### PR DESCRIPTION
* OneToOne relation between voucher and user.invitedVoucher was broken, and so was the `app:voucher:unlink` command.
* Check for invited by `ROLE_SUSPICIOUS` when assigning the role. Instead of running this check in the cronjob when unlinking vouchers, we want to know this immediately when setting a user as suspicious. (Fixes: #215)
* Don't accept invite codes of suspicious users on registration.