### PR TITLE
fix: bring back old logic of `findOneBySource()` in AliasRepository

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -53,6 +53,30 @@ Feature: User
     And I should see text matching "Your new alias address was created."
     And the response status code should be 200
 
+  @fail-to-create-existing-custom-alias
+  Scenario: Fail to create existing custom alias
+    When I am authenticated as "user@example.org"
+    And I am on "/alias"
+    And I fill in the following:
+      | create_custom_alias_alias | alias1 |
+    And I press "Add"
+
+    Then I should be on "/alias"
+    And I should see "The e-mail address is already taken."
+    And the response status code should be 200
+
+  @fail-to-create-deleted-custom-alias
+  Scenario: Fail to create deleted custom alias
+    When I am authenticated as "user@example.org"
+    And I am on "/alias"
+    And I fill in the following:
+      | create_custom_alias_alias | alias2 |
+    And I press "Add"
+
+    Then I should be on "/alias"
+    And I should see "The e-mail address is already taken."
+    And the response status code should be 200
+
   @delete-alias
   Scenario: Delete custom alias
     When I am authenticated as "user@example.org"

--- a/src/EventListener/RandomAliasCreationListener.php
+++ b/src/EventListener/RandomAliasCreationListener.php
@@ -23,7 +23,7 @@ class RandomAliasCreationListener implements EventSubscriberInterface
         /** @var Alias $alias */
         $alias = $event->getAlias();
 
-        while (null !== $this->manager->getRepository(Alias::class)->findOneBySource($alias->getSource())) {
+        while (null !== $this->manager->getRepository(Alias::class)->findOneBySource($alias->getSource(), true)) {
             $localPart = RandomStringGenerator::generate(24, false);
             /** @var Domain $domain */
             $domain = $alias->getDomain();

--- a/src/Handler/AliasHandler.php
+++ b/src/Handler/AliasHandler.php
@@ -31,7 +31,7 @@ class AliasHandler
     {
         $limit = ($random) ? self::ALIAS_LIMIT_RANDOM : self::ALIAS_LIMIT_CUSTOM;
 
-        return (count($aliases) < $limit) ? true : false;
+        return count($aliases) < $limit;
     }
 
     /**
@@ -39,7 +39,7 @@ class AliasHandler
      */
     public function create(User $user, ?string $localPart = null): ?Alias
     {
-        $random = (isset($localPart)) ? false : true;
+        $random = !isset($localPart);
 
         $aliases = $this->repository->findByUser($user, $random);
         if ($this->checkAliasLimit($aliases, $random)) {

--- a/src/Repository/AliasRepository.php
+++ b/src/Repository/AliasRepository.php
@@ -9,26 +9,30 @@ use Doctrine\ORM\EntityRepository;
 class AliasRepository extends EntityRepository
 {
     /**
-     * @param string $email
+     * @param string    $email
+     * @param bool|null $includeDeleted
      * @return Alias|null
      */
-    public function findOneBySource(string $email): ?Alias
+    public function findOneBySource(string $email, ?bool $includeDeleted = false): ?Alias
     {
-        return $this->findOneBy(['source' => $email]);
+        if ($includeDeleted) {
+            return $this->findOneBy(['source' => $email]);
+        }
+
+        return $this->findOneBy(['source' => $email, 'deleted' => false]);
     }
 
     /**
      * @param User $user
      * @param bool|null $random
-     * @param bool $deleted
      * @return array|Alias[]
      */
-    public function findByUser(User $user, ?bool $random = null, ?bool $deleted = false): array
+    public function findByUser(User $user, ?bool $random = null): array
     {
         if (isset($random)) {
-            return $this->findBy(['user' => $user, 'random' => $random, 'deleted' => $deleted]);
+            return $this->findBy(['user' => $user, 'random' => $random, 'deleted' => false]);
         }
 
-        return $this->findBy(['user' => $user, 'deleted' => $deleted]);
+        return $this->findBy(['user' => $user, 'deleted' => false]);
     }
 }


### PR DESCRIPTION
In #556, the logic of functions in AliasRepository got changed. This led to the situation that it was possible to delete already deleted aliases.

See https://github.com/systemli/userli/commit/544ec33d0f4f734c3f3602804f2636658725d54f#diff-c1b762cb165cfafb00e55e399682546f2e6574cacdd07a9a3d66ff9440350901L16-R32

Also adds integration tests for re-using existing and deleted alias names.