### PR TITLE
🧑‍💻Add Remote Debugging Support to Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: docker/userli/Dockerfile
     volumes:
+      - ./docker/userli/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini:ro
       - ./:/var/www/html
     ports:
       - 8000:80

--- a/docker/userli/Dockerfile
+++ b/docker/userli/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update && \
     a2enmod rewrite && \
     docker-php-ext-configure intl && \
     docker-php-ext-install -j$(nproc) gd opcache pdo_mysql pdo_sqlite sodium zip intl && \
+    pecl install xdebug && \
+    docker-php-ext-enable xdebug && \
     echo "memory_limit = 512M" > /usr/local/etc/php/conf.d/memory_limit.ini
 
 COPY --from=builder /var/www/html /var/www/html

--- a/docker/userli/xdebug.ini
+++ b/docker/userli/xdebug.ini
@@ -1,0 +1,13 @@
+zend_extension=xdebug
+
+xdebug.mode=develop,debug,profile
+xdebug.idekey=docker
+xdebug.start_with_request=yes
+xdebug.log=/dev/stdout
+xdebug.log_level=0
+xdebug.remote_enable=1
+xdebug.remote_mode=req
+xdebug.remote_port=9003
+xdebug.remote_connect_back=0
+xdebug.client_host=host.docker.internal
+xdebug.discover_client_host=true


### PR DESCRIPTION
This pull request introduces Xdebug support to the PHP development environment in the Docker setup. The changes include configuring Xdebug in the Dockerfile, mounting an Xdebug configuration file in the `docker-compose.yml`, and adding the configuration file itself.

### Xdebug integration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R9): Added a volume to mount the `xdebug.ini` configuration file into the PHP container.
* [`docker/userli/Dockerfile`](diffhunk://#diff-7d914e038cfbc53be1910bf949d7c784ea5dfeb3257c810d3145dc87e1687945R27-R28): Installed and enabled Xdebug via `pecl` and `docker-php-ext-enable`.
* [`docker/userli/xdebug.ini`](diffhunk://#diff-8c2065b0e08a055df86dcb3e6858e5fc2938edc6585af467fa9d48a676d1caccR1-R13): Added a new configuration file to define Xdebug settings, including modes, IDE key, logging, and client connection options.