### PR TITLE
Monolog: Log to syslog in prod env

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -47,8 +47,8 @@ when@prod:
                 excluded_http_codes: [404, 405]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             nested:
-                type: stream
-                path: php://stderr
+                type: syslog
+                ident: userli
                 level: debug
                 formatter: monolog.formatter.json
             console:


### PR DESCRIPTION
php://stderr is useful für containerized usage, which we don't optimize for. 

use syslog for simplicity