### PR TITLE
feat: Add keycloak API endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -54,3 +54,6 @@ MAILER_DELIVERY_ADDRESS="admin@example.org"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=14&charset=utf8"
 DATABASE_URL="mysql://mail:password@127.0.0.1:3306/mail?charset=utf8mb4"
 ###< doctrine/doctrine-bundle ###
+
+HTTP_BASIC_AUTH_USERNAME="keycloak"
+HTTP_BASIC_AUTH_PASSWORD="keycloak"

--- a/.env
+++ b/.env
@@ -55,5 +55,7 @@ MAILER_DELIVERY_ADDRESS="admin@example.org"
 DATABASE_URL="mysql://mail:password@127.0.0.1:3306/mail?charset=utf8mb4"
 ###< doctrine/doctrine-bundle ###
 
-HTTP_BASIC_AUTH_USERNAME="keycloak"
-HTTP_BASIC_AUTH_PASSWORD="keycloak"
+### Enable keycloak API ###
+# Warning: set a secure access token and limit access to `/api/keyloak` in your webserver or reverse proxy
+KEYCLOAK_API=0
+KEYCLOAK_API_ACCESS_TOKEN="insecure"

--- a/.env
+++ b/.env
@@ -58,7 +58,7 @@ DATABASE_URL="mysql://mail:password@127.0.0.1:3306/mail?charset=utf8mb4"
 ### Enable keycloak API ###
 # Set to `true` to enable keycloak API
 KEYCLOAK_API_ENABLED=false
-# Restrict access to this IP
-KEYCLOAK_API_IP="127.0.0.1"
+# Access is restricted to these IPs (supports subnets like `10.0.0.1/24`)
+KEYCLOAK_API_IP_ALLOWLIST="127.0.0.1, ::1"
 # Warning: set a secure access token
 KEYCLOAK_API_ACCESS_TOKEN="insecure"

--- a/.env
+++ b/.env
@@ -56,6 +56,9 @@ DATABASE_URL="mysql://mail:password@127.0.0.1:3306/mail?charset=utf8mb4"
 ###< doctrine/doctrine-bundle ###
 
 ### Enable keycloak API ###
-# Warning: set a secure access token and limit access to `/api/keyloak` in your webserver or reverse proxy
-KEYCLOAK_API=0
+# Set to `true` to enable keycloak API
+KEYCLOAK_API_ENABLED=false
+# Restrict access to this IP
+KEYCLOAK_API_IP="127.0.0.1"
+# Warning: set a secure access token
 KEYCLOAK_API_ACCESS_TOKEN="insecure"

--- a/.env.test
+++ b/.env.test
@@ -21,5 +21,5 @@ WEBMAIL_URL="https://webmail.example.org"
 WKD_DIRECTORY="/tmp/.well-known/openpgpkey"
 WKD_FORMAT="advanced"
 KEYCLOAK_API_ENABLED=true
-KEYCLOAK_API_IP="127.0.0.1"
+KEYCLOAK_API_IP_ALLOWLIST="127.0.0.1, ::1"
 KEYCLOAK_API_ACCESS_TOKEN="insecure"

--- a/.env.test
+++ b/.env.test
@@ -20,3 +20,6 @@ DOVECOT_MAIL_GID="5000"
 WEBMAIL_URL="https://webmail.example.org"
 WKD_DIRECTORY="/tmp/.well-known/openpgpkey"
 WKD_FORMAT="advanced"
+KEYCLOAK_API_ENABLED=true
+KEYCLOAK_API_IP="127.0.0.1"
+KEYCLOAK_API_ACCESS_TOKEN="insecure"

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -159,6 +159,7 @@ security:
       - { path: "^/admin", roles: ROLE_DOMAIN_ADMIN }
       - {
           path: "^/api/keycloak",
-          roles: ROLE_KEYCLOAK,
-          allow_if: "'%env(KEYCLOAK_API_ENABLED)%' == 'true' and '%env(KEYCLOAK_API_IP)%' == request.getClientIp()",
+          ips: "%env(KEYCLOAK_API_IP_ALLOWLIST)%",
+          allow_if: "'%env(KEYCLOAK_API_ENABLED)%' == 'true' and is_granted('ROLE_KEYCLOAK')",
         }
+      - { path: "^/api/keycloak", roles: ROLE_NO_ACCESS }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -14,11 +14,11 @@ security:
         # Custom UserProvider to allow login via email and localpart (without domain)
         user:
             id: App\Security\UserProvider
