### PR TITLE
Revert "Remove `cache:clear` from compose auto-scripts (at update and…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,6 +100,7 @@
     },
     "scripts": {
         "auto-scripts": {
+            "cache:clear": "symfony-cmd",
             "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },


### PR DESCRIPTION
… install)"

This reverts commit 14360bbb61abd9bbc4cc1096805a06a8392b2646.