### PR TITLE
♻️ Refactor AccountController

### DIFF
--- a/tests/Controller/AccountControllerTest.php
+++ b/tests/Controller/AccountControllerTest.php
@@ -57,7 +57,7 @@ class AccountControllerTest extends WebTestCase
 
         $client->submit($form);
 
-        $this->assertResponseIsSuccessful();
+        $this->assertResponseRedirects('/account');
     }
 
     public function testChangePasswordIdentical()


### PR DESCRIPTION
This pull request refactors the `AccountController` in `src/Controller/AccountController.php` to improve code organization and enhance functionality. Key changes include splitting the password change functionality into a dedicated route, simplifying form handling, and removing unnecessary dependencies.

### Refactoring and Code Organization:
* Renamed the `account` method to `show` and restricted its route to `GET` requests. This method now focuses solely on rendering the account page.
* Moved password change logic to a new `changePassword` method with its own route (`/account/password`) and restricted it to `POST` requests. This improves separation of concerns and makes the functionality more modular.

### Form Handling Improvements:
* Simplified form creation and submission handling by directly associating forms with their respective routes and removing redundant logic. For example, the password change form is now handled entirely within the `changePassword` method.

### Dependency Cleanup:
* Removed the unused `RedirectResponse` import, as the refactored methods no longer return redirect responses in certain cases.

### Other Enhancements:
* Updated the `deleteSubmit` method to return only `Response` instead of `RedirectResponse|Response`, aligning with the refactored logic.