### PR TITLE
♻️ Introduce UserPasswordUpdateHandler

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -118,14 +118,14 @@ services:
     arguments:
       $to: "%env(NOTIFICATION_ADDRESS)%"
 
-  App\Handler\UserRestoreHandler:
-    arguments:
-      $mailCryptEnv: "%env(MAIL_CRYPT)%"
-
   App\Handler\RegistrationHandler:
     public: true
     arguments:
       $registrationOpen: "%env(REGISTRATION_OPEN)%"
+
+  App\Handler\UserPasswordUpdateHandler:
+    public: true
+    arguments:
       $mailCrypt: "%env(MAIL_CRYPT)%"
 
   App\Handler\SuspiciousChildrenHandler:
@@ -196,10 +196,8 @@ services:
           controller: App\Controller\UserCRUDController,
         }
     calls:
-      - [setPasswordUpdater, ['@App\Helper\PasswordUpdater']]
       - [setDomainGuesser, ['@App\Guesser\DomainGuesser']]
-      - [setMailCryptKeyHandler, ['@App\Handler\MailCryptKeyHandler']]
-      - [setMailCryptVar, ["%env(MAIL_CRYPT)%"]]
+      - [setUserPasswordUpdateHandler, ['@App\Handler\UserPasswordUpdateHandler']]
       - [setSecurity, ['@Symfony\Bundle\SecurityBundle\Security']]
 
   userli.admin.domain:

--- a/src/Handler/RegistrationHandler.php
+++ b/src/Handler/RegistrationHandler.php
@@ -25,11 +25,9 @@ readonly class RegistrationHandler
         private EntityManagerInterface   $manager,
         private DomainGuesser            $domainGuesser,
         private EventDispatcherInterface $eventDispatcher,
-        private PasswordUpdater          $passwordUpdater,
-        private MailCryptKeyHandler      $mailCryptKeyHandler,
+        private UserPasswordUpdateHandler $userPasswordUpdateHandler,
         private RecoveryTokenHandler     $recoveryTokenHandler,
         private bool                     $registrationOpen,
-        private bool                     $mailCrypt
     )
     {
     }
@@ -46,11 +44,7 @@ readonly class RegistrationHandler
         // Create user
         $user = $this->buildUser($registration);
 
-        // Update password, generate MailCrypt keys, generate recovery token
-        // key material for mailCrypt is always generated, but only enabled if MAIL_CRYPT >= 2
-        $mailCryptEnable = $this->mailCrypt >= 2;
-        $this->passwordUpdater->updatePassword($user, $registration->getPlainPassword());
-        $this->mailCryptKeyHandler->create($user, $registration->getPlainPassword(), $mailCryptEnable);
+        $this->userPasswordUpdateHandler->updatePassword($user, $registration->getPlainPassword());
         $this->recoveryTokenHandler->create($user);
 
         // We used to erase sensitive data here, but it's now done in RegistrationController

--- a/src/Handler/UserPasswordUpdateHandler.php
+++ b/src/Handler/UserPasswordUpdateHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Handler;
+
+use App\Entity\User;
+use App\Enum\MailCrypt;
+use App\Helper\PasswordUpdater;
+use Doctrine\ORM\EntityManagerInterface;
+
+readonly class UserPasswordUpdateHandler
+{
+    public function __construct(
+        private EntityManagerInterface $manager,
+        private PasswordUpdater        $passwordUpdater,
+        private MailCryptKeyHandler    $mailCryptKeyHandler,
+        private int                    $mailCrypt
+    )
+    {
+    }
+
+    public function updatePassword(User $user, string $newPassword, ?string $oldPassword = null): void
+    {
+        $this->passwordUpdater->updatePassword($user, $newPassword);
+
+        // If the user has a MailCrypt secret box and an old password is provided,
+        // we update the MailCrypt keys using the old password.
+        // If the user does not have a MailCrypt secret box, we create new keys.
+        if ($user->hasMailCryptSecretBox() && $oldPassword !== null) {
+            $this->mailCryptKeyHandler->update($user, $oldPassword, $newPassword);
+        } else {
+            // Update password, generate MailCrypt keys,
+            // and create a new MailCrypt secret box if it doesn't exist.
+            $mailCryptEnable = $this->mailCrypt >= MailCrypt::ENABLED_ENFORCE_NEW_USERS;
+            $this->mailCryptKeyHandler->create($user, $newPassword, $mailCryptEnable);
+        }
+
+        $user->eraseCredentials();
+
+        $this->manager->flush();
+    }
+}

