### PR TITLE
✅ Fix Deprecations & enable Deprecation Helper

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -162,7 +162,6 @@ security:
       user_checker: App\Security\UserChecker
       form_login:
         enable_csrf: true
-        require_previous_session: false
         login_path: login
         check_path: login
         default_target_path: start

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,6 +1,4 @@
 security:
-  enable_authenticator_manager: true
-
   # https://symfony.com/doc/current/security.html#c-hashing-passwords
   password_hashers:
     App\Entity\User:

--- a/config/packages/sonata_admin.yaml
+++ b/config/packages/sonata_admin.yaml
@@ -15,7 +15,6 @@ sonata_admin:
     handler: sonata.admin.security.handler.role
 
 sonata_block:
-  http_cache: false
   default_contexts: [cms]
   blocks:
     sonata.admin.block.admin_list:

--- a/config/routes/annotations.yaml
+++ b/config/routes/annotations.yaml
@@ -1,7 +1,7 @@
 controllers:
   resource: ../../src/Controller/
-  type: annotation
+  type: attribute
 
 kernel:
   resource: ../../src/Kernel.php
-  type: annotation
+  type: attribute

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -186,11 +186,15 @@ services:
     class: App\Admin\UserAdmin
     public: true
     tags:
-      - { name: sonata.admin, manager_type: orm, group: "Mail", label: "User" }
-    arguments:
-      - ~
-      - App\Entity\User
-      - App\Controller\UserCRUDController
+      - {
+          name: sonata.admin,
+          manager_type: orm,
+          group: "Mail",
+          label: "User",
+          code: userli.admin.user,
+          model_class: App\Entity\User,
+          controller: App\Controller\UserCRUDController,
+        }
     calls:
       - [setPasswordUpdater, ['@App\Helper\PasswordUpdater']]
       - [setDomainGuesser, ['@App\Guesser\DomainGuesser']]
@@ -206,11 +210,9 @@ services:
           manager_type: orm,
           group: "Mail",
           label: "Domain",
+          code: userli.admin.domain,
+          model_class: App\Entity\Domain,
         }
-    arguments:
-      - ~
-      - App\Entity\Domain
-      - ~
     calls:
       - [setDomainCreator, ['@App\Creator\DomainCreator']]
       - [
@@ -222,11 +224,15 @@ services:
     class: App\Admin\AliasAdmin
     public: true
     tags:
-      - { name: sonata.admin, manager_type: orm, group: "Mail", label: "Alias" }
-    arguments:
-      - ~
-      - App\Entity\Alias
-      - App\Controller\AliasCRUDController
+      - {
+          name: sonata.admin,
+          manager_type: orm,
+          group: "Mail",
+          label: "Alias",
+          code: userli.admin.alias,
+          model_class: App\Entity\Alias,
+          controller: App\Controller\AliasCRUDController,
+        }
     calls:
       - [setDomainGuesser, ['@App\Guesser\DomainGuesser']]
 
@@ -239,11 +245,9 @@ services:
           manager_type: orm,
           group: "Mail",
           label: "Voucher",
+          code: userli.admin.voucher,
+          model_class: App\Entity\Voucher,
         }
-    arguments:
-      - ~
-      - App\Entity\Voucher
-      - ~
 
   userli.admin.block.statistics:
     class: App\Block\StatisticsBlockService
@@ -263,11 +267,9 @@ services:
           manager_type: orm,
           group: "Mail",
           label: "Reserved Name",
+          code: userli.admin.reservedname,
+          model_class: App\Entity\ReservedName,
         }
