### PR TITLE
💄 Align primary button colors

### DIFF
--- a/templates/Alias/show.html.twig
+++ b/templates/Alias/show.html.twig
@@ -115,9 +115,9 @@
                                     <h3 class="text-sm font-medium text-gray-700 mb-3">{{ "index.alias-active-custom"|trans }}</h3>
                                     {% for alias in aliases_custom %}
                                         <div class="flex items-center justify-between p-3 bg-gray-50 border border-gray-200 rounded-md gap-3">
-                                            <span class="font-mono text-sm text-gray-900 truncate min-w-0 max-w-[calc(100%-80px)]" title="{{ alias.source }}">{{ alias.source }}</span>
+                                            <span class="font-mono text-sm text-gray-900 truncate min-w-0 flex-1 font-stretch-semi-condensed" title="{{ alias.source }}">{{ alias.source }}</span>
                                             <button type="button"
-                                                    class="inline-flex items-center p-2 text-xs font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 transition-colors flex-shrink-0"
+                                                    class="inline-flex items-center p-2 text-gray-700 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 transition-colors flex-shrink-0"
                                                     data-button="copy-to-clipboard"
                                                     data-value="{{ alias.source }}"
                                                     title="{{ "copy-to-clipboard"|trans }}"
@@ -137,8 +137,8 @@
                     <div class="bg-white rounded-2xl border border-gray-200 shadow-sm hover:shadow-md transition-shadow duration-200">
                         <div class="p-6 sm:p-8">
                             <div class="flex items-center mb-6">
-                                <div class="w-12 h-12 bg-green-100 rounded-xl flex items-center justify-center mr-4">
-                                    {{ ux_icon('heroicons:arrow-path', {class: 'w-6 h-6 text-green-600'}) }}
+                                <div class="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mr-4">
+                                    {{ ux_icon('heroicons:arrow-path', {class: 'w-6 h-6 text-blue-600'}) }}
                                 </div>
                                 <div>
                                     <h3 class="text-xl font-semibold text-gray-900">{{ "random-aliases.title"|trans }}</h3>
@@ -183,7 +183,7 @@
                                     </label>
                                     {{ form_widget(random_alias_form.submit, {
                                         'attr': {
-                                            'class': 'w-full px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors'
+                                            'class': 'w-full px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors'
                                         }
                                     }) }}
                                 </div>
@@ -217,10 +217,10 @@
                                     <h3 class="text-sm font-medium text-gray-700 mb-3">{{ "index.alias-active-random"|trans }}</h3>
                                     {% for alias in aliases_random %}
                                         <div class="flex items-center justify-between p-3 bg-gray-50 border border-gray-200 rounded-md gap-3">
-                                            <span class="font-mono text-sm text-gray-900 truncate min-w-0 max-w-[calc(100%-120px)]" title="{{ alias.source }}">{{ alias.source }}</span>
+                                            <span class="font-mono text-sm text-gray-900 truncate min-w-0 flex-1 font-stretch-semi-condensed" title="{{ alias.source }}">{{ alias.source }}</span>
                                             <div class="flex items-center space-x-2 flex-shrink-0">
                                                 <button type="button"
-                                                        class="inline-flex items-center p-2 text-xs font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 transition-colors"
+                                                        class="inline-flex items-center p-2 text-gray-700 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 transition-colors"
                                                         data-button="copy-to-clipboard"
                                                         data-value="{{ alias.source }}"
                                                         title="{{ "copy-to-clipboard"|trans }}"
@@ -230,7 +230,7 @@
                                                 {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
                                                 </button>
                                                 <a href="{{ url('alias_delete', {'id': alias.id}) }}"
-                                                   class="inline-flex items-center px-2 py-1 text-xs font-medium text-red-700 bg-red-100 rounded hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-colors"
+                                                   class="inline-flex items-center p-2 text-red-700 bg-red-100 rounded hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-colors"
                                                    title="{{ "alias.delete"|trans }}"
                                                    data-toggle="tooltip"
                                                    data-placement="top">

--- a/templates/Start/index_anonymous.html.twig
+++ b/templates/Start/index_anonymous.html.twig
@@ -35,8 +35,8 @@
                     {# Login form section #}
                     <div class="bg-white rounded-xl border border-gray-200 shadow-sm p-6 sm:p-8">
                         <div class="flex items-center mb-6">
-                            <div class="w-10 h-10 bg-green-100 rounded-full flex items-center justify-center mr-4">
-                                {{ ux_icon('heroicons:arrow-left-end-on-rectangle', {'class': 'w-5 h-5 text-green-600'}) }}
+                            <div class="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center mr-4">
+                                {{ ux_icon('heroicons:arrow-left-end-on-rectangle', {'class': 'w-5 h-5 text-blue-600'}) }}
                             </div>
                             <h2 class="text-xl font-semibold text-gray-900">{{ "form.signin-header"|trans }}</h2>
                         </div>
@@ -73,7 +73,7 @@
 
                             <div class="pt-2">
                                 <button type="submit"
-                                        class="w-full px-5 py-3 bg-green-600 text-white font-medium rounded-lg hover:bg-green-700 focus:ring-4 focus:ring-green-300 focus:outline-none transition-colors duration-200">
+                                        class="w-full px-5 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 focus:outline-none transition-colors duration-200">
                                     {{ "form.signin"|trans }}
                                 </button>
                             </div>


### PR DESCRIPTION
Use a consistent color (blue) for primary buttons throughout the entire project. I also adjusted the alias list after we shrank the copy button, which has now created more space.

<img width="2560" height="1402" alt="grafik" src="https://github.com/user-attachments/assets/7aa63f32-9927-4490-9baa-c8767eb7cbde" />
