### PR TITLE
💬 Adjust messages for no account

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -112,9 +112,9 @@ form:
   recovery-link: Passwort vergessen?
   auth-failed: Authentifizierung fehlgeschlagen
   errors-found: Bitte korrigiere die folgenden Fehler
-  no-account: Noch kein Konto?
+  no-account: Du hast ein Einladungscode?
   have-account: Bereits ein Konto?
-  create-account: Hier erstellen
+  create-account: Account erstellen
   roles: Rollen
   submit: Senden
   voucher: Einladungscode

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -111,9 +111,9 @@ form:
   recovery-link: Password forgotten?
   auth-failed: Authentication failed
   errors-found: Please correct the following errors
-  no-account: Don't have an account?
+  no-account: You have an invite code?
   have-account: Already have an account?
-  create-account: Create one here
+  create-account: Register here
   roles: Roles
   submit: Submit
   voucher: Invite code

--- a/templates/Security/login.html.twig
+++ b/templates/Security/login.html.twig
@@ -113,12 +113,12 @@
 {% endblock %}
 
 {% block step_footer %}
-    <div class="mt-6 pt-6 border-t border-gray-100">
-        <p class="text-center text-sm text-gray-600">
-            {{ "form.no-account"|trans }}
-            <a href="{{ path('register') }}" class="font-medium text-blue-600 hover:text-blue-500 focus:outline-none focus:underline transition-colors duration-200 ml-1">
+    <div class="-mx-6 sm:-mx-8 -mb-6 sm:-mb-8 mt-8 px-6 py-4 sm:px-8 sm:py-6 bg-gray-50 border-t border-gray-100">
+        <div class="text-center text-sm">
+            <span class="text-gray-600">{{ "form.no-account"|trans }}</span>
+            <a href="{{ path('register') }}" class="font-medium text-blue-600 hover:text-blue-500 transition-colors duration-200 ml-1">
                 {{ "form.create-account"|trans }}
             </a>
-        </p>
+        </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
I adjusted the texts at the bottom of the login to better fit the project's purpose. I also adapted the footer layout from the registration template.

<img width="2560" height="1586" alt="grafik" src="https://github.com/user-attachments/assets/e022a5d4-31f2-472b-9c4f-9ea8a30fd421" />
