### PR TITLE
💄 Improve Login and 2FA Template

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -150,6 +150,7 @@ form:
   twofactor-login-cancel: Login abbrechen
   twofactor-enable: Zwei-Faktor-Authentifizierung aktivieren
   twofactor-disable: Zwei-Faktor-Authentifizierung deaktivieren
+  twofactor-login-help: Deine Zwei-Faktor-Authentifikator-App generiert einen 6-stelligen Code, den du hier eingeben musst.
 
 # OpenPGP Keys
 openpgp-key-file: "Deinen Schlüssel als Datei hochladen:"

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -150,6 +150,7 @@ form:
   twofactor-login-cancel: Cancel login
   twofactor-enable: Enable two-factor authentication
   twofactor-disable: Disable two-factor authentication
+  twofactor-login-help: Your two-factor authenticator app generates a 6-digit code that you need to enter here.
 
 # OpenPGP Keys
 openpgp-key-file: "Upload your key file:"

--- a/templates/Security/2fa_form.html.twig
+++ b/templates/Security/2fa_form.html.twig
@@ -1,69 +1,77 @@
-{% extends 'base_page.html.twig' %}
+{% extends 'base_step.html.twig' %}
 
-{% block page_title %}{{ "form.twofactor-login"|trans }}{% endblock %}
+{% block title %}{{ domain }} - {{ "form.twofactor-login"|trans }}{% endblock %}
 
-{% block page_subtitle %}{{ "form.twofactor-login-desc"|trans }}{% endblock %}
+{% block step_icon %}
+    <div class="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center">
+        <!-- Heroicon name: outline/shield-check -->
+        <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+        </svg>
+    </div>
+{% endblock %}
 
-{% block page_content %}
-    <div>
-        {% if authenticationError %}
-            <div class="mb-6 p-4 rounded-lg bg-red-50 border border-red-200" role="alert" aria-live="polite">
-                <div class="flex items-start">
-                    <svg class="w-5 h-5 text-red-400 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
-                    </svg>
-                    <div>
-                        <p class="text-sm text-red-700">{{ authenticationError|trans(authenticationErrorData, 'SchebTwoFactorBundle') }}</p>
-                    </div>
+{% block step_title %}{{ "form.twofactor-login"|trans }}{% endblock %}
+
+{% block step_description %}
+    <p class="text-gray-600">
+        {{ "form.twofactor-login-desc"|trans }}
+    </p>
+{% endblock %}
+
+{% block step_content %}
+    {% if authenticationError %}
+        <div class="mb-6 p-4 rounded-lg bg-red-50 border border-red-200" role="alert" aria-live="polite">
+            <div class="flex items-start">
+                <svg class="w-5 h-5 text-red-400 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                </svg>
+                <div>
+                    <h3 class="text-sm font-medium text-red-800 mb-1">{{ "form.auth-failed"|trans }}</h3>
+                    <p class="text-sm text-red-700">{{ authenticationError|trans(authenticationErrorData, 'SchebTwoFactorBundle') }}</p>
                 </div>
             </div>
+        </div>
+    {% endif %}
+
+    <form method="post" action="{{ checkPathUrl ? checkPathUrl : path(checkPathRoute) }}" class="space-y-6" novalidate>
+        <div>
+            <label for="_auth_code" class="block text-sm font-medium text-gray-700 mb-2">
+                {{ "form.twofactor-login-auth-code"|trans }}
+                <span class="text-red-500 ml-1" aria-label="required">*</span>
+            </label>
+            <input
+                type="text"
+                id="_auth_code"
+                name="{{ authCodeParameterName }}"
+                autocomplete="off"
+                required
+                autofocus
+                placeholder="{{ "form.twofactor-login-placeholder"|trans }}"
+                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors duration-200{% if authenticationError %} border-red-300{% endif %}"
+                aria-describedby="auth-code-help{% if authenticationError %} auth-code-error{% endif %}"
+                {% if authenticationError %}aria-invalid="true"{% endif %}
+            >
+        </div>
+
+        {% if isCsrfProtectionEnabled %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrfTokenId) }}">
         {% endif %}
 
