### PR TITLE
Add lowercase validator and use it for email and name trait

### DIFF
--- a/default_translations/de/validators.de.yml
+++ b/default_translations/de/validators.de.yml
@@ -1,3 +1,4 @@
+---
 form:
   weak_password: Das Passwort entspricht nicht den Sicherheitsanforderungen.
   forbidden_char: Das Passwort enthält nicht erlaubte Zeichen.
@@ -5,10 +6,12 @@ form:
   invalid-email: Die E-Mail-Adresse ist ungültig.
   wrong-password: Das eingegebene Passwort ist falsch
   identical-passwords: Das neue Passwort stimmt mit dem aktuellen überein.
-  missing-domain: Die Domain wird nicht vom System verwaltet und kann nicht benutzt
-    werden.
+  missing-domain: Die Domain wird nicht vom System verwaltet und kann nicht benutzt werden.
   registration-recovery-token-noack: Dieses Feld muss ausgewählt werden.
   invalid-token: Der Code hat ein ungültiges Format.
+  twofactor-secret-invalid: "Der Verifizierungscode ist ungültig."
+  twofactor-backup-ack-missing: "Dies muss muss ausgewählt werden."
+  lowercase: "Die Zeichenkette darf keine Großbuchstaben enthalten."
 
 registration:
   voucher-invalid: Der Einladungscode ist ungültig.

--- a/default_translations/en/validators.en.yml
+++ b/default_translations/en/validators.en.yml
@@ -11,6 +11,7 @@ form:
   invalid-token: "This token has an invalid format."
   twofactor-secret-invalid: "The verification code is not valid."
   twofactor-backup-ack-missing: "This needs to be checked."
+  lowercase: "The string must not contain uppercase letters."
 
 registration:
   voucher-invalid: "The invite code is invalid."

--- a/src/Creator/DomainCreator.php
+++ b/src/Creator/DomainCreator.php
@@ -16,7 +16,7 @@ class DomainCreator extends AbstractCreator
     {
         $domain = DomainFactory::create($name);
 
-        $this->validate($domain, ['Default', 'unique']);
+        $this->validate($domain, ['Default', 'lowercase', 'unique']);
         $this->save($domain);
 
         $this->eventDispatcher->dispatch(new DomainCreatedEvent($domain), DomainCreatedEvent::NAME);

--- a/src/Traits/EmailTrait.php
+++ b/src/Traits/EmailTrait.php
@@ -2,6 +2,7 @@
 
 namespace App\Traits;
 
+use App\Validator\Constraints\Lowercase;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -10,6 +11,7 @@ trait EmailTrait
 {
     #[ORM\Column(unique: true)]
     #[Assert\NotNull]
+    #[Lowercase]
     #[Assert\Email]
     private ?string $email = '';
 

--- a/src/Traits/NameTrait.php
+++ b/src/Traits/NameTrait.php
@@ -2,6 +2,7 @@
 
 namespace App\Traits;
 
+use App\Validator\Constraints\Lowercase;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -10,6 +11,7 @@ trait NameTrait
     #[ORM\Column(unique: true)]
     #[Assert\NotNull]
     #[Assert\NotBlank]
+    #[Lowercase]
     private ?string $name = null;
 
     public function getName(): ?string

--- a/src/Validator/Constraints/Lowercase.php
+++ b/src/Validator/Constraints/Lowercase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Validator\Constraints;
+
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class Lowercase extends Constraint
+{
+    public string $message = 'form.lowercase';
+    public string $mode = 'strict';
+
+    public function __construct(?string $mode = null, ?string $message = null, ?array $groups = null, $payload = null) {
+        parent::__construct([], $groups, $payload);
+
+        $this->mode = $mode ?? $this->mode;
+    }
+}

--- a/src/Validator/Constraints/LowercaseValidator.php
+++ b/src/Validator/Constraints/LowercaseValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class LowercaseValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof Lowercase) {
+            throw new UnexpectedTypeException($constraint, Lowercase::class);
+        }
+
+        // custom constraints should ignore null and empty values to allow
+        // other constraints (NotBlank, NotNull, etc.) to take care of that
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        if (!preg_match('/[A-Z]/', $value, $matches)) {
+            return;
+        }
+
+        $this->context->buildViolation($constraint->message)
+            ->setParameter('{{ string }}', $value)
+            ->addViolation();
+    }
+}

--- a/tests/Validator/Constraints/LowercaseValidatorTest.php
+++ b/tests/Validator/Constraints/LowercaseValidatorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Tests\Validator\Constraints;
+
+use App\Validator\Constraints\Lowercase;
+use App\Validator\Constraints\LowercaseValidator;
+use stdClass;
+use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class LowercaseValidatorTest extends ConstraintValidatorTestCase
+{
+    private $domain = 'example.org';
+    private $minLength = 3;
+    private $maxLength = 10;
+
+    protected function createValidator(): LowercaseValidator
+    {
+        return new LowercaseValidator();
+    }
+
+    public function testExpectsStringType(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validate('string', new Valid());
+    }
+
+    public function testNullIsValid(): void
+    {
+        $this->validator->validate(null, new Lowercase());
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid(): void
+    {
+        $this->validator->validate('', new Lowercase());
+        $this->assertNoViolation();
+    }
+
+    public function testExpectsStringCompatibleType(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validate(new stdClass(), new Lowercase());
+    }
+
+    public function testValidateValid(): void
+    {
+        $this->validator->validate('example#3!%', new Lowercase());
+        $this->validator->validate('example.org', new Lowercase());
+        $this->validator->validate('new@example.org', new Lowercase());
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getStrings
+     */
+    public function testValidateUppercaseInvalid(string $string): void
+    {
+        $this->validator->validate($string, new Lowercase());
+        $this->buildViolation('form.lowercase')
+            ->setParameter('{{ string }}', $string)
+            ->assertRaised();
+    }
+
+    public static function getStrings(): array
+    {
+        return [
+            ['Example#3!%'],
+            ['example.Org'],
+            ['neW@example.org'],
+        ];
+    }
+}


### PR DESCRIPTION
This forbids uppercase strings in emails, domains, reserved names.

Fixes: #210