### PR TITLE
Change booleans in docker compose env vars to integers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       MYSQL_USER: mail
       MYSQL_PASSWORD: password
       MYSQL_DATABASE: mail
-      MARIADB_RANDOM_ROOT_PASSWORD: true
+      MARIADB_RANDOM_ROOT_PASSWORD: 1
     ports:
       - 3306:3306
     volumes:
@@ -34,7 +34,7 @@ services:
       MAIL_CRYPT: 2
       USERLI_HOST: userli
       USERLI_API_ACCESS_TOKEN: insecure
-      DOVECOT_LUA_INSECURE: true
+      DOVECOT_LUA_INSECURE: 1
     volumes:
       - ./contrib/dovecot/dovecot.conf:/etc/dovecot/dovecot.conf:ro
       - ./contrib/dovecot/conf.d:/etc/dovecot/conf.d:ro


### PR DESCRIPTION
Fixes:

> ERROR: The Compose file './docker-compose.yml' is invalid because:
> services.dovecot.environment.DOVECOT_LUA_INSECURE contains true, which
> is an invalid type, it should be a string, number, or a null
> services.mariadb.environment.MARIADB_RANDOM_ROOT_PASSWORD contains true,
> which is an invalid type, it should be a string, number, or a null