-        keycloak_api_user:
+        keycloak:
             memory:
                 users:
                     - identifier: keycloak
-                      roles: ['ROLE_API_KEYCLOAK']
+                      roles: ['ROLE_KEYCLOAK']
 
     role_hierarchy:
         # User
@@ -110,10 +110,10 @@ security:
         dev:
             pattern: ^/(_(profiler|error|wdt)|css|images|js)/
             security: false
-        api_keycloak:
+        keycloak:
             pattern: ^/api/keycloak
             stateless: true
-            provider: keycloak_api_user
+            provider: keycloak
             access_token:
                 token_handler: App\Security\KeycloakApiAccessTokenHandler
         main:
@@ -157,4 +157,8 @@ security:
       - { path: "^/account", roles: ROLE_USER, allow_if: "!is_granted('ROLE_SPAM')" }
       - { path: "^/openpgp", roles: ROLE_USER, allow_if: "!is_granted('ROLE_SPAM')" }
       - { path: "^/admin", roles: ROLE_DOMAIN_ADMIN }
-      - { path: "^/api/keycloak", roles: ROLE_API_KEYCLOAK }
+      - {
+          path: "^/api/keycloak",
+          roles: ROLE_KEYCLOAK,
+          allow_if: "'%env(KEYCLOAK_API_ENABLED)%' == 'true' and '%env(KEYCLOAK_API_IP)%' == request.getClientIp()",
+        }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -7,12 +7,19 @@ security:
             algorithm: sodium
         legacy:
             id: 'App\Security\Encoder\LegacyPasswordHasher'
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: plaintext
 
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         # Custom UserProvider to allow login via email and localpart (without domain)
         user:
             id: App\Security\UserProvider
+        in_memory_users:
+            memory:
+                users:
+                    - identifier: '%env(HTTP_BASIC_AUTH_USERNAME)%'
+                      password: '%env(HTTP_BASIC_AUTH_PASSWORD)%'
+                      roles: ['ROLE_API_KEYCLOAK']
 
     role_hierarchy:
         # User
@@ -104,6 +111,12 @@ security:
         dev:
             pattern: ^/(_(profiler|error|wdt)|css|images|js)/
             security: false
+        api_keycloak:
+            pattern: ^/api/keycloak
+            stateless: true
+            provider: in_memory_users
+            http_basic:
+                realm: Secured Area
         main:
             pattern: ^/
             provider: user
@@ -145,3 +158,4 @@ security:
       - { path: "^/account", roles: ROLE_USER, allow_if: "!is_granted('ROLE_SPAM')" }
       - { path: "^/openpgp", roles: ROLE_USER, allow_if: "!is_granted('ROLE_SPAM')" }
       - { path: "^/admin", roles: ROLE_DOMAIN_ADMIN }
+      - { path: "^/api/keycloak", roles: ROLE_API_KEYCLOAK }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -14,11 +14,10 @@ security:
         # Custom UserProvider to allow login via email and localpart (without domain)
         user:
             id: App\Security\UserProvider
-        in_memory_users:
+        keycloak_api_user:
             memory:
                 users:
-                    - identifier: '%env(HTTP_BASIC_AUTH_USERNAME)%'
-                      password: '%env(HTTP_BASIC_AUTH_PASSWORD)%'
+                    - identifier: keycloak
                       roles: ['ROLE_API_KEYCLOAK']
 
     role_hierarchy:
@@ -114,9 +113,9 @@ security:
         api_keycloak:
             pattern: ^/api/keycloak
             stateless: true
-            provider: in_memory_users
-            http_basic:
-                realm: Secured Area
+            provider: keycloak_api_user
+            access_token:
+                token_handler: App\Security\KeycloakApiAccessTokenHandler
         main:
             pattern: ^/
             provider: user

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -115,7 +115,7 @@ security:
             stateless: true
             provider: keycloak
             access_token:
-                token_handler: App\Security\KeycloakApiAccessTokenHandler
+                token_handler: App\Security\KeycloakAccessTokenHandler
         main:
             pattern: ^/
             provider: user

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -164,6 +164,11 @@ services:
             - '@Doctrine\ORM\EntityManagerInterface'
         public: true
 
