### PR TITLE
Remove `cache:clear` from compose auto-scripts (at update and install)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,6 @@
     },
     "scripts": {
         "auto-scripts": {
-            "cache:clear": "symfony-cmd",
             "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },


### PR DESCRIPTION
Required to build userli in a Git clone without DB backend.