### PR TITLE
Adjust Validator Signatures

### DIFF
--- a/src/Validator/Constraints/EmailDomainValidator.php
+++ b/src/Validator/Constraints/EmailDomainValidator.php
@@ -8,33 +8,23 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-/**
- * Class EmailDomainValidator.
- */
 class EmailDomainValidator extends ConstraintValidator
 {
-    /**
-     * EmailDomainValidator constructor.
-     */
     public function __construct(private readonly EntityManagerInterface $manager)
     {
     }
 
-    /**
-     * Checks if the passed value is valid.
-     *
-     * @param User       $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     */
-    public function validate($value, Constraint $constraint): void
+    public function validate(mixed $value, Constraint $constraint): void
     {
-        if ($value instanceof User) {
-            $name = substr(strrchr((string) $value->getEmail(), '@'), 1);
-            $domain = $this->manager->getRepository(Domain::class)->findOneBy(['name' => $name]);
+        if (!$value instanceof User) {
+            return;
+        }
 
-            if (null === $domain) {
-                $this->context->addViolation('form.missing-domain');
-            }
+        $name = substr(strrchr((string)$value->getEmail(), '@'), 1);
+        $domain = $this->manager->getRepository(Domain::class)->findOneBy(['name' => $name]);
+
+        if (null === $domain) {
+            $this->context->addViolation('form.missing-domain');
         }
     }
 }

--- a/src/Validator/Constraints/EmailLengthValidator.php
+++ b/src/Validator/Constraints/EmailLengthValidator.php
@@ -6,18 +6,9 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-/**
- * Class EmailLengthValidator.
- */
 class EmailLengthValidator extends ConstraintValidator
 {
-    /**
-     * Checks if the passed value is valid.
-     *
-     * @param string     $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     */
-    public function validate($value, Constraint $constraint): void
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof EmailLength) {
             throw new UnexpectedTypeException($constraint, EmailLength::class);

--- a/src/Validator/Constraints/VoucherExistsValidator.php
+++ b/src/Validator/Constraints/VoucherExistsValidator.php
@@ -20,13 +20,7 @@ class VoucherExistsValidator extends ConstraintValidator
         $this->voucherRepository = $manager->getRepository(Voucher::class);
     }
 
-    /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     */
-    public function validate($value, Constraint $constraint): void
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof VoucherExists) {
             throw new UnexpectedTypeException($constraint, VoucherExists::class);
@@ -36,7 +30,7 @@ class VoucherExistsValidator extends ConstraintValidator
             throw new UnexpectedTypeException($value, 'string');
         }
 