+    App\Security\KeycloakApiAccessTokenHandler:
+        arguments:
+            $keycloakApi: "%env(KEYCLOAK_API)%"
+            $keycloakApiAccessToken: "%env(KEYCLOAK_API_ACCESS_TOKEN)%"
+
     App\Sender\WelcomeMessageSender:
         public: true
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -164,7 +164,7 @@ services:
             - '@Doctrine\ORM\EntityManagerInterface'
         public: true
 
-    App\Security\KeycloakApiAccessTokenHandler:
+    App\Security\KeycloakAccessTokenHandler:
         arguments:
             $keycloakApiAccessToken: "%env(KEYCLOAK_API_ACCESS_TOKEN)%"
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -166,7 +166,6 @@ services:
 
     App\Security\KeycloakApiAccessTokenHandler:
         arguments:
-            $keycloakApi: "%env(KEYCLOAK_API)%"
             $keycloakApiAccessToken: "%env(KEYCLOAK_API_ACCESS_TOKEN)%"
 
     App\Sender\WelcomeMessageSender:

--- a/src/Controller/KeycloakController.php
+++ b/src/Controller/KeycloakController.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Domain;
+use App\Entity\User;
+use App\Handler\UserAuthenticationHandler;
+use App\Repository\DomainRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class KeycloakController extends AbstractController
+{
+    private readonly DomainRepository $domainRepository;
+    private readonly UserRepository $userRepository;
+
+    public function __construct(private readonly EntityManagerInterface $manager, private readonly UserAuthenticationHandler $handler) {
+        $this->domainRepository = $this->manager->getRepository(Domain::class);
+        $this->userRepository = $this->manager->getRepository(User::class);
+    }
+
+    #[Route(path: '/api/keycloak', name: 'api_keycloak_index', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        if (null === $domain = $this->domainRepository->findByName($request->query->get('domain') ?? '')) {
+            return $this->json([
+                'message' => 'domain not found',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        if (null === $search = $request->query->get('search')) {
+            $search = '';
+        }
+
+        if (null === $max = $request->query->get('max')) {
+            $max = 10;
+        }
+
+        if (null === $first = $request->query->get('first')) {
+            $first = 0;
+        }
+
+        $users = $this->userRepository->findUsersByString($domain, $search, $max, $first)->map(function (User $user) {
+            return [
+                'id' => explode('@', $user->getEmail())[0],
+                'email' => $user->getEmail(),
+            ];
+        });
+        return $this->json($users);
+    }
+
+    #[Route(path: '/api/keycloak/count', name: 'api_keycloak_count', methods: ['GET'])]
+    public function count(Request $request): Response
+    {
+        if (null === $domain = $this->domainRepository->findByName($request->query->get('domain') ?? '')) {
+            return $this->json([
+                'message' => 'domain not found',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json($this->userRepository->countDomainUsers($domain));
+    }
+
+    #[Route(path: '/api/keycloak/user/{email}', name: 'api_keycloak_user', methods: ['GET'])]
+    public function get(Request $request, string $email): Response
+    {
+        if (null === $domain = $this->domainRepository->findByName($request->query->get('domain') ?? '')) {
+            return $this->json([
+                'message' => 'domain not found',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        if (!str_contains($email, '@')) {
+            $email .= '@' . $domain->getName();
+        }
+
+        if (null === $foundUser = $this->userRepository->findByDomainAndEmail($domain, $email)) {
+            return $this->json([
+                'message' => 'user not found',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json([
+            'id' => explode('@', $foundUser->getEmail())[0],
+            'email' => $foundUser->getEmail(),
+        ]);
+    }
+
+    #[Route(path: '/api/keycloak/validate/{email}', name: 'api_keycloak_user_validate', methods: ['POST'])]
+    public function validate(Request $request, string $email): Response
+    {
+        if (null === $domain = $this->domainRepository->findByName($request->request->get('domain') ?? '')) {
+            return $this->json([
+                'message' => 'domain not found',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        if (null === $password = $request->request->get('password')) {
+            return $this->json([
+                'message' => 'missing password',
+            ], Response::HTTP_FORBIDDEN);
+        }
+
+        if (null === $user = $this->userRepository->findByDomainAndEmail($domain, $email)) {
+            return $this->json([
+                'message' => 'authentication failed',
+            ], Response::HTTP_FORBIDDEN);
+        }
+
+        if (null === $authUser = $this->handler->authenticate($user, $password)) {
+            return $this->json([
+                'message' => 'authentication failed',
+            ], Response::HTTP_FORBIDDEN);
+        }
+
+        return $this->json([
+            'message' => 'success',
+        ]);
+    }
+}

--- a/src/Controller/KeycloakController.php
+++ b/src/Controller/KeycloakController.php
@@ -78,7 +78,7 @@ class KeycloakController extends AbstractController
     #[Route(path: '/api/keycloak/validate/{email}', name: 'api_keycloak_user_validate', methods: ['POST'], stateless: true)]
     public function postUserValidate(#[MapRequestPayload] KeycloakUserValidateDto $requestData, string $email): Response
     {
-        if (null === $domainObject = $this->manager->getRepository(Domain::class)->findByName($requestData->domain)) {
+        if (null === $domainObject = $this->manager->getRepository(Domain::class)->findByName($requestData->getDomain())) {
             return $this->json([], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
@@ -88,7 +88,7 @@ class KeycloakController extends AbstractController
             ], Response::HTTP_FORBIDDEN);
         }
 
-        if ($this->handler->authenticate($user, $requestData->password) === null) {
+        if ($this->handler->authenticate($user, $requestData->getPassword()) === null) {
             return $this->json([
                 'message' => 'authentication failed',
             ], Response::HTTP_FORBIDDEN);

--- a/src/Controller/KeycloakController.php
+++ b/src/Controller/KeycloakController.php
@@ -23,7 +23,7 @@ class KeycloakController extends AbstractController
         $this->userRepository = $this->manager->getRepository(User::class);
     }
 
-    #[Route(path: '/api/keycloak', name: 'api_keycloak_index', methods: ['GET'])]
+    #[Route(path: '/api/keycloak', name: 'api_keycloak_index', methods: ['GET'], stateless: true)]
     public function index(Request $request): Response
     {
         if (null === $domain = $this->domainRepository->findByName($request->query->get('domain') ?? '')) {
@@ -53,7 +53,7 @@ class KeycloakController extends AbstractController
         return $this->json($users);
     }
 
-    #[Route(path: '/api/keycloak/count', name: 'api_keycloak_count', methods: ['GET'])]
+    #[Route(path: '/api/keycloak/count', name: 'api_keycloak_count', methods: ['GET'], stateless: true)]
     public function count(Request $request): Response
     {
         if (null === $domain = $this->domainRepository->findByName($request->query->get('domain') ?? '')) {
@@ -65,7 +65,7 @@ class KeycloakController extends AbstractController
         return $this->json($this->userRepository->countDomainUsers($domain));
     }
 
-    #[Route(path: '/api/keycloak/user/{email}', name: 'api_keycloak_user', methods: ['GET'])]
+    #[Route(path: '/api/keycloak/user/{email}', name: 'api_keycloak_user', methods: ['GET'], stateless: true)]
     public function get(Request $request, string $email): Response
     {
         if (null === $domain = $this->domainRepository->findByName($request->query->get('domain') ?? '')) {
@@ -90,7 +90,7 @@ class KeycloakController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/api/keycloak/validate/{email}', name: 'api_keycloak_user_validate', methods: ['POST'])]
+    #[Route(path: '/api/keycloak/validate/{email}', name: 'api_keycloak_user_validate', methods: ['POST'], stateless: true)]
     public function validate(Request $request, string $email): Response
     {
         if (null === $domain = $this->domainRepository->findByName($request->request->get('domain') ?? '')) {

--- a/src/Dto/KeycloakUserValidateDto.php
+++ b/src/Dto/KeycloakUserValidateDto.php
@@ -6,17 +6,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class KeycloakUserValidateDto {
     #[Assert\NotBlank]
-    private string $domain;
-    #[Assert\NotBlank]
     private string $password = '';
-
-    public function getDomain(): string {
-        return $this->domain;
-    }
-
-    public function setDomain(string $domain): void {
-        $this->domain = $domain;
-    }
 
     public function getPassword(): string {
         return $this->password;

--- a/src/Dto/KeycloakUserValidateDto.php
+++ b/src/Dto/KeycloakUserValidateDto.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class KeycloakUserValidateDto {
+    #[Assert\NotBlank]
+    public string $domain;
+    #[Assert\NotBlank]
+    public string $password = '';
+}

--- a/src/Dto/KeycloakUserValidateDto.php
+++ b/src/Dto/KeycloakUserValidateDto.php
@@ -6,7 +6,23 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class KeycloakUserValidateDto {
     #[Assert\NotBlank]
-    public string $domain;
+    private string $domain;
     #[Assert\NotBlank]
-    public string $password = '';
+    private string $password = '';
+
+    public function getDomain(): string {
+        return $this->domain;
+    }
+
+    public function setDomain(string $domain): void {
+        $this->domain = $domain;
+    }
+
+    public function getPassword(): string {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): void {
+        $this->password = $password;
+    }
 }

--- a/src/Enum/Roles.php
+++ b/src/Enum/Roles.php
@@ -11,7 +11,7 @@ final class Roles
     public const USER = 'ROLE_USER';
     public const DOMAIN_ADMIN = 'ROLE_DOMAIN_ADMIN';
     public const ADMIN = 'ROLE_ADMIN';
-    public const API_KEYCLOAK = 'ROLE_API_KEYCLOAK';
+    public const KEYCLOAK = 'ROLE_KEYCLOAK';
 
     public static function getAll(): array
     {
@@ -23,7 +23,7 @@ final class Roles
             self::USER => self::USER,
             self::DOMAIN_ADMIN => self::DOMAIN_ADMIN,
             self::ADMIN => self::ADMIN,
-            self::API_KEYCLOAK => self::API_KEYCLOAK,
+            self::KEYCLOAK => self::KEYCLOAK,
         ];
     }
 }

--- a/src/Enum/Roles.php
+++ b/src/Enum/Roles.php
@@ -11,6 +11,7 @@ final class Roles
     public const USER = 'ROLE_USER';
     public const DOMAIN_ADMIN = 'ROLE_DOMAIN_ADMIN';
     public const ADMIN = 'ROLE_ADMIN';
+    public const API_KEYCLOAK = 'ROLE_API_KEYCLOAK';
 
     public static function getAll(): array
     {
@@ -22,6 +23,7 @@ final class Roles
             self::USER => self::USER,
             self::DOMAIN_ADMIN => self::DOMAIN_ADMIN,
             self::ADMIN => self::ADMIN,
+            self::API_KEYCLOAK => self::API_KEYCLOAK,
         ];
     }
 }

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -19,6 +19,9 @@ class LocaleListener implements EventSubscriberInterface
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
+        if ($request->attributes->getBoolean('_stateless')) {
+            return;
+        }
         $session = $request->getSession();
         $sessionLocale = $session->get('_locale');
 

--- a/src/Security/KeycloakAccessTokenHandler.php
+++ b/src/Security/KeycloakAccessTokenHandler.php
@@ -6,14 +6,14 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
-class KeycloakApiAccessTokenHandler implements AccessTokenHandlerInterface
+class KeycloakAccessTokenHandler implements AccessTokenHandlerInterface
 {
     public function __construct(private string $keycloakApiAccessToken)
     {
     }
 
     public function getUserBadgeFrom(#[\SensitiveParameter] string $accessToken): UserBadge {
-        if (!($accessToken === $this->keycloakApiAccessToken)) {
+        if ($accessToken !== $this->keycloakApiAccessToken) {
             throw new BadCredentialsException('Invalid access token');
         }
 

--- a/src/Security/KeycloakApiAccessTokenHandler.php
+++ b/src/Security/KeycloakApiAccessTokenHandler.php
@@ -8,15 +8,11 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class KeycloakApiAccessTokenHandler implements AccessTokenHandlerInterface
 {
-    public function __construct(private string $keycloakApi, private string $keycloakApiAccessToken)
+    public function __construct(private string $keycloakApiAccessToken)
     {
     }
 
     public function getUserBadgeFrom(#[\SensitiveParameter] string $accessToken): UserBadge {
-        if (!$this->keycloakApi) {
-            throw new BadCredentialsException('API disabled');
-        }
-
         if (!($accessToken === $this->keycloakApiAccessToken)) {
             throw new BadCredentialsException('Invalid access token');
         }

--- a/src/Security/KeycloakApiAccessTokenHandler.php
+++ b/src/Security/KeycloakApiAccessTokenHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+
+class KeycloakApiAccessTokenHandler implements AccessTokenHandlerInterface
+{
+    public function __construct(private string $keycloakApi, private string $keycloakApiAccessToken)
+    {
+    }
+
+    public function getUserBadgeFrom(#[\SensitiveParameter] string $accessToken): UserBadge {
+        if (!$this->keycloakApi) {
+            throw new BadCredentialsException('API disabled');
+        }
+
+        if (!($accessToken === $this->keycloakApiAccessToken)) {
+            throw new BadCredentialsException('Invalid access token');
+        }
+
+        return new UserBadge('keycloak');
+    }
+}

--- a/tests/Controller/KeycloakControllerTest.php
+++ b/tests/Controller/KeycloakControllerTest.php
@@ -11,7 +11,7 @@ class KeycloakControllerTest extends WebTestCase
         $client = static::createClient([], [
             'HTTP_Authorization' => 'Bearer wrong',
         ]);
-        $client->request('GET', '/api/keycloak?domain=example.org&search=example&max=2');
+        $client->request('GET', '/api/keycloak/example.org?search=example&max=2');
 
         self::assertResponseStatusCodeSame(401);
     }
@@ -21,7 +21,7 @@ class KeycloakControllerTest extends WebTestCase
         $client = static::createClient([], [
             'HTTP_Authorization' => 'Bearer insecure',
         ]);
-        $client->request('GET', '/api/keycloak?domain=example.org&search=example&max=2');
+        $client->request('GET', '/api/keycloak/example.org?search=example&max=2');
 
         self::assertResponseIsSuccessful();
 
@@ -33,14 +33,14 @@ class KeycloakControllerTest extends WebTestCase
         self::assertEquals($expected, $data);
     }
 
-    public function testGetUsersSearchEmptyDomain(): void
+    public function testGetUsersSearchNonexistentDomain(): void
     {
         $client = static::createClient([], [
             'HTTP_Authorization' => 'Bearer insecure',
         ]);
-        $client->request('GET', '/api/keycloak?domain=&search=example&max=2');
+        $client->request('GET', '/api/keycloak/nonexistent.org?search=example&max=2');
 
-        self::assertResponseStatusCodeSame(422);
+        self::assertResponseStatusCodeSame(404);
     }
 
     public function testGetUsersCount(): void
@@ -48,7 +48,7 @@ class KeycloakControllerTest extends WebTestCase
         $client = static::createClient([], [
             'HTTP_Authorization' => 'Bearer insecure',
         ]);
-        $client->request('GET', '/api/keycloak/count?domain=example.org');
+        $client->request('GET', '/api/keycloak/example.org/count');
 
         self::assertResponseIsSuccessful();
 
@@ -62,7 +62,7 @@ class KeycloakControllerTest extends WebTestCase
         $client = static::createClient([], [
             'HTTP_Authorization' => 'Bearer insecure',
         ]);
-        $client->request('GET', '/api/keycloak/user/user@example.org?domain=example.org');
+        $client->request('GET', '/api/keycloak/example.org/user/user@example.org');
 
         self::assertResponseIsSuccessful();
 
@@ -76,7 +76,7 @@ class KeycloakControllerTest extends WebTestCase
         $client = static::createClient([], [
             'HTTP_Authorization' => 'Bearer insecure',
         ]);
-        $client->request('GET', '/api/keycloak/user/nonexistent@example.org?domain=example.org');
+        $client->request('GET', '/api/keycloak/example.org/user/nonexistent@example.org');
 
         self::assertResponseStatusCodeSame(404);
     }
@@ -86,10 +86,7 @@ class KeycloakControllerTest extends WebTestCase
         $client = static::createClient([], [
             'HTTP_Authorization' => 'Bearer insecure',
         ]);
-        $client->request('POST', '/api/keycloak/validate/support@example.org', [
-            'domain' => 'example.org',
-            'password' => 'password',
-        ]);
+        $client->request('POST', '/api/keycloak/example.org/validate/support@example.org', ['password' => 'password']);
 
         self::assertResponseIsSuccessful();
 
@@ -103,10 +100,7 @@ class KeycloakControllerTest extends WebTestCase
         $client = static::createClient([], [
             'HTTP_Authorization' => 'Bearer insecure',
         ]);
-        $client->request('POST', '/api/keycloak/validate/support@example.org', [
-            'domain' => 'example.org',
-            'password' => 'wrong',
-        ]);
+        $client->request('POST', '/api/keycloak/example.org/validate/support@example.org', ['password' => 'wrong']);
 
         self::assertResponseStatusCodeSame(403);
 

--- a/tests/Controller/KeycloakControllerTest.php
+++ b/tests/Controller/KeycloakControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class KeycloakControllerTest extends WebTestCase
+{
+    public function testGetUsersSearchWrongApiToken(): void
+    {
+        $client = static::createClient([], [
+            'HTTP_Authorization' => 'Bearer wrong',
+        ]);
+        $client->request('GET', '/api/keycloak?domain=example.org&search=example&max=2');
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testGetUsersSearch(): void
+    {
+        $client = static::createClient([], [
+            'HTTP_Authorization' => 'Bearer insecure',
+        ]);
+        $client->request('GET', '/api/keycloak?domain=example.org&search=example&max=2');
+
+        self::assertResponseIsSuccessful();
+
+        $expected = [
+            [ 'id' => 'admin', 'email' => 'admin@example.org' ],
+            [ 'id' => 'user', 'email' => 'user@example.org']
+        ];
+        $data = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testGetUsersSearchEmptyDomain(): void
+    {
+        $client = static::createClient([], [
+            'HTTP_Authorization' => 'Bearer insecure',
+        ]);
+        $client->request('GET', '/api/keycloak?domain=&search=example&max=2');
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    public function testGetUsersCount(): void
+    {
+        $client = static::createClient([], [
+            'HTTP_Authorization' => 'Bearer insecure',
+        ]);
+        $client->request('GET', '/api/keycloak/count?domain=example.org');
+
+        self::assertResponseIsSuccessful();
+
+        $expected = 5;
+        $data = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testGetOneUser(): void
+    {
+        $client = static::createClient([], [
+            'HTTP_Authorization' => 'Bearer insecure',
+        ]);
+        $client->request('GET', '/api/keycloak/user/user@example.org?domain=example.org');
+
+        self::assertResponseIsSuccessful();
+
+        $expected = [ 'id' => 'user', 'email' => 'user@example.org' ];
+        $data = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testGetOneNonexistentUser(): void
+    {
+        $client = static::createClient([], [
+            'HTTP_Authorization' => 'Bearer insecure',
+        ]);
+        $client->request('GET', '/api/keycloak/user/nonexistent@example.org?domain=example.org');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testPostUserValidatae(): void
+    {
+        $client = static::createClient([], [
+            'HTTP_Authorization' => 'Bearer insecure',
+        ]);
+        $client->request('POST', '/api/keycloak/validate/support@example.org', [
+            'domain' => 'example.org',
+            'password' => 'password',
+        ]);
+
+        self::assertResponseIsSuccessful();
+
+        $expected = ['message' => 'success'];
+        $data = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testPostUserValidateWrongPassword(): void
+    {
+        $client = static::createClient([], [
+            'HTTP_Authorization' => 'Bearer insecure',
+        ]);
+        $client->request('POST', '/api/keycloak/validate/support@example.org', [
+            'domain' => 'example.org',
+            'password' => 'wrong',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+
+        $expected = ['message' => 'authentication failed'];
+        $data = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertEquals($expected, $data);
+    }
+}

--- a/tests/EventListener/LocaleListenerTest.php
+++ b/tests/EventListener/LocaleListenerTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\EventListener;
 use App\EventListener\LocaleListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -22,6 +23,9 @@ class LocaleListenerTest extends TestCase
 
         $this->session = $this->createMock(Session::class);
         $this->request = $this->createMock(Request::class);
+        $attributes = $this->createMock(ParameterBag::class);
+        $attributes->method('getBoolean')->willReturn(false);
+        $this->request->attributes = $attributes;
         $this->request->method('getSession')
             ->willReturn($this->session);
         $this->request->query = new InputBag();


### PR DESCRIPTION
Meant to be used by our custom keycloak user provider that queries userli for users and credential validation.

## Todo

* [x] Refactor event listeners to not break stateless firewall
* [x] Tests for API endpoints (Behat or PHPUnit)

## How to test

1. Comment out `stateless: true` (currently broken) in `security.yaml`
2. Set `KEYCLOAK_API=1` in `.env.local`

List users:
`curl --header "Authorization: Bearer insecure" 'http://192.168.60.99/api/keycloak?domain=example.org&search=user'`

Get user:
`curl --header "Authorization: Bearer insecure" 'http://192.168.60.99/api/keycloak/user/user@example.org?domain=example.org'`

Validate credentials:
`curl -X POST -i --header "Authorization: Bearer insecure" --data "domain=example.org" --data "password=password" 'http://192.168.60.99/api/keycloak/validate/user@example.org'`