### PR TITLE
Unify copy button behaviour

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -81,18 +81,81 @@ document.addEventListener("DOMContentLoaded", function () {
   // After the value has been copied, the textarea is removed from
   // DOM again.
   function copyToClipboard(event) {
-    let el = document.createElement("textarea");
+    const button = event.currentTarget;
+    const textToCopy = button.dataset.value;
 
-    el.value = event.currentTarget.dataset.value;
+    // Use modern clipboard API with fallback
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard
+        .writeText(textToCopy)
+        .then(function () {
+          showCopySuccess(button);
+        })
+        .catch(function (err) {
+          console.error("Copy failed:", err);
+          fallbackCopy(textToCopy);
+          showCopySuccess(button);
+        });
+    } else {
+      // Fallback for older browsers or non-secure contexts
+      fallbackCopy(textToCopy);
+      showCopySuccess(button);
+    }
+  }
+
+  function fallbackCopy(text) {
+    let el = document.createElement("textarea");
+    el.value = text;
     el.setAttribute("readonly", "");
     el.style.position = "absolute";
     el.style.left = "-9999px";
     document.body.appendChild(el);
     el.select();
-
     document.execCommand("copy");
-
     document.body.removeChild(el);
+  }
+
+  function showCopySuccess(button) {
+    // Store original content and update button to show success
+    const originalContent = button.innerHTML;
+    button.innerHTML = `<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path></svg>`;
+
+    // Add success styling
+    button.classList.add("text-green-600", "border-green-300", "bg-green-50");
+    const originalClasses = [];
+
+    // Store and remove original color classes
+    if (button.classList.contains("text-gray-700")) {
+      originalClasses.push("text-gray-700");
+      button.classList.remove("text-gray-700");
+    }
+    if (button.classList.contains("text-green-700")) {
+      originalClasses.push("text-green-700");
+      button.classList.remove("text-green-700");
+    }
+    if (button.classList.contains("bg-gray-100")) {
+      originalClasses.push("bg-gray-100");
+      button.classList.remove("bg-gray-100");
+    }
+    if (button.classList.contains("bg-white")) {
+      originalClasses.push("bg-white");
+      button.classList.remove("bg-white");
+    }
+    if (button.classList.contains("border-gray-300")) {
+      originalClasses.push("border-gray-300");
+      button.classList.remove("border-gray-300");
+    }
+
+    // Reset after 2 seconds
+    setTimeout(function () {
+      button.innerHTML = originalContent;
+      button.classList.remove(
+        "text-green-600",
+        "border-green-300",
+        "bg-green-50"
+      );
+      originalClasses.forEach((cls) => button.classList.add(cls));
+    }, 2000);
   }
 
   // Initialize tooltips (replacing Bootstrap's jQuery tooltip)

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -472,7 +472,3 @@ random-aliases.feature-privacy: "Perfekt für Online-Shopping und Registrierunge
 random-aliases.feature-deletable: "Können jederzeit gelöscht werden, wenn sie nicht mehr benötigt werden"
 random-aliases.limitation-random-name: "Zufällige Namen, die schwerer zu merken sind"
 random-aliases.management-hint: "<strong>Tipp:</strong> Lösche ungenutzte zufällige Aliasse, um Platz für neue zu schaffen."
-
-button:
-  copy: Kopieren
-  copied: Kopiert

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -315,7 +315,8 @@ recovery-token:
   unset:
     Du hast noch keinen Wiederherstellungscode gesetzt. Wir empfehlen dir dringend,
     jetzt einen zu erstellen.
-  created-headline: "Der folgende Wiederherstellungscode wurde für dich erstellt:"
+  created-headline: "Dein neuer Wiederherstellungscode"
+  created-subtitle: "Bitte kopiere und speicher dein Wiederherstellungscode sicher."
   created-info: >
     Mit dem Wiederherstellungscode kannst du jederzeit dein Passwort zurücksetzen,
     wenn du dieses vergessen hast. Notiere ihn dir und speichere ihn an einem sicheren

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -305,7 +305,8 @@ recovery-token:
   unset:
     You don't have a recovery token set yet. We strongly recommend to create
     one now.
-  created-headline: "The following recovery token got created for you:"
+  created-headline: "Your new recovery token"
+  created-subtitle: "Please copy and securely store this recovery token"
   created-info: >
     If you lost your password, the recovery token allows you to reset a new one.
     Write it down and store it at a secure place.

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -456,7 +456,3 @@ random-aliases.feature-privacy: "Perfect for online shopping and registrations"
 random-aliases.feature-deletable: "Can be deleted anytime when no longer needed"
 random-aliases.limitation-random-name: "Random names that are harder to remember"
 random-aliases.management-hint: "<strong>Tip:</strong> Delete unused random aliases to make room for new ones."
-
-button:
-  copy: Copy
-  copied: Copied

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -31,7 +31,7 @@ Feature: registration
     And I press "Submit"
 
     Then I should be on "/register"
-    And I should see text matching "The following recovery token got created for you"
+    And I should see text matching "Please copy and securely store this recovery token"
 
     When I am on "/logout"
     Then I should be on "/"

--- a/features/user.feature
+++ b/features/user.feature
@@ -176,7 +176,7 @@ Feature: User
       | recovery_token_password | asdasd |
     And I press "Create new recovery token"
 
-    Then I should see text matching "The following recovery token got created for you"
+    Then I should see text matching "Please copy and securely store this recovery token"
     And I fill in the following:
       | recovery_token_confirm_confirm | 1 |
     And I press "Continue"

--- a/templates/Account/recovery_token.html.twig
+++ b/templates/Account/recovery_token.html.twig
@@ -16,13 +16,28 @@
                         {% if recovery_token is defined %}
                             <!-- Token display -->
                             <div class="mb-6">
-                                <h2 class="text-xl font-semibold text-gray-900 mb-4">{{ "recovery-token.created-headline"|trans }}</h2>
-                                <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
-                                    <div class="flex items-start">
-                                        {{ ux_icon('heroicons:exclamation-triangle', {'class': 'w-5 h-5 text-yellow-400 mt-0.5 mr-3'}) }}
-                                        <div class="text-yellow-800 font-mono text-lg font-semibold break-all">
-                                            {{ recovery_token }}
-                                        </div>
+                                <div class="flex items-center mb-2">
+                                    <div class="w-10 h-10 bg-yellow-100 rounded-xl flex items-center justify-center mr-3">
+                                        {{ ux_icon('heroicons:exclamation-triangle', {'class': 'w-5 h-5 text-yellow-600'}) }}
+                                    </div>
+                                    <h3 class="text-lg font-semibold text-gray-900">
+                                        {{ "recovery-token.created-headline"|trans }}
+                                    </h3>
+                                </div>
+                                <p class="mb-3 text-sm text-gray-600">
+                                    {{ "recovery-token.created-subtitle"|trans }}
+                                </p>
+                                <div class="bg-white rounded border border-gray-200">
+                                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3">
+                                        <code class="text-sm font-mono text-gray-900 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>
+                                        <button type="button"
+                                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-gray-600 bg-gray-50 border border-gray-300 rounded-md hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
+                                                onclick="copyRecoveryToken('{{ recovery_token }}', this)"
+                                                title="{{ "copy-to-clipboard"|trans }}"
+                                                aria-label="{{ "copy-to-clipboard"|trans }}">
+                                            {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4 mr-1'}) }}
+                                            <span>{{ "button.copy"|trans }}</span>
+                                        </button>
                                     </div>
                                 </div>
                             </div>
@@ -121,4 +136,27 @@
             </div>
         </div>
     </div>
+
+    <script>
+        function copyRecoveryToken(text, button) {
+            navigator.clipboard.writeText(text).then(function() {
+                // Update button text temporarily to show success
+                const originalContent = button.innerHTML;
+                button.innerHTML = `
+                    {{ ux_icon('heroicons:check', {'class': 'w-4 h-4 mr-2'}) }}
+                    <span>{{ "button.copied"|trans }}</span>
+                `;
+                button.classList.add('text-green-600', 'border-green-300', 'bg-green-50');
+                button.classList.remove('text-gray-700', 'border-gray-300', 'bg-white');
+
+                setTimeout(function() {
+                    button.innerHTML = originalContent;
+                    button.classList.remove('text-green-600', 'border-green-300', 'bg-green-50');
+                    button.classList.add('text-gray-700', 'border-gray-300', 'bg-white');
+                }, 2000);
+            }).catch(function(err) {
+                console.error('{{ "error.copy-failed"|trans }}', err);
+            });
+        }
+    </script>
 {% endblock %}

--- a/templates/Account/recovery_token.html.twig
+++ b/templates/Account/recovery_token.html.twig
@@ -29,15 +29,14 @@
                                 </p>
                                 <div class="bg-white rounded border border-gray-200">
                                     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3">
-                                        <code class="text-sm font-mono text-gray-900 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>
-                                        <button type="button"
-                                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-gray-600 bg-gray-50 border border-gray-300 rounded-md hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
-                                                onclick="copyRecoveryToken('{{ recovery_token }}', this)"
-                                                title="{{ "copy-to-clipboard"|trans }}"
-                                                aria-label="{{ "copy-to-clipboard"|trans }}">
-                                            {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4 mr-1'}) }}
-                                            <span>{{ "button.copy"|trans }}</span>
-                                        </button>
+                                        <code class="font-stretch-semi-condensed text-sm font-mono text-gray-900 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>                                            <button type="button"
+                                                    class="inline-flex items-center p-2 text-xs font-medium text-gray-600 bg-gray-50 border border-gray-300 rounded-md hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
+                                                    data-button="copy-to-clipboard"
+                                                    data-value="{{ recovery_token }}"
+                                                    title="{{ "copy-to-clipboard"|trans }}"
+                                                    aria-label="{{ "copy-to-clipboard"|trans }}">
+                                                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
+                                            </button>
                                     </div>
                                 </div>
                             </div>
@@ -136,27 +135,4 @@
             </div>
         </div>
     </div>
-
-    <script>
-        function copyRecoveryToken(text, button) {
-            navigator.clipboard.writeText(text).then(function() {
-                // Update button text temporarily to show success
-                const originalContent = button.innerHTML;
-                button.innerHTML = `
-                    {{ ux_icon('heroicons:check', {'class': 'w-4 h-4 mr-2'}) }}
-                    <span>{{ "button.copied"|trans }}</span>
-                `;
-                button.classList.add('text-green-600', 'border-green-300', 'bg-green-50');
-                button.classList.remove('text-gray-700', 'border-gray-300', 'bg-white');
-
-                setTimeout(function() {
-                    button.innerHTML = originalContent;
-                    button.classList.remove('text-green-600', 'border-green-300', 'bg-green-50');
-                    button.classList.add('text-gray-700', 'border-gray-300', 'bg-white');
-                }, 2000);
-            }).catch(function(err) {
-                console.error('{{ "error.copy-failed"|trans }}', err);
-            });
-        }
-    </script>
 {% endblock %}

--- a/templates/Account/twofactor_backup_code_confirm.html.twig
+++ b/templates/Account/twofactor_backup_code_confirm.html.twig
@@ -32,11 +32,12 @@
                     <div class="bg-gray-50 border border-gray-200 rounded-lg p-6 mb-8">
                         <div class="mb-4 flex items-center justify-start">
                             <button type="button"
-                                    class="inline-flex items-center px-3 py-1 text-xs font-medium text-gray-600 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200"
-                                    onclick="copyBackupCodes()">
-                                {# Heroicon: clipboard #}
-                                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4 mr-1'}) }}
-                                <span>{{ "button.copy"|trans }}</span>
+                                    class="inline-flex items-center p-2 text-xs font-medium text-gray-600 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200"
+                                    data-button="copy-to-clipboard"
+                                    data-value="{% for key, value in user.totpBackupCodes %}{{ value }}{{ not loop.last ? '\n' : '' }}{% endfor %}"
+                                    title="{{ "copy-to-clipboard"|trans }}"
+                                    aria-label="{{ "copy-to-clipboard"|trans }}">
+                                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
                             </button>
                         </div>
                         <div class="grid grid-cols-2 gap-2 font-mono text-sm">
@@ -83,37 +84,4 @@
             </div>
         </div>
     </div>
-
-    <script>
-        function copyBackupCodes() {
-            // Collect all backup codes
-            const codes = [
-                {% for key, value in user.totpBackupCodes %}
-                    '{{ value }}'{{ not loop.last ? ',' : '' }}
-                {% endfor %}
-            ];
-
-            const codesText = codes.join('\n');
-            const button = event.target.closest('button');
-
-            navigator.clipboard.writeText(codesText).then(function() {
-                // Update button text temporarily to show success
-                const originalContent = button.innerHTML;
-                button.innerHTML = `
-                    {{ ux_icon('heroicons:check', {'class': 'w-4 h-4 mr-1'}) }}
-                    <span>{{ "button.copied"|trans }}</span>
-                `;
-                button.classList.add('text-green-600', 'border-green-300', 'bg-green-50');
-                button.classList.remove('text-gray-600', 'border-gray-300', 'bg-white');
-
-                setTimeout(function() {
-                    button.innerHTML = originalContent;
-                    button.classList.remove('text-green-600', 'border-green-300', 'bg-green-50');
-                    button.classList.add('text-gray-600', 'border-gray-300', 'bg-white');
-                }, 2000);
-            }).catch(function(err) {
-                console.error('{{ "error.copy-failed"|trans }}', err);
-            });
-        }
-    </script>
 {% endblock %}

--- a/templates/Account/twofactor_confirm.html.twig
+++ b/templates/Account/twofactor_confirm.html.twig
@@ -47,18 +47,20 @@
                                 </h3>
                             </div>
                             <button type="button"
-                                    class="inline-flex items-center px-3 py-1 text-xs font-medium text-gray-600 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200"
-                                    onclick="copyToClipboard('{{ user.totpSecret }}', this)">
-                                {# Heroicon: clipboard #}
-                                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4 mr-1'}) }}
-                                <span>{{ "button.copy"|trans }}</span>
+                                    class="inline-flex items-center p-2 text-xs font-medium text-gray-600 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200"
+                                    onclick="copyToClipboard('{{ user.totpSecret }}', this)"
+                                    data-button="copy-to-clipboard"
+                                    data-value="{{ user.totpSecret }}"
+                                    title="{{ "copy-to-clipboard"|trans }}"
+                                    aria-label="{{ "copy-to-clipboard"|trans }}">
+                                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
                             </button>
                         </div>
                         <p class="mb-3 text-sm text-gray-600">
                             {{ "account.twofactor.setup-key-description"|trans }}
                         </p>
                         <div class="bg-white p-3 rounded border border-gray-200">
-                            <code id="totp-secret" class="text-sm font-mono text-gray-900 break-all">{{ user.totpSecret }}</code>
+                            <code id="totp-secret" class="font-stretch-semi-condensed text-sm font-mono text-gray-900 break-all">{{ user.totpSecret }}</code>
                         </div>
                     </div>
 
@@ -99,27 +101,4 @@
             </div>
         </div>
     </div>
-
-    <script>
-        function copyToClipboard(text, button) {
-            navigator.clipboard.writeText(text).then(function() {
-                // Update button text temporarily to show success
-                const originalContent = button.innerHTML;
-                button.innerHTML = `
-                    {{ ux_icon('heroicons:check', {'class': 'w-4 h-4 mr-1'}) }}
-                    <span>{{ "button.copied"|trans }}</span>
-                `;
-                button.classList.add('text-green-600', 'border-green-300', 'bg-green-50');
-                button.classList.remove('text-gray-600', 'border-gray-300', 'bg-white');
-
-                setTimeout(function() {
-                    button.innerHTML = originalContent;
-                    button.classList.remove('text-green-600', 'border-green-300', 'bg-green-50');
-                    button.classList.add('text-gray-600', 'border-gray-300', 'bg-white');
-                }, 2000);
-            }).catch(function(err) {
-                console.error('{{ "error.copy-failed"|trans }}', err);
-            });
-        }
-    </script>
 {% endblock %}

--- a/templates/Alias/show.html.twig
+++ b/templates/Alias/show.html.twig
@@ -117,15 +117,14 @@
                                         <div class="flex items-center justify-between p-3 bg-gray-50 border border-gray-200 rounded-md gap-3">
                                             <span class="font-mono text-sm text-gray-900 truncate min-w-0 max-w-[calc(100%-80px)]" title="{{ alias.source }}">{{ alias.source }}</span>
                                             <button type="button"
-                                                    class="inline-flex items-center px-2 py-1 text-xs font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 transition-colors flex-shrink-0"
+                                                    class="inline-flex items-center p-2 text-xs font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 transition-colors flex-shrink-0"
                                                     data-button="copy-to-clipboard"
                                                     data-value="{{ alias.source }}"
                                                     title="{{ "copy-to-clipboard"|trans }}"
                                                     aria-label="{{ "copy-to-clipboard"|trans }}"
                                                     data-toggle="tooltip"
                                                     data-placement="top">
-                                                {{ ux_icon('heroicons:clipboard', {class: 'w-3 h-3 sm:mr-1'}) }}
-                                                <span class="hidden sm:inline">{{ "copy-to-clipboard"|trans }}</span>
+                                                {{ ux_icon('heroicons:clipboard', {class: 'w-4 h-4'}) }}
                                             </button>
                                         </div>
                                     {% endfor %}
@@ -221,22 +220,21 @@
                                             <span class="font-mono text-sm text-gray-900 truncate min-w-0 max-w-[calc(100%-120px)]" title="{{ alias.source }}">{{ alias.source }}</span>
                                             <div class="flex items-center space-x-2 flex-shrink-0">
                                                 <button type="button"
-                                                        class="inline-flex items-center px-2 py-1 text-xs font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 transition-colors"
+                                                        class="inline-flex items-center p-2 text-xs font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 transition-colors"
                                                         data-button="copy-to-clipboard"
                                                         data-value="{{ alias.source }}"
                                                         title="{{ "copy-to-clipboard"|trans }}"
                                                         aria-label="{{ "copy-to-clipboard"|trans }}"
                                                         data-toggle="tooltip"
                                                         data-placement="top">
-                                                {{ ux_icon('heroicons:clipboard', {'class': 'w-3 h-3 sm:mr-1'}) }}
-                                                    <span class="hidden sm:inline">{{ "copy-to-clipboard"|trans }}</span>
+                                                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
                                                 </button>
                                                 <a href="{{ url('alias_delete', {'id': alias.id}) }}"
                                                    class="inline-flex items-center px-2 py-1 text-xs font-medium text-red-700 bg-red-100 rounded hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-colors"
                                                    title="{{ "alias.delete"|trans }}"
                                                    data-toggle="tooltip"
                                                    data-placement="top">
-                                                    {{ ux_icon('heroicons:x-mark', {'class': 'w-3 h-3'}) }}
+                                                    {{ ux_icon('heroicons:x-mark', {'class': 'w-4 h-4'}) }}
                                                 </a>
                                             </div>
                                         </div>

--- a/templates/Recovery/show_recovery_token.html.twig
+++ b/templates/Recovery/show_recovery_token.html.twig
@@ -1,11 +1,18 @@
 <div class="mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4 text-center">{{ "recovery-token.created-headline"|trans }}</h2>
-    <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
-        <div class="flex items-start">
-            {{ ux_icon('heroicons:exclamation-triangle-solid', {'class': 'w-5 h-5 text-yellow-400 mt-0.5 mr-3 flex-shrink-0'}) }}
-            <div class="text-yellow-800 font-mono text-lg font-semibold break-all">
-                {{ recovery_token }}
-            </div>
+    <p class="mb-3 text-sm text-gray-600">
+        {{ "recovery-token.created-subtitle"|trans }}
+    </p>
+    <div class="bg-white rounded border border-gray-200">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3">
+            <code class="text-sm font-mono text-gray-900 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>
+            <button type="button"
+                    class="inline-flex items-center px-3 py-1 text-xs font-medium text-gray-600 bg-gray-50 border border-gray-300 rounded-md hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
+                    onclick="copyRecoveryToken('{{ recovery_token }}', this)"
+                    title="{{ "copy-to-clipboard"|trans }}"
+                    aria-label="{{ "copy-to-clipboard"|trans }}">
+                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4 mr-1'}) }}
+                <span>{{ "button.copy"|trans }}</span>
+            </button>
         </div>
     </div>
 </div>

--- a/templates/Recovery/show_recovery_token.html.twig
+++ b/templates/Recovery/show_recovery_token.html.twig
@@ -4,14 +4,14 @@
     </p>
     <div class="bg-white rounded border border-gray-200">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3">
-            <code class="text-sm font-mono text-gray-900 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>
+            <code class="font-stretch-semi-condensed text-sm font-mono text-gray-900 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>
             <button type="button"
-                    class="inline-flex items-center px-3 py-1 text-xs font-medium text-gray-600 bg-gray-50 border border-gray-300 rounded-md hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
-                    onclick="copyRecoveryToken('{{ recovery_token }}', this)"
+                    class="inline-flex items-center p-2 text-xs font-medium text-gray-600 bg-gray-50 border border-gray-300 rounded-md hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
+                    data-button="copy-to-clipboard"
+                    data-value="{{ recovery_token }}"
                     title="{{ "copy-to-clipboard"|trans }}"
                     aria-label="{{ "copy-to-clipboard"|trans }}">
-                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4 mr-1'}) }}
-                <span>{{ "button.copy"|trans }}</span>
+                {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
             </button>
         </div>
     </div>

--- a/templates/Registration/recovery_token.html.twig
+++ b/templates/Registration/recovery_token.html.twig
@@ -25,27 +25,4 @@
     <div class="mt-8">
         {% include 'Recovery/recovery_token_notes.html.twig' %}
     </div>
-
-    <script>
-        function copyRecoveryToken(text, button) {
-            navigator.clipboard.writeText(text).then(function() {
-                // Update button text temporarily to show success
-                const originalContent = button.innerHTML;
-                button.innerHTML = `
-                    {{ ux_icon('heroicons:check', {'class': 'w-4 h-4 mr-1'}) }}
-                    <span>{{ "button.copied"|trans }}</span>
-                `;
-                button.classList.add('text-green-600', 'border-green-300', 'bg-green-50');
-                button.classList.remove('text-gray-600', 'border-gray-300', 'bg-gray-50');
-
-                setTimeout(function() {
-                    button.innerHTML = originalContent;
-                    button.classList.remove('text-green-600', 'border-green-300', 'bg-green-50');
-                    button.classList.add('text-gray-600', 'border-gray-300', 'bg-gray-50');
-                }, 2000);
-            }).catch(function(err) {
-                console.error('{{ "error.copy-failed"|trans }}', err);
-            });
-        }
-    </script>
 {% endblock %}

--- a/templates/Registration/recovery_token.html.twig
+++ b/templates/Registration/recovery_token.html.twig
@@ -25,4 +25,27 @@
     <div class="mt-8">
         {% include 'Recovery/recovery_token_notes.html.twig' %}
     </div>
+
+    <script>
+        function copyRecoveryToken(text, button) {
+            navigator.clipboard.writeText(text).then(function() {
+                // Update button text temporarily to show success
+                const originalContent = button.innerHTML;
+                button.innerHTML = `
+                    {{ ux_icon('heroicons:check', {'class': 'w-4 h-4 mr-1'}) }}
+                    <span>{{ "button.copied"|trans }}</span>
+                `;
+                button.classList.add('text-green-600', 'border-green-300', 'bg-green-50');
+                button.classList.remove('text-gray-600', 'border-gray-300', 'bg-gray-50');
+
+                setTimeout(function() {
+                    button.innerHTML = originalContent;
+                    button.classList.remove('text-green-600', 'border-green-300', 'bg-green-50');
+                    button.classList.add('text-gray-600', 'border-gray-300', 'bg-gray-50');
+                }, 2000);
+            }).catch(function(err) {
+                console.error('{{ "error.copy-failed"|trans }}', err);
+            });
+        }
+    </script>
 {% endblock %}

--- a/templates/Voucher/show.html.twig
+++ b/templates/Voucher/show.html.twig
@@ -84,13 +84,12 @@
                                                         </p>
                                                     </div>
                                                     <button type="button"
-                                                            class="inline-flex items-center px-3 py-2 border border-green-300 rounded-lg text-sm font-medium text-green-700 bg-white hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors duration-200 cursor-pointer"
+                                                            class="inline-flex items-center p-2 border border-green-300 rounded-lg text-sm font-medium text-green-700 bg-white hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors duration-200 cursor-pointer"
                                                             title="{{ "copy-to-clipboard"|trans }}"
                                                             data-button="copy-to-clipboard"
                                                             data-value="{{ url('register_voucher', {'voucher': voucher.code}) }}"
                                                             aria-label="{{ "copy-to-clipboard"|trans }}">
-                                                        {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4 sm:mr-2'}) }}
-                                                        <span class="hidden sm:inline">{{ "copy-to-clipboard"|trans }}</span>
+                                                        {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
                                                     </button>
                                                 </div>
                                             </div>


### PR DESCRIPTION
I simplified the copy-to-clipboard button and make them use also for the recovery token. So it is consistant over the whole application. The button not showing the word "copy" because it breaks the recovery-token in different languages. So I decided to keep it simple.

<img width="2560" height="1824" alt="Screenshot 2025-07-15 at 16-15-09 example org - Wiederherstellungscode" src="https://github.com/user-attachments/assets/7ef024cc-abcd-46aa-8310-262a04e435b3" />
