### PR TITLE
🐛 Store User to uploaded OpenPgpKey

### DIFF
--- a/src/Controller/OpenPGPController.php
+++ b/src/Controller/OpenPGPController.php
@@ -81,7 +81,7 @@ class OpenPGPController extends AbstractController
     private function importOpenPgpKey(User $user, string $key): void
     {
         try {
-            $this->wkdHandler->importKey($key, $user);
+            $this->wkdHandler->importKey($key, $user->getEmail(), $user);
             $this->addFlash('success', 'flashes.openpgp-key-upload-successful');
         } catch (NoGpgDataException) {
             $this->addFlash('error', 'flashes.openpgp-key-upload-error-no-openpgp');


### PR DESCRIPTION
This pull request includes a small but important change to the `importOpenPgpKey` method in `src/Controller/OpenPGPController.php`. The change modifies the `importKey` method call to include the user as an additional parameter, ensuring that the key import process has access to more specific user data.