--- a/src/Handler/UserPasswordUpdateHandler.php
+++ b/src/Handler/UserPasswordUpdateHandler.php
@@ -34,8 +34,6 @@ readonly class UserPasswordUpdateHandler
             $this->mailCryptKeyHandler->create($user, $newPassword, $mailCryptEnable);
         }
 
-        $user->eraseCredentials();
-
         $this->manager->flush();
     }
 }

--- a/src/Handler/UserRestoreHandler.php
+++ b/src/Handler/UserRestoreHandler.php
@@ -3,41 +3,29 @@
 namespace App\Handler;
 
 use App\Entity\User;
-use App\Enum\MailCrypt;
 use App\Event\UserCreatedEvent;
-use App\Helper\PasswordUpdater;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 
-class UserRestoreHandler
+readonly class UserRestoreHandler
 {
-    private MailCrypt $mailCrypt;
-
     public function __construct(
-        private readonly EntityManagerInterface $manager,
-        private readonly PasswordUpdater $passwordUpdater,
-        private readonly MailCryptKeyHandler $mailCryptKeyHandler,
-        private readonly RecoveryTokenHandler $recoveryTokenHandler,
-        private readonly EventDispatcherInterface $eventDispatcher,
-        readonly int $mailCryptEnv,
-    ) {
-        $this->mailCrypt = MailCrypt::from($mailCryptEnv);
+        private EntityManagerInterface    $manager,
+        private UserPasswordUpdateHandler $userPasswordUpdateHandler,
+        private RecoveryTokenHandler      $recoveryTokenHandler,
+        private EventDispatcherInterface  $eventDispatcher,
+    )
+    {
     }
 
-    public function restoreUser(User $user, string $password): ?string {
+    public function restoreUser(User $user, string $password): ?string
+    {
         $user->setDeleted(false);
-        $this->passwordUpdater->updatePassword($user, $password);
+        $this->userPasswordUpdateHandler->updatePassword($user, $password);
 
         // Generate MailCrypt key with new password (overwrites old MailCrypt key)
-        $recoveryToken = null;
-        if ($this->mailCrypt->isAtLeast(MailCrypt::ENABLED_ENFORCE_NEW_USERS)) {
-            $this->mailCryptKeyHandler->create($user, $password, true);
-
-            // Reset recovery token
-            $this->recoveryTokenHandler->create($user);
-            $recoveryToken = $user->getPlainRecoveryToken();
-        }
-
+        $this->recoveryTokenHandler->create($user);
+        $recoveryToken = $user->getPlainRecoveryToken();
         // Clear sensitive plaintext data from User object
         $user->eraseCredentials();
 

--- a/src/Helper/AdminPasswordUpdater.php
+++ b/src/Helper/AdminPasswordUpdater.php
@@ -5,11 +5,15 @@ namespace App\Helper;
 use App\Entity\Domain;
 use App\Entity\User;
 use App\Enum\Roles;
+use App\Handler\UserPasswordUpdateHandler;
 use Doctrine\ORM\EntityManagerInterface;
 
-class AdminPasswordUpdater
+readonly class AdminPasswordUpdater
 {
-    public function __construct(private readonly EntityManagerInterface $manager, private readonly PasswordUpdater $updater)
+    public function __construct(
+        private EntityManagerInterface    $manager,
+        private UserPasswordUpdateHandler $userPasswordUpdateHandler
+    )
     {
     }
 
@@ -20,7 +24,7 @@ class AdminPasswordUpdater
     public function updateAdminPassword(string $password): void
     {
         $domain = $this->manager->getRepository(Domain::class)->getDefaultDomain();
-        $adminEmail = 'postmaster@'.$domain;
+        $adminEmail = 'postmaster@' . $domain;
         $admin = $this->manager->getRepository(User::class)->findByEmail($adminEmail);
         if (null === $admin) {
             // create admin user
@@ -29,7 +33,7 @@ class AdminPasswordUpdater
             $admin->setRoles([Roles::ADMIN]);
             $admin->setDomain($domain);
         }
-        $this->updater->updatePassword($admin, $password);
+        $this->userPasswordUpdateHandler->updatePassword($admin, $password);
         $this->manager->persist($admin);
         $this->manager->flush();
     }

--- a/tests/Command/UsersResetCommandTest.php
+++ b/tests/Command/UsersResetCommandTest.php
@@ -2,12 +2,11 @@
 
 namespace App\Tests\Command;
 
+use App\Handler\UserPasswordUpdateHandler;
 use Exception;
 use App\Command\UsersResetCommand;
 use App\Entity\User;
-use App\Handler\MailCryptKeyHandler;
 use App\Handler\RecoveryTokenHandler;
-use App\Helper\PasswordUpdater;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -39,11 +38,7 @@ class UsersResetCommandTest extends TestCase
             ->getMock();
         $manager->method('getRepository')->willReturn($repository);
 
-        $passwordUpdater = $this->getMockBuilder(PasswordUpdater::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mailCryptKeyHandler = $this->getMockBuilder(MailCryptKeyHandler::class)
+        $userPasswordUpdateHandler = $this->getMockBuilder(UserPasswordUpdateHandler::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -53,7 +48,7 @@ class UsersResetCommandTest extends TestCase
 
         $mailLocation = '/tmp/vmail';
 
-        $this->command = new UsersResetCommand($manager, $passwordUpdater, $mailCryptKeyHandler, $recoveryTokenHandler, $mailLocation);
+        $this->command = new UsersResetCommand($manager, $userPasswordUpdateHandler, $recoveryTokenHandler, $mailLocation);
     }
 
     public function testExecute(): void

--- a/tests/Controller/DovecotControllerTest.php
+++ b/tests/Controller/DovecotControllerTest.php
@@ -92,7 +92,7 @@ class DovecotControllerTest extends WebTestCase
         self::assertEquals($data['message'], 'success');
         self::assertEquals($data['body']['user'], 'user@example.org');
         self::assertEquals($data['body']['mailCrypt'], 0);
-        self::assertEquals($data['body']['mailCryptPublicKey'], "");
+        self::assertNotEmpty($data['body']['mailCryptPublicKey']);
         self::assertIsInt($data['body']['gid']);
         self::assertIsInt($data['body']['uid']);
         self::assertNotEquals($data['body']['home'], '');

--- a/tests/Handler/RegistrationHandlerTest.php
+++ b/tests/Handler/RegistrationHandlerTest.php
@@ -9,6 +9,7 @@ use App\Enum\Roles;
 use App\Event\Events;
 use App\Event\UserCreatedEvent;
 use App\Event\UserEvent;
+use App\Handler\UserPasswordUpdateHandler;
 use App\Repository\VoucherRepository;
 use Exception;
 use App\Form\Model\Registration;
@@ -29,8 +30,7 @@ class RegistrationHandlerTest extends KernelTestCase
             $this->createMock(EntityManagerInterface::class),
             $this->createMock(DomainGuesser::class),
             $this->createMock(EventDispatcherInterface::class),
-            $this->createMock(PasswordUpdater::class),
-            $this->createMock(MailCryptKeyHandler::class),
+            $this->createMock(UserPasswordUpdateHandler::class),
             $this->createMock(RecoveryTokenHandler::class),
             false,
             false
@@ -69,11 +69,9 @@ class RegistrationHandlerTest extends KernelTestCase
             $manager,
             $domainGuesser,
             $eventDispatcher,
-            $this->createMock(PasswordUpdater::class),
-            $this->createMock(MailCryptKeyHandler::class),
+            $this->createMock(UserPasswordUpdateHandler::class),
             $this->createMock(RecoveryTokenHandler::class),
-            true,
-            false
+            true
         );
 
         $registration = new Registration();

--- a/tests/Handler/UserPasswordUpdateHandlerTest.php
+++ b/tests/Handler/UserPasswordUpdateHandlerTest.php
@@ -44,8 +44,6 @@ class UserPasswordUpdateHandlerTest extends TestCase
         $user->expects($this->once())
             ->method('hasMailCryptSecretBox')
             ->willReturn(false);
-        $user->expects($this->once())
-            ->method('eraseCredentials');
 
         // Expect password update to be called
         $this->passwordUpdater
@@ -76,8 +74,6 @@ class UserPasswordUpdateHandlerTest extends TestCase
         $user->expects($this->once())
             ->method('hasMailCryptSecretBox')
             ->willReturn(true);
-        $user->expects($this->once())
-            ->method('eraseCredentials');
 
         // Expect password update to be called
         $this->passwordUpdater
@@ -107,8 +103,6 @@ class UserPasswordUpdateHandlerTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->never())
             ->method('hasMailCryptSecretBox');
-        $user->expects($this->never())
-            ->method('eraseCredentials');
 
         // Password updater throws exception
         $this->passwordUpdater
@@ -142,8 +136,6 @@ class UserPasswordUpdateHandlerTest extends TestCase
         $user->expects($this->once())
             ->method('hasMailCryptSecretBox')
             ->willReturn(true);
-        $user->expects($this->never())
-            ->method('eraseCredentials');
 
         // Password updater succeeds
         $this->passwordUpdater
@@ -192,9 +184,6 @@ class UserPasswordUpdateHandlerTest extends TestCase
             ->method('update')
             ->with($user, $oldPassword, $newPassword);
 
-        $user->expects($this->once())
-            ->method('eraseCredentials');
-
         $this->manager
             ->expects($this->once())
             ->method('flush');
@@ -211,7 +200,6 @@ class UserPasswordUpdateHandlerTest extends TestCase
     ): void {
         $user = $this->createMock(User::class);
         $user->method('hasMailCryptSecretBox')->willReturn(false);
-        $user->method('eraseCredentials');
 
         $this->passwordUpdater
             ->expects($this->once())

--- a/tests/Handler/UserPasswordUpdateHandlerTest.php
+++ b/tests/Handler/UserPasswordUpdateHandlerTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Handler;
+
+use App\Entity\User;
+use App\Enum\MailCrypt;
+use App\Handler\MailCryptKeyHandler;
+use App\Handler\UserPasswordUpdateHandler;
+use App\Helper\PasswordUpdater;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UserPasswordUpdateHandlerTest extends TestCase
+{
+    private UserPasswordUpdateHandler $handler;
+    private MockObject $manager;
+    private MockObject $passwordUpdater;
+    private MockObject $mailCryptKeyHandler;
+
+    protected function setUp(): void
+    {
+        $this->manager = $this->createMock(EntityManagerInterface::class);
+        $this->passwordUpdater = $this->createMock(PasswordUpdater::class);
+        $this->mailCryptKeyHandler = $this->createMock(MailCryptKeyHandler::class);
+
+        $this->handler = new UserPasswordUpdateHandler(
+            $this->manager,
+            $this->passwordUpdater,
+            $this->mailCryptKeyHandler,
+            2 // Assuming MailCrypt::ENABLED_ENFORCE_NEW_USERS is 2
+        );
+    }
+
+    public function testUpdatePasswordSuccessfully(): void
+    {
+        $newPassword = 'newSecurePassword123';
+        $oldPassword = 'oldPassword123';
+
+        // Mock user without mail crypt secret box
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('hasMailCryptSecretBox')
+            ->willReturn(false);
+        $user->expects($this->once())
+            ->method('eraseCredentials');
+
+        // Expect password update to be called
+        $this->passwordUpdater
+            ->expects($this->once())
+            ->method('updatePassword')
+            ->with($user, $newPassword);
+
+        // Mail crypt key handler should NOT be called
+        $this->mailCryptKeyHandler
+            ->expects($this->never())
+            ->method('update');
+
+        // Entity manager should flush
+        $this->manager
+            ->expects($this->once())
+            ->method('flush');
+
+        $this->handler->updatePassword($user, $newPassword, $oldPassword);
+    }
+
+    public function testUpdatePasswordWithMailCryptKey(): void
+    {
+        $newPassword = 'newSecurePassword123';
+        $oldPassword = 'oldPassword123';
+
+        // Mock user with mail crypt secret box
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('hasMailCryptSecretBox')
+            ->willReturn(true);
+        $user->expects($this->once())
+            ->method('eraseCredentials');
+
+        // Expect password update to be called
+        $this->passwordUpdater
+            ->expects($this->once())
+            ->method('updatePassword')
+            ->with($user, $newPassword);
+
+        // Mail crypt key handler SHOULD be called
+        $this->mailCryptKeyHandler
+            ->expects($this->once())
+            ->method('update')
+            ->with($user, $oldPassword, $newPassword);
+
+        // Entity manager should flush
+        $this->manager
+            ->expects($this->once())
+            ->method('flush');
+
+        $this->handler->updatePassword($user, $newPassword, $oldPassword);
+    }
+
+    public function testUpdatePasswordFailsWhenPasswordUpdaterThrows(): void
+    {
+        $newPassword = 'newSecurePassword123';
+        $oldPassword = 'oldPassword123';
+
+        $user = $this->createMock(User::class);
+        $user->expects($this->never())
+            ->method('hasMailCryptSecretBox');
+        $user->expects($this->never())
+            ->method('eraseCredentials');
+
+        // Password updater throws exception
+        $this->passwordUpdater
+            ->expects($this->once())
+            ->method('updatePassword')
+            ->with($user, $newPassword)
+            ->willThrowException(new \Exception('Password update failed'));
+
+        // Mail crypt key handler should NOT be called
+        $this->mailCryptKeyHandler
+            ->expects($this->never())
+            ->method('update');
+
+        // Entity manager should NOT flush
+        $this->manager
+            ->expects($this->never())
+            ->method('flush');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Password update failed');
+
+        $this->handler->updatePassword($user, $newPassword, $oldPassword);
+    }
+
+    public function testUpdatePasswordFailsWhenMailCryptKeyHandlerThrows(): void
+    {
+        $newPassword = 'newSecurePassword123';
+        $oldPassword = 'oldPassword123';
+
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('hasMailCryptSecretBox')
+            ->willReturn(true);
+        $user->expects($this->never())
+            ->method('eraseCredentials');
+
+        // Password updater succeeds
+        $this->passwordUpdater
+            ->expects($this->once())
+            ->method('updatePassword')
+            ->with($user, $newPassword);
+
+        // Mail crypt key handler throws exception
+        $this->mailCryptKeyHandler
+            ->expects($this->once())
+            ->method('update')
+            ->with($user, $oldPassword, $newPassword)
+            ->willThrowException(new \Exception('Mail crypt key update failed'));
+
+        // Entity manager should NOT flush
+        $this->manager
+            ->expects($this->never())
+            ->method('flush');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Mail crypt key update failed');
+
+        $this->handler->updatePassword($user, $newPassword, $oldPassword);
+    }
+
+    public function testUpdatePasswordCallsMethodsInCorrectOrder(): void
+    {
+        $newPassword = 'newSecurePassword123';
+        $oldPassword = 'oldPassword123';
+
+        $user = $this->createMock(User::class);
+
+        // Set up expectations for method call order
+        $user->expects($this->once())
+            ->method('hasMailCryptSecretBox')
+            ->willReturn(true);
+
+        // Create a sequence to verify call order
+        $this->passwordUpdater
+            ->expects($this->once())
+            ->method('updatePassword')
+            ->with($user, $newPassword);
+
+        $this->mailCryptKeyHandler
+            ->expects($this->once())
+            ->method('update')
+            ->with($user, $oldPassword, $newPassword);
+
+        $user->expects($this->once())
+            ->method('eraseCredentials');
+
+        $this->manager
+            ->expects($this->once())
+            ->method('flush');
+
+        $this->handler->updatePassword($user, $newPassword, $oldPassword);
+    }
+
+    /**
+     * @dataProvider passwordDataProvider
+     */
+    public function testUpdatePasswordWithVariousPasswordFormats(
+        string $newPassword,
+        string $oldPassword
+    ): void {
+        $user = $this->createMock(User::class);
+        $user->method('hasMailCryptSecretBox')->willReturn(false);
+        $user->method('eraseCredentials');
+
+        $this->passwordUpdater
+            ->expects($this->once())
+            ->method('updatePassword')
+            ->with($user, $newPassword);
+
+        $this->manager
+            ->expects($this->once())
+            ->method('flush');
+
+        $this->handler->updatePassword($user, $newPassword, $oldPassword);
+    }
+
+    public function passwordDataProvider(): array
+    {
+        return [
+            'simple passwords' => ['newPass123', 'oldPass123'],
+            'special characters' => ['N3w!P@ssw0rd$', 'Old!P@ssw0rd$'],
+            'unicode characters' => ['newPäßwörd123', 'oldPäßwörd123'],
+            'long passwords' => [
+                'ThisIsAVeryLongPasswordWithManyCharacters123!',
+                'ThisWasAnOldVeryLongPasswordWithManyCharacters456!'
+            ],
+            'empty old password' => ['newPassword123', ''],
+        ];
+    }
+}


### PR DESCRIPTION
This pull request introduces a major refactor to replace the `PasswordUpdater` and `MailCryptKeyHandler` with a new unified `UserPasswordUpdateHandler` class across the codebase. The refactor simplifies password update logic, consolidates responsibilities related to MailCrypt keys, and improves maintainability. Additionally, minor adjustments were made to tests and configurations to align with these changes.

### Refactor to unify password update logic:

* **Introduction of `UserPasswordUpdateHandler`:** Added a new `UserPasswordUpdateHandler` class to handle password updates and MailCrypt key management. This class encapsulates logic for updating passwords, generating MailCrypt keys, and flushing changes to the database. (`src/Handler/UserPasswordUpdateHandler.php`)

* **Replacement in `UserAdmin`:** Updated the `UserAdmin` class to use `UserPasswordUpdateHandler` instead of `PasswordUpdater` and `MailCryptKeyHandler`. This change simplifies methods like `prePersist` and `preUpdate`. (`src/Admin/UserAdmin.php`) [[1]](diffhunk://#diff-c0545377919eb8da2db959c0d034e26f324d15486e3f4c9b01f7de7d99f72343L8-R8) [[2]](diffhunk://#diff-c0545377919eb8da2db959c0d034e26f324d15486e3f4c9b01f7de7d99f72343L181-R180) [[3]](diffhunk://#diff-c0545377919eb8da2db959c0d034e26f324d15486e3f4c9b01f7de7d99f72343L201-R197)

* **Replacement in `UsersResetCommand`:** Refactored the `UsersResetCommand` class to use `UserPasswordUpdateHandler` for resetting user passwords and MailCrypt keys. (`src/Command/UsersResetCommand.php`) [[1]](diffhunk://#diff-58d106f69b6ca25df20faa64f8db9e1d86acac50c7c62f5a6e3e36832d62269fR5-L9) [[2]](diffhunk://#diff-58d106f69b6ca25df20faa64f8db9e1d86acac50c7c62f5a6e3e36832d62269fL96-R98)

* **Replacement in `AccountController`:** Updated the `AccountController` class to use `UserPasswordUpdateHandler` for password changes, removing direct interactions with `PasswordUpdater` and `MailCryptKeyHandler`. (`src/Controller/AccountController.php`) [[1]](diffhunk://#diff-8cc3de1e9a0fc9eb9c8e4ccd261693a7fbd18307d3365e7353e1e9ed0bd1bfd5L11-R11) [[2]](diffhunk://#diff-8cc3de1e9a0fc9eb9c8e4ccd261693a7fbd18307d3365e7353e1e9ed0bd1bfd5L55-R56)

### Configuration updates:

* **Service definitions:** Updated `services.yaml` to register the new `UserPasswordUpdateHandler` and remove references to `PasswordUpdater` and `MailCryptKeyHandler`. (`config/services.yaml`) [[1]](diffhunk://#diff-c47b03734cd2b4337b345eeba955637ba790d51fd98979f6d366d4acbdb104e0L121-R128) [[2]](diffhunk://#diff-c47b03734cd2b4337b345eeba955637ba790d51fd98979f6d366d4acbdb104e0L199-R200)

### Test adjustments:

* **Test updates:** Modified unit tests to replace mocks and dependencies for `PasswordUpdater` and `MailCryptKeyHandler` with `UserPasswordUpdateHandler`. (`tests/Command/UsersResetCommandTest.php`, `tests/Handler/RegistrationHandlerTest.php`) [[1]](diffhunk://#diff-10e01a63ac610a4ffecf162b46ac300a0b6d62a332aeb6b9ec19953a19a5ce98L42-R41) [[2]](diffhunk://#diff-6eecba4a85f0cea152d53e959f7b3178a61e8b0aa3545c6cab46fa83281a2e49L32-R33)

### Minor changes:

* **MailCrypt public key validation:** Adjusted a test in `DovecotControllerTest` to ensure the `mailCryptPublicKey` is not empty. (`tests/Controller/DovecotControllerTest.php`)