### PR TITLE
Fix log config 

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -46,6 +46,7 @@ when@prod:
                 handler: syslog_handler
                 excluded_http_codes: [404, 405]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+                channels: [ "!deprecation" ]
             syslog_handler:
                 type: syslog
                 ident: userli


### PR DESCRIPTION
- fix usage of "nested" keyword
- filter deprecation warnings in 'fingers_crossed' handler: the handler bundles debug and info level logs with errors for each request. this makes debugging easier, but also aggregates deprecation warnings, which are not useful for debugging requests