### PR TITLE
Show email and domain filters per default in admin user list

### DIFF
--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -74,8 +74,12 @@ class UserAdmin extends Admin
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
-            ->add('email')
-            ->add('domain')
+            ->add('email', null, [
+                'show_filter' => true,
+            ])
+            ->add('domain', null, [
+                'show_filter' => true,
+            ])
             ->add('creationTime', DateTimeRangeFilter::class, [
                 'field_type' => DateRangePickerType::class,
                 'field_options' => [


### PR DESCRIPTION
email is the filter I use the most often.

Before | After 
--- | ---
![grafik](https://github.com/user-attachments/assets/98cb595d-44ab-4e15-8be3-c767a96c57fd) | ![grafik](https://github.com/user-attachments/assets/e3a54337-b1d4-49fd-88e6-70758a61709d)