-        <form method="post" action="{{ checkPathUrl ? checkPathUrl : path(checkPathRoute) }}" class="space-y-6">
-            <div>
-                <label for="_auth_code" class="block text-sm font-medium text-gray-700 mb-2">
-                    {{ "form.twofactor-login-auth-code"|trans }}
-                    <span class="text-red-500" aria-label="required">*</span>
-                </label>
-                <div class="relative">
-                    <input
-                        type="text"
-                        id="_auth_code"
-                        name="{{ authCodeParameterName }}"
-                        autocomplete="off"
-                        required
-                        autofocus
-                        placeholder="{{ "form.twofactor-login-placeholder"|trans }}"
-                        class="block w-full px-3 py-3 sm:px-4 border border-gray-300 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors duration-200 text-sm sm:text-sm{% if authenticationError %} border-red-300{% endif %}"
-                        {% if authenticationError %}aria-invalid="true"{% endif %}
-                    >
-                    <div class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                        <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
-                        </svg>
-                    </div>
-                </div>
-            </div>
+        <div class="flex flex-col space-y-4">
+            <button
+                type="submit"
+                class="w-full px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+                {{ "form.verify"|trans() }}
+            </button>
 
-            {% if isCsrfProtectionEnabled %}
-                <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrfTokenId) }}">
-            {% endif %}
-
-            <div class="flex flex-col space-y-4">
-                <button
-                    type="submit"
-                    class="w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-all duration-200 transform hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                    {{ "form.verify"|trans() }}
-                </button>
-
-                <a
-                    href="{{ logoutPath }}"
-                    class="w-full flex justify-center py-3 px-4 border border-gray-300 text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-all duration-200"
-                >
-                    {{ "form.twofactor-login-cancel"|trans() }}
-                </a>
-            </div>
-        </form>
-    </div>
+            <a
+                href="{{ logoutPath }}"
+                class="w-full flex justify-center px-6 py-3 border border-gray-300 text-gray-700 font-medium rounded-lg bg-white hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200"
+            >
+                {{ "form.twofactor-login-cancel"|trans() }}
+            </a>
+        </div>
+    </form>
 {% endblock %}

--- a/templates/Security/2fa_form.html.twig
+++ b/templates/Security/2fa_form.html.twig
@@ -52,6 +52,14 @@
                 aria-describedby="auth-code-help{% if authenticationError %} auth-code-error{% endif %}"
                 {% if authenticationError %}aria-invalid="true"{% endif %}
             >
+            <p id="auth-code-help" class="mt-2 text-xs text-gray-500">
+                {{ "form.twofactor-login-help"|trans }}
+            </p>
+            {% if authenticationError %}
+                <div id="auth-code-error" class="mt-2 text-xs text-red-600">
+                    {{ authenticationError|trans }}
+                </div>
+            {% endif %}
         </div>
 
         {% if isCsrfProtectionEnabled %}

--- a/templates/Security/2fa_form.html.twig
+++ b/templates/Security/2fa_form.html.twig
@@ -49,15 +49,16 @@
                 autofocus
                 placeholder="{{ "form.twofactor-login-placeholder"|trans }}"
                 class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors duration-200{% if authenticationError %} border-red-300{% endif %}"
-                aria-describedby="auth-code-help{% if authenticationError %} auth-code-error{% endif %}"
+                aria-describedby="{% if authenticationError %}auth-code-error{% else %}auth-code-help{% endif %}"
                 {% if authenticationError %}aria-invalid="true"{% endif %}
             >
-            <p id="auth-code-help" class="mt-2 text-xs text-gray-500">
-                {{ "form.twofactor-login-help"|trans }}
-            </p>
             {% if authenticationError %}
                 <div id="auth-code-error" class="mt-2 text-xs text-red-600">
-                    {{ authenticationError|trans }}
+                    {{ authenticationError|trans(authenticationErrorData, 'SchebTwoFactorBundle') }}
+                </div>
+            {% else %}
+                <div id="auth-code-help" class="mt-2 text-xs text-gray-500">
+                    {{ "form.twofactor-login-help"|trans }}
                 </div>
             {% endif %}
         </div>

--- a/templates/Security/login.html.twig
+++ b/templates/Security/login.html.twig
@@ -1,138 +1,129 @@
-{% extends 'base.html.twig' %}
+{% extends 'base_step.html.twig' %}
 
