### PR TITLE
🐛 Fix MailCryptKeyHandler create/update

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -175,11 +175,6 @@ services:
         tags:
             - { name: validator.constraint_validator, alias: password_policy }
 
-
-    App\Validator\PasswordChangeValidator:
-        tags:
-            - { name: validator.constraint_validator, alias: password_change }
-
     App\Validator\Constraints\EmailDomainValidator:
         tags:
             - { name: validator.constraint_validator }
@@ -194,10 +189,7 @@ services:
             - App\Entity\User
             - App\Controller\UserCRUDController
         calls:
-            - [setPasswordUpdater, ['@App\Helper\PasswordUpdater']]
             - [setDomainGuesser, ['@App\Guesser\DomainGuesser']]
-            - [setMailCryptKeyHandler, ['@App\Handler\MailCryptKeyHandler']]
-            - [setMailCryptVar, ["%env(MAIL_CRYPT)%"]]
 
     userli.admin.domain:
         class: App\Admin\DomainAdmin

--- a/src/Command/UsersCheckPasswordCommand.php
+++ b/src/Command/UsersCheckPasswordCommand.php
@@ -148,7 +148,7 @@ class UsersCheckPasswordCommand extends Command
             false === $userDbLookup &&
             false === $user->hasMailCrypt() &&
             null === $user->getMailCryptPublicKey()) {
-            $this->mailCryptKeyHandler->create($user);
+            $this->mailCryptKeyHandler->create($user, $password);
         }
 
         // Optionally set mail_crypt environment variables for checkpassword-reply command

--- a/src/Command/UsersResetCommand.php
+++ b/src/Command/UsersResetCommand.php
@@ -102,7 +102,7 @@ class UsersResetCommand extends Command
 
         // Generate MailCrypt key with new password (overwrites old MailCrypt key)
         if ($user->hasMailCryptSecretBox()) {
-            $this->mailCryptKeyHandler->create($user);
+            $this->mailCryptKeyHandler->create($user, $password);
 
             // Reset recovery token
             $this->recoveryTokenHandler->create($user);

--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -69,11 +69,10 @@ class AccountController extends AbstractController
      */
     private function changePassword(Request $request, User $user, PasswordChange $passwordChange): void
     {
-        $user->setPlainPassword($passwordChange->getNewPassword());
         $this->passwordUpdater->updatePassword($user, $passwordChange->getNewPassword());
         // Reencrypt the MailCrypt key with new password
         if ($user->hasMailCryptSecretBox()) {
-            $this->mailCryptKeyHandler->update($user, $passwordChange->getPassword());
+            $this->mailCryptKeyHandler->update($user, $passwordChange->getPassword(), $passwordChange->getNewPassword());
         }
         $user->eraseCredentials();
 

--- a/src/Handler/RecoveryTokenHandler.php
+++ b/src/Handler/RecoveryTokenHandler.php
@@ -11,12 +11,12 @@ use Ramsey\Uuid\Uuid;
 /**
  * Class RecoveryTokenHandler.
  */
-class RecoveryTokenHandler
+readonly class RecoveryTokenHandler
 {
     /**
      * RecoveryTokenHandler constructor.
      */
-    public function __construct(private readonly EntityManagerInterface $manager)
+    public function __construct(private EntityManagerInterface $manager)
     {
     }
 
@@ -36,11 +36,6 @@ class RecoveryTokenHandler
     {
         $recoveryToken = $this->generateToken();
 
-        // get plain user password to be encrypted
-        if (null === $plainPassword = $user->getPlainPassword()) {
-            throw new Exception('plainPassword should not be null');
-        }
-
         if (null === $user->getPlainMailCryptPrivateKey()) {
             throw new Exception('plainMailCryptPrivateKey should not be null');
         }
@@ -52,7 +47,6 @@ class RecoveryTokenHandler
 
         // Clear variables with confidential content from memory
         sodium_memzero($recoveryToken);
-        sodium_memzero($plainPassword);
 
         $this->manager->flush();
     }

--- a/src/Handler/RegistrationHandler.php
+++ b/src/Handler/RegistrationHandler.php
@@ -47,7 +47,7 @@ readonly class RegistrationHandler
 
         // Update password, generate MailCrypt keys, generate recovery token
         $this->passwordUpdater->updatePassword($user, $registration->getPlainPassword());
-        $this->mailCryptKeyHandler->create($user);
+        $this->mailCryptKeyHandler->create($user, $registration->getPlainPassword());
         $this->recoveryTokenHandler->create($user);
 
         // Enable mailbox encryption

--- a/tests/Handler/MailCryptKeyHandlerTest.php
+++ b/tests/Handler/MailCryptKeyHandlerTest.php
@@ -43,21 +43,11 @@ UQ==
         self::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $privateKeyPkcs8);
     }
 
-    public function testCreateExceptionNullPassword(): void
-    {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('plainPassword should not be null');
-        $handler = $this->createHandler();
-        $user = new User();
-        $handler->create($user);
-    }
-
     public function testCreate(): void
     {
         $handler = $this->createHandler();
         $user = new User();
-        $user->setPlainPassword('password');
-        $handler->create($user);
+        $handler->create($user, "password");
 
         self::assertNotEmpty($user->getMailCryptPublicKey());
         self::assertNotEmpty($user->getMailCryptSecretBox());
@@ -70,8 +60,7 @@ UQ==
         $this->expectExceptionMessage('secret should not be null');
         $handler = $this->createHandler();
         $user = new User();
-        $user->setPlainPassword('password');
-        $handler->update($user, 'old_password');
+        $handler->update($user, 'oldPassword', 'newPassword');
     }
 
     public function testUpdateExceptionDecryptionFailed(): void
@@ -80,46 +69,32 @@ UQ==
         $this->expectExceptionMessage('decryption of mailCryptSecretBox failed');
         $handler = $this->createHandler();
         $user = new User();
-        $user->setPlainPassword('password');
-        $handler->create($user);
+        $handler->create($user, 'password');
 
-        $handler->update($user, 'wrong_password');
+        $handler->update($user, 'wrongPassword', 'newPassword');
     }
 
     public function testUpdate(): void
     {
         $handler = $this->createHandler();
         $user = new User();
-        $user->setPlainPassword('password');
-        $handler->create($user);
+        $handler->create($user, 'password');
         $secret = $user->getMailCryptSecretBox();
 
-        $user->setPlainPassword('new_password');
-        $handler->update($user, 'password');
+        $handler->update($user, 'password', 'newPassword');
 
         self::assertNotEquals($secret, $user->getMailCryptSecretBox());
-        self::assertNotEmpty($handler->decrypt($user, 'new_password'));
-    }
-
-    public function testUpdateWithPrivateKeyExceptionNullPassword(): void
-    {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('plainPassword should not be null');
-        $handler = $this->createHandler();
-        $user = new User();
-        $handler->updateWithPrivateKey($user, 'old_password');
+        self::assertNotEmpty($handler->decrypt($user, 'newPassword'));
     }
 
     public function testUpdateWithPrivateKey(): void
     {
         $handler = $this->createHandler();
         $user = new User();
-        $user->setPlainPassword('password');
-        $handler->create($user);
+        $handler->create($user, 'password');
         $secret = $user->getMailCryptSecretBox();
 
-        $user->setPlainPassword('new_password');
-        $handler->updateWithPrivateKey($user, 'plain_private_key');
+        $handler->updateWithPrivateKey($user, $secret, 'new_password');
 
         self::assertNotEquals($secret, $user->getMailCryptSecretBox());
         self::assertNotEmpty($handler->decrypt($user, 'new_password'));
@@ -141,9 +116,7 @@ UQ==
         $this->expectExceptionMessage('decryption of mailCryptSecretBox failed');
         $handler = $this->createHandler();
         $user = new User();
-        $user->setPlainPassword('password');
-        $handler->create($user);
-
+        $handler->create($user, 'password');
         $handler->decrypt($user, 'wrong_password');
     }
 