-    arguments:
-      - ~
-      - App\Entity\ReservedName
-      - ~
 
   Symfony\Component\Security\Http\HttpUtils:
     alias: security.http_utils

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,7 @@
         <env name="APP_DEBUG" value="1"/>
         <env name="APP_SECRET" value="s$cretf0rt3st"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;verbose=1"/>
         <!-- define your env variables for the test env here -->
     </php>
     <testsuites>

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -4,18 +4,9 @@ namespace App\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
-use Symfony\Bundle\SecurityBundle\Security;
 
 abstract class Admin extends AbstractAdmin
 {
-    /**
-     * Admin constructor.
-     */
-    public function __construct(protected Security $security)
-    {
-        parent::__construct();
-    }
-
     protected function configureDefaultSortValues(array &$sortValues): void
     {
         $sortValues[DatagridInterface::PAGE] = 1;

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -4,7 +4,7 @@ namespace App\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 abstract class Admin extends AbstractAdmin
 {

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -11,9 +11,9 @@ abstract class Admin extends AbstractAdmin
     /**
      * Admin constructor.
      */
-    public function __construct(string $code, string $class, string $baseControllerName, protected Security $security)
+    public function __construct(protected Security $security)
     {
-        parent::__construct($code, $class, $baseControllerName);
+        parent::__construct();
     }
 
     protected function configureDefaultSortValues(array &$sortValues): void

--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -12,12 +12,18 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 
 class AliasAdmin extends Admin
 {
     use DomainGuesserAwareTrait;
+
+    public function __construct(protected Security $security)
+    {
+        parent::__construct();
+    }
 
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {

--- a/src/Admin/VoucherAdmin.php
+++ b/src/Admin/VoucherAdmin.php
@@ -9,9 +9,15 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter;
 use Sonata\Form\Type\DateRangePickerType;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class VoucherAdmin extends Admin
 {
+    public function __construct(protected Security $security)
+    {
+        parent::__construct();
+    }
+
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
         return 'voucher';

--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class AccountController extends AbstractController
 {

--- a/src/Controller/AliasController.php
+++ b/src/Controller/AliasController.php
@@ -13,7 +13,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class AliasController extends AbstractController
 {

--- a/src/Controller/DeleteController.php
+++ b/src/Controller/DeleteController.php
@@ -14,7 +14,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DeleteController extends AbstractController
 {

--- a/src/Controller/DovecotController.php
+++ b/src/Controller/DovecotController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DovecotController extends AbstractController
 {

--- a/src/Controller/InitController.php
+++ b/src/Controller/InitController.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class InitController extends AbstractController
 {

--- a/src/Controller/KeycloakController.php
+++ b/src/Controller/KeycloakController.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class KeycloakController extends AbstractController
 {

--- a/src/Controller/OpenPGPController.php
+++ b/src/Controller/OpenPGPController.php
@@ -14,7 +14,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class OpenPGPController extends AbstractController
 {

--- a/src/Controller/RecoveryController.php
+++ b/src/Controller/RecoveryController.php
@@ -23,7 +23,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Doctrine\ORM\EntityManagerInterface;
 

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -3,7 +3,7 @@
 namespace App\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Exception;
 use App\Entity\User;

--- a/src/Controller/RetentionController.php
+++ b/src/Controller/RetentionController.php
@@ -10,7 +10,7 @@ use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class RetentionController extends AbstractController
 {

--- a/src/Controller/RoundcubeController.php
+++ b/src/Controller/RoundcubeController.php
@@ -6,7 +6,7 @@ use App\Entity\Alias;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class RoundcubeController extends AbstractController
 {

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController

--- a/src/Controller/StartController.php
+++ b/src/Controller/StartController.php
@@ -8,7 +8,7 @@ use App\Enum\Roles;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class StartController extends AbstractController
 {

--- a/src/Controller/TwofactorController.php
+++ b/src/Controller/TwofactorController.php
@@ -21,7 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class TwofactorController extends AbstractController
 {

--- a/src/Controller/VoucherController.php
+++ b/src/Controller/VoucherController.php
@@ -12,7 +12,7 @@ use App\Handler\VoucherHandler;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class VoucherController extends AbstractController
 {

--- a/src/EventListener/BeforeRequestListener.php
+++ b/src/EventListener/BeforeRequestListener.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class BeforeRequestListener implements EventSubscriberInterface
 {

--- a/src/Form/AliasDeleteType.php
+++ b/src/Form/AliasDeleteType.php
@@ -12,7 +12,7 @@ class AliasDeleteType extends AbstractType
 {
     public const NAME = 'delete_alias';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('password', PasswordType::class, ['label' => 'form.delete-password'])
@@ -22,7 +22,7 @@ class AliasDeleteType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => 'App\Form\Model\Delete']);
     }
@@ -30,7 +30,7 @@ class AliasDeleteType extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/src/Form/CustomAliasCreateType.php
+++ b/src/Form/CustomAliasCreateType.php
@@ -12,7 +12,7 @@ class CustomAliasCreateType extends AbstractType
 {
     public const NAME = 'create_custom_alias';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('alias', TextType::class, ['label' => 'form.new-custom-alias'])
@@ -22,7 +22,7 @@ class CustomAliasCreateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => 'App\Form\Model\AliasCreate']);
     }
@@ -30,7 +30,7 @@ class CustomAliasCreateType extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/src/Form/DomainCreateType.php
+++ b/src/Form/DomainCreateType.php
@@ -12,14 +12,14 @@ class DomainCreateType extends AbstractType
 {
     public const NAME = 'create_domain';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('domain', TextType::class, ['label' => 'form.domain'])
             ->add('submit', SubmitType::class, ['label' => 'form.add']);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => 'App\Form\Model\DomainCreate']);
     }
@@ -27,7 +27,7 @@ class DomainCreateType extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/src/Form/OpenPgpDeleteType.php
+++ b/src/Form/OpenPgpDeleteType.php
@@ -12,7 +12,7 @@ class OpenPgpDeleteType extends AbstractType
 {
     public const NAME = 'delete_openpgp';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('password', PasswordType::class, ['label' => 'form.delete-password'])
@@ -22,7 +22,7 @@ class OpenPgpDeleteType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => 'App\Form\Model\Delete']);
     }
@@ -30,7 +30,7 @@ class OpenPgpDeleteType extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/src/Form/RegistrationType.php
+++ b/src/Form/RegistrationType.php
@@ -31,7 +31,7 @@ class RegistrationType extends AbstractType
         $this->domain = $manager->getRepository(Domain::class)->getDefaultDomain()->getName();
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $transformer = new TextToEmailTransformer($this->domain);
 

--- a/src/Voter/DomainVoter.php
+++ b/src/Voter/DomainVoter.php
@@ -9,7 +9,7 @@ use App\Guesser\DomainGuesser;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class DomainVoter extends Voter
 {

--- a/templates/Form/fields.html.twig
+++ b/templates/Form/fields.html.twig
@@ -1,20 +1,18 @@
 {% block form_errors %}
-    {% apply spaceless %}
-        {% if errors|length > 0 %}
-            <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
-                <div class="flex">
-                    <svg class="w-5 h-5 text-red-400 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
-                    </svg>
-                    <div class="text-sm text-red-800">
-                        {% for error in errors %}
-                            <p{% if not loop.last %} class="mb-1"{% endif %}>{{ error.message }}</p>
-                        {% endfor %}
-                    </div>
+    {% if errors|length > 0 %}
+        <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
+            <div class="flex">
+                <svg class="w-5 h-5 text-red-400 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                </svg>
+                <div class="text-sm text-red-800">
+                    {% for error in errors %}
+                        <p{% if not loop.last %} class="mb-1"{% endif %}>{{ error.message }}</p>
+                    {% endfor %}
                 </div>
             </div>
-        {% endif %}
-    {% endapply %}
+        </div>
+    {% endif %}
 {% endblock form_errors %}
 
 {% block form_label %}

--- a/tests/EntityListener/UserChangedListenerTest.php
+++ b/tests/EntityListener/UserChangedListenerTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class UserChangedListenerTest extends TestCase
 {
+    private Session $session;
+    private Request $request;
+    private RequestEvent $event;
     private SuspiciousChildrenHandler $suspiciousChildrenHandler;
     private VoucherRepository $voucherRepository;
     private UserChangedListener $listener;

--- a/tests/EventListener/BeforeRequestListenerTest.php
+++ b/tests/EventListener/BeforeRequestListenerTest.php
@@ -9,10 +9,9 @@ use App\EventListener\BeforeRequestListener;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\FilterCollection;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class BeforeRequestListenerTest extends TestCase
 {

--- a/tests/Voter/DomainVoterTest.php
+++ b/tests/Voter/DomainVoterTest.php
@@ -12,7 +12,7 @@ use App\Voter\DomainVoter;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class DomainVoterTest extends TestCase
 {


### PR DESCRIPTION
This pull request includes several updates to configuration files, service definitions, and controller classes. The most notable changes involve transitioning from Symfony annotations to attributes for routing, enhancing service definitions for Sonata Admin, and modifying security-related configurations. Below is a breakdown of the most important changes grouped by theme:

### Symfony Routing Transition
* Updated routing definitions in multiple controller files to use Symfony attributes (`Attribute\Route`) instead of annotations (`Annotation\Route`) for improved consistency and future compatibility. Files affected include `src/Controller/AccountController.php`, `src/Controller/AliasController.php`, `src/Controller/DeleteController.php`, and others. [[1]](diffhunk://#diff-8cc3de1e9a0fc9eb9c8e4ccd261693a7fbd18307d3365e7353e1e9ed0bd1bfd5L14-R14) [[2]](diffhunk://#diff-d3bab4f8518b5baed86cc2291504592ddb2a0acc181b722adad42340af82c9fcL16-R16) [[3]](diffhunk://#diff-c9a799a9b9332482093088ed910afba046b5ab4f97a3fed101d297f7851d1c24L17-R17) [[4]](diffhunk://#diff-7dda94f889063c4ff8e1577cd40fbc4ff6cfbfe93c765277e589f94374361328L17-R17) [[5]](diffhunk://#diff-727889bf3a2db1478652dd901578a594211dcb1a9dd9e9b003bc802e9ecb8d74L18-R18) [[6]](diffhunk://#diff-06bb61cd0707d1c5b70bab86b4f0593419061f8e39285023d2cb98b9339aba35L16-R16) [[7]](diffhunk://#diff-eae4a6aad9170750d0f38627aea59ca1277e4b677375d7a30b9d992b6809b1f3L17-R17) [[8]](diffhunk://#diff-054aa9a4de0429af3fd103cb0a5fa29748390c38656b76bf60464061bc03ea99L26-R26) [[9]](diffhunk://#diff-d6e0320f959fd80725fad202416df75fa98c151cd17f17879872f7ebbd50e2e0L6-R6) [[10]](diffhunk://#diff-8f604d120ee7c290eedaee67703c8deb5d456d0f103d31589b46a2a2afc85df8L13-R13) [[11]](diffhunk://#diff-6b983fcbe0613946194cfb1ff80b5602321aa691eb100a27dbaac102b27d05d8L9-R9) [[12]](diffhunk://#diff-1d5c51312047aa4ab330883ca067b55aa4f81675b1577d93de88f20d03b14a10L9-R9) [[13]](diffhunk://#diff-e7d0499c1c17675f8dc46ce7705d41264fee21c299af5ae7e6f28f5a73d4fd4dL11-R11) [[14]](diffhunk://#diff-ea0ef429ed0238fbc67f075cec2a1dce4dfab4113a55fad4a6fec680c8cd95a2L24-R24)

### Sonata Admin Service Enhancements
* Enhanced service definitions for Sonata Admin by adding explicit `code`, `model_class`, and `controller` properties to improve clarity and extensibility. Changes affect services like `UserAdmin`, `DomainAdmin`, `AliasAdmin`, `VoucherAdmin`, and `ReservedNameAdmin` in `config/services.yaml`. [[1]](diffhunk://#diff-c47b03734cd2b4337b345eeba955637ba790d51fd98979f6d366d4acbdb104e0L189-R197) [[2]](diffhunk://#diff-c47b03734cd2b4337b345eeba955637ba790d51fd98979f6d366d4acbdb104e0R213-L213) [[3]](diffhunk://#diff-c47b03734cd2b4337b345eeba955637ba790d51fd98979f6d366d4acbdb104e0L225-R235) [[4]](diffhunk://#diff-c47b03734cd2b4337b345eeba955637ba790d51fd98979f6d366d4acbdb104e0R248-L246) [[5]](diffhunk://#diff-c47b03734cd2b4337b345eeba955637ba790d51fd98979f6d366d4acbdb104e0R270-L270)

### Security and Configuration Updates
* Removed the `enable_authenticator_manager` option from `config/packages/security.yaml` and adjusted `form_login` settings for better alignment with current security practices. [[1]](diffhunk://#diff-19446c4b69407952b20ae26dbd032cdad8dcc487db081a5cb17261831e80a4ccL2-L3) [[2]](diffhunk://#diff-19446c4b69407952b20ae26dbd032cdad8dcc487db081a5cb17261831e80a4ccL165)
* Updated the `SYMFONY_DEPRECATIONS_HELPER` environment variable in `phpunit.xml` to strengthen deprecation handling during tests.

### Codebase Simplification
* Refactored the `Admin` class constructor to simplify initialization by removing redundant parameters and switching to `Symfony\Bundle\SecurityBundle\Security`.

### Miscellaneous Updates
* Changed `type` from `annotation` to `attribute` for route definitions in `config/routes/annotations.yaml` to align with Symfony's attribute-based approach.
* Removed unused or outdated configurations, such as `http_cache` in `config/packages/sonata_admin.yaml`.