### PR TITLE
♻️ Refactor AliasController

### DIFF
--- a/src/Controller/AliasController.php
+++ b/src/Controller/AliasController.php
@@ -25,7 +25,7 @@ class AliasController extends AbstractController
     ) {}
 
     #[Route(path: '/alias', name: 'aliases', methods: ['GET'])]
-    public function show(Request $request): Response
+    public function show(): Response
     {
         /** @var User $user */
         $user = $this->getUser();


### PR DESCRIPTION
This pull request refactors the `AliasController` to improve code clarity, separate concerns, and add stricter typing. It also updates related tests in `AliasControllerTest` to align with the changes in the controller and extend test coverage. The most notable changes include introducing stricter typing, splitting the alias creation logic into separate routes and methods, and enhancing test cases for better validation.

### Refactoring and Code Improvements:
* Added `declare(strict_types=1)` to enforce strict typing in `AliasController` and `AliasControllerTest`. [[1]](diffhunk://#diff-d3bab4f8518b5baed86cc2291504592ddb2a0acc181b722adad42340af82c9fcR3-R4) [[2]](diffhunk://#diff-dfd54cd720ebe8a5491d627a894a26d6f8430f132ec52932da4657ca50d4faa7R3-R4)
* Renamed `alias` method to `show` and updated its route to only handle `GET` requests.
* Moved alias creation logic into a new `create` method with a dedicated route (`/alias/create`) for handling `POST` requests.
* Refactored helper methods `createRandomAlias` and `createCustomAlias` into `processRandomAliasCreation` and `processCustomAliasCreation` for improved naming consistency and separation of concerns.

### Test Updates and Enhancements:
* Updated existing tests to reflect the new `/alias/create` route for alias creation.
* Added new test cases to cover scenarios such as unauthenticated alias creation, alias creation by a spammer, invalid custom alias data, and alias creation without form data.