@@ -151,8 +124,7 @@ UQ==
     {
         $handler = $this->createHandler();
         $user = new User();
-        $user->setPlainPassword('password');
-        $handler->create($user);
+        $handler->create($user, 'password');
 
         self::assertNotNull($handler->decrypt($user, 'password'));
     }

--- a/tests/Handler/RecoveryTokenHandlerTest.php
+++ b/tests/Handler/RecoveryTokenHandlerTest.php
@@ -19,16 +19,6 @@ class RecoveryTokenHandlerTest extends TestCase
         return new RecoveryTokenHandler($EntityManagerInterface);
     }
 
-    public function testCreateExceptionPlainPasswordNull(): void
-    {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('plainPassword should not be null');
-        $handler = $this->createHandler();
-        $user = new User();
-
-        $handler->create($user);
-    }
-
     public function testCreateExceptionPlainMailCryptPrivateKeyNull(): void
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
Found an issue when trying to reset a user. This comes from the usage of the implicit plain password at the user object.

```
$ bin/console app:users:reset -u <REDACTED>
Really reset user? This will clear their mailbox: (yes|no) yes
New password:
Repeat password:

Resetting user <REDACTED> ...

{"message":"Error thrown while running command \"app:users:reset -u '<REDACTED>'\". Message: \"plainPassword should not be null\"","context":{"exception":{"class":"Exception","message":"plainPassword should not be null","code":0,"file":"/var/www/users.systemli.org/userli-3.8.0/src/Handler/MailCryptKeyHandler.php:77"},"command":"app:users:reset -u '<REDACTED>'","message":"plainPassword should not be null"},"level":500,"level_name":"CRITICAL","channel":"console","datetime":"2024-08-22T10:09:46.238772+00:00","extra":{}}
10:09:46 CRITICAL  [console] Error thrown while running command "app:users:reset -u '<REDACTED>'". Message: "plainPassword should not be null" ["exception" => Exception { …},"command" => "app:users:reset -u '<REDACTED>'","message" => "plainPassword should not be null"]
{"message":"Command \"app:users:reset -u '<REDACTED>'\" exited with code \"1\"","context":{"command":"app:users:reset -u '<REDACTED>'","code":1},"level":100,"level_name":"DEBUG","channel":"console","datetime":"2024-08-22T10:09:46.280854+00:00","extra":{}}

In MailCryptKeyHandler.php line 77:

  plainPassword should not be null
```

I refactored the `MailCryptKeyHandler::create` and `MailCryptKeyHandler::update` methods to use the password explictly as a parameter and not from the user itself. Also I removed the password change option in `UserAdmin`.