### PR TITLE
🐛 Fix UserAdmin

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -200,6 +200,7 @@ services:
       - [setDomainGuesser, ['@App\Guesser\DomainGuesser']]
       - [setMailCryptKeyHandler, ['@App\Handler\MailCryptKeyHandler']]
       - [setMailCryptVar, ["%env(MAIL_CRYPT)%"]]
+      - [setSecurity, ['@Symfony\Bundle\SecurityBundle\Security']]
 
   userli.admin.domain:
     class: App\Admin\DomainAdmin

--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -17,6 +17,7 @@ use Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter;
 use Sonata\Form\Type\BooleanType;
 use Sonata\Form\Type\DateRangePickerType;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -30,6 +31,7 @@ class UserAdmin extends Admin
     private PasswordUpdater $passwordUpdater;
     private MailCryptKeyHandler $mailCryptKeyHandler;
     private readonly MailCrypt $mailCrypt;
+    private readonly Security $security;
 
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
@@ -219,5 +221,10 @@ class UserAdmin extends Admin
     public function setMailCryptVar(string $mailCrypt): void
     {
         $this->mailCrypt = MailCrypt::from((int) $mailCrypt);
+    }
+
+    public function setSecurity(Security $security): void
+    {
+        $this->security = $security;
     }
 }


### PR DESCRIPTION
This pull request introduces a new dependency on Symfony's `Security` component and integrates it into the `UserAdmin` class. The changes involve updating service definitions, adding the `Security` dependency to the class, and providing a setter method for it.

### Integration of Symfony Security Component:

* [`config/services.yaml`](diffhunk://#diff-c47b03734cd2b4337b345eeba955637ba790d51fd98979f6d366d4acbdb104e0R203): Added `setSecurity` method to the service definitions for dependency injection of the `Security` component.

* `src/Admin/UserAdmin.php`: 
  - Imported the `Security` class to make it available in the `UserAdmin` class.
  - Added a new `readonly Security $security` property to the `UserAdmin` class for storing the injected `Security` instance.
  - Introduced the `setSecurity(Security $security): void` method to allow dependency injection of the `Security` component.