-{% block content %}
-    <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">
-        <div class="max-w-lg mx-auto px-4">
-            <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-                {# Main content section #}
-                <div class="p-6 sm:p-8">
-                    {# Optional icon section #}
-                    <div class="flex justify-center mb-6">
-                        <div class="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center">
-                            <!-- Heroicon: arrow-right-on-rectangle -->
-                            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75"></path>
-                            </svg>
-                        </div>
-                    </div>
+{% block title %}{{ domain }} - {{ "form.signin-header"|trans }}{% endblock %}
 
-                    {# Step header #}
-                    <div class="text-center mb-8">
-                        <h1 class="text-xl sm:text-2xl font-bold text-gray-900 mb-2">
-                            {{ "form.signin-header"|trans }}
-                        </h1>
-                        <p class="text-gray-600">
-                            {{ "form.signin-subtitle"|trans }}
-                        </p>
-                    </div>
+{% block step_icon %}
+    <div class="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center">
+        <!-- Heroicon name: outline/arrow-right-on-rectangle -->
+        <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75"></path>
+        </svg>
+    </div>
+{% endblock %}
 
-                    {# Error message with improved accessibility #}
-                    {% if error %}
-                        <div class="mb-6 p-4 rounded-lg bg-red-50 border border-red-200" role="alert" aria-live="polite">
-                            <div class="flex items-start">
-                                <svg class="w-5 h-5 text-red-400 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
-                                </svg>
-                                <div>
-                                    <h3 class="text-sm font-medium text-red-800 mb-1">{{ "form.auth-failed"|trans }}</h3>
-                                    <p class="text-sm text-red-700">{{ error.message|trans }}</p>
-                                </div>
-                            </div>
-                        </div>
-                    {% endif %}
+{% block step_title %}{{ "form.signin-header"|trans }}{% endblock %}
 
-                    {# Login form with semantic HTML and accessibility features #}
-                    <form method="post" action="{{ path('login') }}" class="space-y-6" novalidate aria-labelledby="signin-heading">
-                        {# Email field #}
-                        <div>
-                            <label for="username" class="block text-sm font-medium text-gray-700 mb-2">
-                                {{ "form.email"|trans }}
-                                <span class="text-red-500 ml-1" aria-label="required">*</span>
-                            </label>
-                            <input
-                                type="email"
-                                id="username"
-                                name="_username"
-                                value="{{ last_username }}"
-                                autocomplete="username email"
-                                required
-                                autofocus
-                                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors duration-200{% if error %} border-red-300{% endif %}"
-                                aria-describedby="username-help{% if error %} username-error{% endif %}"
-                                {% if error %}aria-invalid="true"{% endif %}
-                            >
-                            <p id="username-help" class="mt-1 text-xs text-gray-500">
-                                {{ "form.email-help"|trans }}
-                            </p>
-                        </div>
+{% block step_description %}
+    <p class="text-gray-600">
+        {{ "form.signin-subtitle"|trans }}
+    </p>
+{% endblock %}
 
-                        {# Password field #}
-                        <div>
-                            <label for="password" class="block text-sm font-medium text-gray-700 mb-2">
-                                {{ "form.password"|trans }}
-                                <span class="text-red-500 ml-1" aria-label="required">*</span>
-                            </label>
-                            <input
-                                type="password"
-                                id="password"
-                                name="_password"
-                                autocomplete="current-password"
-                                required
-                                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors duration-200{% if error %} border-red-300{% endif %}"
-                                aria-describedby="password-help{% if error %} password-error{% endif %}"
-                                {% if error %}aria-invalid="true"{% endif %}
-                            >
-                            <p id="password-help" class="mt-1 text-xs text-gray-500">
-                                {{ "form.password-help"|trans }}
-                            </p>
-                        </div>
-
-                        {# CSRF token #}
-                        <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
-
-                        {# Remember me and forgot password #}
-                        <div class="flex items-center justify-between">
-                            <div class="flex items-center">
-                                <input
-                                    id="remember-me"
-                                    name="_remember_me"
-                                    type="checkbox"
-                                    class="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
-                                >
-                                <label for="remember-me" class="ml-2 block text-sm text-gray-700">
-                                    {{ "form.remember-me"|trans }}
-                                </label>
-                            </div>
-
-                            <div class="text-sm">
-                                <a href="{{ path('recovery') }}" class="text-blue-600 hover:text-blue-500 focus:outline-none focus:underline transition-colors duration-200">
-                                    {{ "form.recovery-link"|trans }}
-                                </a>
-                            </div>
-                        </div>
-
-                        {# Submit button #}
-                        <div>
-                            <button
-                                type="submit"
-                                class="w-full px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                                {{ "form.signin"|trans }}
-                            </button>
-                        </div>
-                    </form>
-                </div>
-
-                {# Footer section with registration link #}
-                <div class="px-6 py-4 sm:px-8 sm:py-6 bg-gray-50 border-t border-gray-100">
-                    <p class="text-center text-sm text-gray-600">
-                        {{ "form.no-account"|trans }}
-                        <a href="{{ path('register') }}" class="font-medium text-blue-600 hover:text-blue-500 focus:outline-none focus:underline transition-colors duration-200 ml-1">
-                            {{ "form.create-account"|trans }}
-                        </a>
-                    </p>
+{% block step_content %}
+    {# Error message with improved accessibility #}
+    {% if error %}
+        <div class="mb-6 p-4 rounded-lg bg-red-50 border border-red-200" role="alert" aria-live="polite">
+            <div class="flex items-start">
+                <svg class="w-5 h-5 text-red-400 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                </svg>
+                <div>
+                    <h3 class="text-sm font-medium text-red-800 mb-1">{{ "form.auth-failed"|trans }}</h3>
+                    <p class="text-sm text-red-700">{{ error.message|trans }}</p>
                 </div>
             </div>
         </div>
+    {% endif %}
+
+    {# Login form with semantic HTML and accessibility features #}
+    <form method="post" action="{{ path('login') }}" class="space-y-6" novalidate aria-labelledby="signin-heading">
+        {# Email field #}
+        <div>
+            <label for="username" class="block text-sm font-medium text-gray-700 mb-2">
+                {{ "form.email"|trans }}
+                <span class="text-red-500 ml-1" aria-label="required">*</span>
+            </label>
+            <input
+                type="email"
+                id="username"
+                name="_username"
+                value="{{ last_username }}"
+                autocomplete="username email"
+                required
+                autofocus
+                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors duration-200{% if error %} border-red-300{% endif %}"
+                aria-describedby="username-help{% if error %} username-error{% endif %}"
+                {% if error %}aria-invalid="true"{% endif %}
+            >
+            <p id="username-help" class="mt-1 text-xs text-gray-500">
+                {{ "form.email-help"|trans }}
+            </p>
+        </div>
+
+        {# Password field #}
+        <div>
+            <label for="password" class="block text-sm font-medium text-gray-700 mb-2">
+                {{ "form.password"|trans }}
+                <span class="text-red-500 ml-1" aria-label="required">*</span>
+            </label>
+            <input
+                type="password"
+                id="password"
+                name="_password"
+                autocomplete="current-password"
+                required
+                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors duration-200{% if error %} border-red-300{% endif %}"
+                aria-describedby="password-help{% if error %} password-error{% endif %}"
+                {% if error %}aria-invalid="true"{% endif %}
+            >
+            <p id="password-help" class="mt-1 text-xs text-gray-500">
+                {{ "form.password-help"|trans }}
+            </p>
+        </div>
+
+        {# CSRF token #}
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
+
+        {# Remember me and forgot password #}
+        <div class="flex items-center justify-between">
+            <div class="flex items-center">
+                <input
+                    id="remember-me"
+                    name="_remember_me"
+                    type="checkbox"
+                    class="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                >
+                <label for="remember-me" class="ml-2 block text-sm text-gray-700">
+                    {{ "form.remember-me"|trans }}
+                </label>
+            </div>
+
+            <div class="text-sm">
+                <a href="{{ path('recovery') }}" class="text-blue-600 hover:text-blue-500 focus:outline-none focus:underline transition-colors duration-200">
+                    {{ "form.recovery-link"|trans }}
+                </a>
+            </div>
+        </div>
+
+        {# Submit button #}
+        <div>
+            <button
+                type="submit"
+                class="w-full px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+                {{ "form.signin"|trans }}
+            </button>
+        </div>
+    </form>
+{% endblock %}
+
+{% block step_footer %}
+    <div class="mt-6 pt-6 border-t border-gray-100">
+        <p class="text-center text-sm text-gray-600">
+            {{ "form.no-account"|trans }}
+            <a href="{{ path('register') }}" class="font-medium text-blue-600 hover:text-blue-500 focus:outline-none focus:underline transition-colors duration-200 ml-1">
+                {{ "form.create-account"|trans }}
+            </a>
+        </p>
     </div>
 {% endblock %}

--- a/templates/base_step.html.twig
+++ b/templates/base_step.html.twig
@@ -3,24 +3,30 @@
 {% block content %}
     <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">
         <div class="max-w-lg mx-auto px-4">
-            <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 sm:p-8">
-                {# Optional icon section #}
-                <div class="flex justify-center mb-6">
-                    {% block step_icon %}{% endblock %}
-                </div>
+            <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+                {# Main content section #}
+                <div class="p-6 sm:p-8">
+                    {# Optional icon section #}
+                    <div class="flex justify-center mb-6">
+                        {% block step_icon %}{% endblock %}
+                    </div>
 
-                {# Step header #}
-                <div class="text-center mb-8">
-                    <h1 class="text-xl sm:text-2xl font-bold text-gray-900 mb-2">
-                        {% block step_title %}{% endblock %}
-                    </h1>
-                    {% block step_description %}
-                        {# Optional description that child templates can override #}
-                    {% endblock %}
-                </div>
+                    {# Step header #}
+                    <div class="text-center mb-8">
+                        <h1 class="text-xl sm:text-2xl font-bold text-gray-900 mb-2">
+                            {% block step_title %}{% endblock %}
+                        </h1>
+                        {% block step_description %}
+                            {# Optional description that child templates can override #}
+                        {% endblock %}
+                    </div>
 
-                {# Step content #}
-                {% block step_content %}{% endblock %}
+                    {# Step content #}
+                    {% block step_content %}{% endblock %}
+
+                    {# Optional footer content within main section #}
+                    {% block step_footer %}{% endblock %}
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This pull request refactors the `2fa_form.html.twig` and `login.html.twig` templates to improve structure, accessibility, and user experience. It introduces a new base template, `base_step.html.twig`, to standardize layout and styling for step-based forms. Key changes include replacing the previous base templates, enhancing accessibility features, and optimizing CSS classes for consistency.

### Refactoring templates for step-based forms:
* [`templates/Security/2fa_form.html.twig`](diffhunk://#diff-b0cddefe5f71134463ae560ad5e9c92dd231cbd24e24de1182f76252afd07ccbL1-L28): Switched to `base_step.html.twig` for layout, added blocks for `step_icon`, `step_title`, and `step_description`, and improved accessibility with `aria-describedby` and `aria-invalid` attributes. [[1]](diffhunk://#diff-b0cddefe5f71134463ae560ad5e9c92dd231cbd24e24de1182f76252afd07ccbL1-L28) [[2]](diffhunk://#diff-b0cddefe5f71134463ae560ad5e9c92dd231cbd24e24de1182f76252afd07ccbL37-L45) [[3]](diffhunk://#diff-b0cddefe5f71134463ae560ad5e9c92dd231cbd24e24de1182f76252afd07ccbL55-L68)
* [`templates/Security/login.html.twig`](diffhunk://#diff-db718921b23b2198f7acf061375c7e528ff8317fc50080708ef2a93c3ec70e83L1-R22): Updated to use `base_step.html.twig`, added blocks for `step_icon`, `step_title`, `step_description`, and `step_footer`, and improved error message accessibility. [[1]](diffhunk://#diff-db718921b23b2198f7acf061375c7e528ff8317fc50080708ef2a93c3ec70e83L1-R22) [[2]](diffhunk://#diff-db718921b23b2198f7acf061375c7e528ff8317fc50080708ef2a93c3ec70e83L124-L137)

### Introducing `base_step.html.twig`:
* [`templates/base_step.html.twig`](diffhunk://#diff-538cbe8e1d392d04e304fb203c110eb6d242fb30640a6081c79bc637d0529108L6-R8): Created a new base template to standardize the layout and styling for step-based forms, including sections for icons, titles, content, and optional footers. [[1]](diffhunk://#diff-538cbe8e1d392d04e304fb203c110eb6d242fb30640a6081c79bc637d0529108L6-R8) [[2]](diffhunk://#diff-538cbe8e1d392d04e304fb203c110eb6d242fb30640a6081c79bc637d0529108R26-R29)