### PR TITLE
Add docker image for human testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.vscode
+ansible
+build
+docs
+var
+vendor

--- a/.env
+++ b/.env
@@ -53,7 +53,7 @@ MAILER_DELIVERY_ADDRESS="admin@example.org"
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=14&charset=utf8"
-DATABASE_URL="mysql://mail:password@127.0.0.1:3306/mail?charset=utf8mb4"
+DATABASE_URL="mysql://mail:password@mariadb:3306/mail?charset=utf8mb4"
 ###< doctrine/doctrine-bundle ###
 
 ### Enable keycloak API ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM composer AS composer
+
+FROM php:8.2-apache-bookworm
+RUN apt-get update && apt-get install -y libpng-dev libzip-dev nodejs npm zlib1g-dev zip
+RUN docker-php-ext-install -j$(nproc) gd zip
+COPY . /var/www/html
+COPY userli.conf /etc/apache2/sites-enabled/000-default.conf
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+RUN mv .env.test .env
+RUN APP_ENV=test composer install --no-scripts &&   bin/console doctrine:schema:create --env=test &&   bin/console doctrine:fixtures:load --group=basic --env=test -n
+RUN npm install --global yarn && yarn install && yarn encore production
+RUN bin/console assets:install
+RUN chown -R www-data:www-data var

--- a/contrib/apache.conf
+++ b/contrib/apache.conf
@@ -14,7 +14,7 @@
         Require all granted
     </Directory>
 
-    SetEnv APP_ENV test
+    SetEnv APP_ENV dev
 
     <IfModule fcgid_module>
         AddHandler fcgid-script .php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,28 @@
 ---
 services:
-  mysql:
-    image: mariadb:10.11
+  userli:
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
-      - '3306:3306'
+      - 8000:80
+    networks:
+      - userli
+
+  mariadb:
+    image: mariadb:10.11
     environment:
       MYSQL_USER: mail
       MYSQL_PASSWORD: password
       MYSQL_DATABASE: mail
       MARIADB_RANDOM_ROOT_PASSWORD: true
     volumes:
-      - mysql:/var/lib/mysql
+      - mariadb:/var/lib/mysql
+    networks:
+        - userli
+
+networks:
+  userli:
 
 volumes:
-  mysql:
+  mariadb:

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,29 +1,38 @@
 # Getting Started
 
-The easiest way to install Userli on a fresh Debian Buster is running these commands:
+The easiest way to get started with Userli is to use podman or docker.
+We provide a `docker-compose.yml` file that starts Userli and MariaDB.
+This is not recommended for production use, but it is a good way to get started.
 
-    # install dependencies
-    sudo apt update && sudo apt install -y ansible git python3-pip
-    sudo pip3 install molecule  # re-run in case of error
+!!! info
+    If you don't have podman or docker installed, you can find the installation instructions on the [podman website](https://podman.io/getting-started/installation) or the [docker website](https://docs.docker.com/get-docker/).
 
-    # get code
-    git clone https://github.com/systemli/ansible-role-userli.git
-    cd ansible-role-userli
+1. Start Userli and MariaDB with podman or docker:
+    
+    Using podman: 
 
-    # install apache2, mariadb, php8.0 and userli
-    sudo molecule converge -s localhost
+    ```shell
+    podman compose up -d --build
+   ```
 
-This installs all dependencies, creates a database and database user
-(name: userli, password: userli), and installs the userli code at `/var/www/userli`.
-It is accessible via [http://localhost:8080](http://localhost:8080).
-There, you can create the first domain and user for your instance.
+    Using docker:
 
-!!! warning
-    Do not run this configuration in production.
+    ```shell
+    docker-compose up -d --build
+    ```
 
-Next, you would have to change the password of the database user,
-[configure your instance](../installation/configuration),
-and probably install Dovecot to do anything meaningful.
+2. Initialize the database:
 
-Better, do a [manual installation](../installation) to understand each part of your
-configuration.
+    Using podman:
+
+    ```shell
+    podman exec userli bin/console doctrine:schema:create
+    ```
+
+    Using docker:
+
+    ```shell
+    docker exec userli bin/console doctrine:schema:create
+    ```
+
+3. Open your browser and go to [http://localhost:8000](http://localhost:8000)

--- a/userli.conf
+++ b/userli.conf
@@ -1,0 +1,36 @@
+<VirtualHost *:80>
+
+    DocumentRoot /var/www/html/public
+
+    <Directory /var/www/html/public>
+        AllowOverride AuthConfig FileInfo Indexes Limit Options=ExecCGI,Includes,Indexes,SymLinksIfOwnerMatch,MultiViews
+        Options -Indexes -MultiViews +SymLinksIfOwnerMatch
+
+        LimitRequestBody 10485760
+
+    </Directory>
+
+    <Directory /var/www/html/public/.well-known>
+        Require all granted
+    </Directory>
+
+    SetEnv APP_ENV test
+
+    <IfModule fcgid_module>
+        AddHandler fcgid-script .php
+        FCGIWrapper /var/www/users.example.org/php-fcgi/php-fcgi-starter .php
+
+        IPCConnectTimeout 20
+        IPCCommTimeout 60
+        FcgidBusyTimeout 60
+        MaxRequestLen 10485760
+
+        <Directory /var/www/html/public>
+            Options +ExecCGI
+        </Directory>
+    </IfModule>
+
+    ErrorLog  "|/usr/bin/logger -t apache -p local0.error"
+
+    Protocols h2 http/1.1
+</VirtualHost>


### PR DESCRIPTION
Adding an docker image with fixtures to enable human testing

Build 
```
podman build . -t userli:latest
```
Run
```
podman run -it -p 8000:80 userli:latest
```
One can login with `admin@example.org:password`

Can be easily improved, but maybe it works as a basis for discussion.