### PR TITLE
🐛 Fix indicator if OpenPGP key exists

### DIFF
--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -14,6 +14,7 @@ use App\Form\UserDeleteType;
 use App\Handler\DeleteHandler;
 use App\Handler\MailCryptKeyHandler;
 use App\Handler\RecoveryTokenHandler;
+use App\Handler\WkdHandler;
 use App\Helper\PasswordUpdater;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
@@ -30,6 +31,7 @@ class AccountController extends AbstractController
         private readonly EntityManagerInterface $manager,
         private readonly DeleteHandler          $deleteHandler,
         private readonly RecoveryTokenHandler   $recoveryTokenHandler,
+        private readonly WkdHandler             $wkdHandler,
     )
     {
     }
@@ -39,11 +41,13 @@ class AccountController extends AbstractController
     {
         /** @var User $user */
         $user = $this->getUser();
+        $openPgpKey = $this->wkdHandler->getKey($user);
 
         return $this->render(
             'Account/show.html.twig',
             [
                 'user' => $user,
+                'openpgp_key' => $openPgpKey,
             ]
         );
     }

--- a/templates/Account/show.html.twig
+++ b/templates/Account/show.html.twig
@@ -123,7 +123,7 @@
                     </div>
                     <div class="flex-grow flex justify-center items-end">
                         <div class="flex-shrink-0">
-                            {% if user.hasOpenPgpKeys %}
+                            {% if openpgp_key %}
                                 <div class="inline-flex items-center px-2 py-1 bg-green-100 text-green-800 text-xs font-medium rounded-full">
                                     {{ ux_icon('heroicons:check-circle-20-solid', {class: 'w-3 h-3 mr-1'}) }}
                                     {{ "account.openpgp.configured"|trans }}


### PR DESCRIPTION
We cannot use `user.hasOpenPgpKeys` in the template because the relation is not properly implemented. So we have to manually fetch the key.