-        $stringValue = (string) $value;
+        $stringValue = (string)$value;
 
         if (true === $constraint->exists) {
             if (null === $voucher = $this->voucherRepository->findByCode($stringValue)) {

--- a/src/Validator/Constraints/VoucherUserValidator.php
+++ b/src/Validator/Constraints/VoucherUserValidator.php
@@ -11,12 +11,6 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class VoucherUserValidator extends ConstraintValidator
 {
-    /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     */
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof VoucherUser) {
@@ -27,9 +21,8 @@ class VoucherUserValidator extends ConstraintValidator
             return;
         }
 
-        /** @var User $user */
         $user = $value->getUser();
-        if ($user->hasRole(Roles::SUSPICIOUS)) {
+        if (null !== $user && $user->hasRole(Roles::SUSPICIOUS)) {
             $this->context->addViolation('voucher.suspicious-user');
         }
     }

--- a/src/Validator/PasswordChangeValidator.php
+++ b/src/Validator/PasswordChangeValidator.php
@@ -13,21 +13,11 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class PasswordChangeValidator extends ConstraintValidator
 {
-    /**
-     * Constructor.
-     */
     public function __construct(private readonly TokenStorageInterface $storage, private readonly PasswordHasherFactoryInterface $passwordHasherFactory)
     {
     }
 
-    /**
-     * Checks if the passed value is valid.
-     *
-     * @param PasswordChange $value
-     *
-     * @throws UnexpectedTypeException
-     */
-    public function validate($value, Constraint $constraint): bool
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$value instanceof PasswordChange) {
             throw new UnexpectedTypeException('Wrong value type given', Registration::class);
@@ -39,16 +29,10 @@ class PasswordChangeValidator extends ConstraintValidator
 
         if (!$hasher->verify($user->getPassword(), $value->password)) {
             $this->context->addViolation('form.wrong-password');
-
-            return false;
         }
 
         if ($value->password === $value->getPlainPassword()) {
             $this->context->addViolation('form.identical-passwords');
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Validator/PasswordPolicyValidator.php
+++ b/src/Validator/PasswordPolicyValidator.php
@@ -12,13 +12,10 @@ class PasswordPolicyValidator extends ConstraintValidator
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function validate($value, Constraint $constraint): bool
+    public function validate(mixed $value, Constraint $constraint): void
     {
-        if (empty($value)) {
-            return true;
+        if (empty($value) || !is_string($value)) {
+            return;
         }
 
         $errors = $this->handler->validate($value);
@@ -27,10 +24,6 @@ class PasswordPolicyValidator extends ConstraintValidator
             foreach ($errors as $error) {
                 $this->context->addViolation($error);
             }
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/tests/Validator/Constraints/EmailDomainValidatorTest.php
+++ b/tests/Validator/Constraints/EmailDomainValidatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tests\Validator\Constraints;
+
+use App\Entity\User;
+use App\Repository\DomainRepository;
+use App\Validator\Constraints\EmailDomain;
+use App\Validator\Constraints\EmailDomainValidator;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class EmailDomainValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): EmailDomainValidator
+    {
+        $repository = $this->createMock(DomainRepository::class);
+        $repository->expects($this->any())
+            ->method('findOneBy')
+            ->will($this->returnValue(null));
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects($this->any())
+            ->method('getRepository')
+            ->will($this->returnValue($repository));
+
+        return new EmailDomainValidator($manager);
+    }
+
+    public function testNullIsValid(): void
+    {
+        $this->validator->validate(null, new EmailDomain());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid(): void
+    {
+        $this->validator->validate('', new EmailDomain());
+
+        $this->assertNoViolation();
+    }
+
+    public function testDomainNotFound(): void
+    {
+        $user = new User();
+        $user->setEmail('user@example.com');
+        $this->validator->validate($user, new EmailDomain());
+
+        $this->buildViolation('form.missing-domain')
+            ->assertRaised();
+    }
+}

--- a/tests/Validator/Constraints/PasswordPolicyValidatorTest.php
+++ b/tests/Validator/Constraints/PasswordPolicyValidatorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Tests\Validator\Constraints;
+
+use App\Handler\PasswordStrengthHandler;
+use App\Validator\Constraints\PasswordPolicy;
+use App\Validator\PasswordPolicyValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class PasswordPolicyValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): PasswordPolicyValidator
+    {
+        $passwordStrengthHandler = new PasswordStrengthHandler();
+        return new PasswordPolicyValidator($passwordStrengthHandler);
+    }
+
+    public function testNullIsValid(): void
+    {
+        $this->validator->validate(null, new PasswordPolicy());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid(): void
+    {
+        $this->validator->validate('', new PasswordPolicy());
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidPassword(): void
+    {
+        $this->validator->validate('Password123!', new PasswordPolicy());
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidPassword(): void
+    {
+        $this->validator->validate('password', new PasswordPolicy());
+
+        $this->buildViolation('form.weak_password')
+            ->assertRaised();
+    }
+}

--- a/tests/Validator/PasswordChangeValidatorTest.php
+++ b/tests/Validator/PasswordChangeValidatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Tests\Validator;
+
+use App\Entity\User;
+use App\Form\Model\PasswordChange;
+use App\Validator\Constraints\PasswordChangeConstraint;
+use App\Validator\PasswordChangeValidator;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\Hasher\PlaintextPasswordHasher;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class PasswordChangeValidatorTest extends ConstraintValidatorTestCase
+{
+    private readonly PlaintextPasswordHasher $hasher;
+
+    protected function setUp(): void
+    {
+        $this->hasher = new PlaintextPasswordHasher();
+        parent::setUp();
+    }
+
+
+    protected function createValidator(): PasswordChangeValidator
+    {
+        $user = new User();
+        $user->setPassword($this->hasher->hash("password"));
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        $storage = $this->createMock(TokenStorageInterface::class);
+        $storage->method('getToken')->willReturn($token);
+
+        $encoder = $this->createMock(PasswordHasherFactoryInterface::class);
+        $encoder->method('getPasswordHasher')->willReturn($this->hasher);
+
+        return new PasswordChangeValidator($storage, $encoder);
+    }
+
+    public function testRaiseException()
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validate(null, new PasswordChangeConstraint());
+    }
+
+    public function testInvalidPassword()
+    {
+        $passwordChange = new PasswordChange();
+        $passwordChange->password = $this->hasher->hash('invalid');
+
+        $this->validator->validate($passwordChange, new PasswordChangeConstraint());
+
+        $this->buildViolation('form.wrong-password')
+            ->assertRaised();
+    }
+
+    public function testIdenticalPasswords()
+    {
+        $passwordChange = new PasswordChange();
+        $passwordChange->password = $this->hasher->hash('password');
+        $passwordChange->setPlainPassword('password');
+
+        $this->validator->validate($passwordChange, new PasswordChangeConstraint());
+
+        $this->buildViolation('form.identical-passwords')
+            ->assertRaised();
+    }
+}


### PR DESCRIPTION
Use the correct signature from the interface:

```php
public function validate(mixed $value, Constraint $constraint): void
```

Also added tests for all validators that were missed