### PR TITLE
💄 Align password form information

### DIFF
--- a/templates/Account/password.html.twig
+++ b/templates/Account/password.html.twig
@@ -1,55 +1,54 @@
-{% extends 'base_page.html.twig' %}
+{% extends 'base_step.html.twig' %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 
 {% block title %}{{ domain }} - {{ "account.password.title"|trans }}{% endblock %}
 
-{% block page_title %}{{ "account.password.title"|trans }}{% endblock %}
+{% block step_icon %}
+    <div class="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center">
+        {{ ux_icon('heroicons:key', {'class': 'w-6 h-6 text-blue-600'}) }}
+    </div>
+{% endblock %}
 
-{% block page_subtitle %}{{ "account.password.subtitle"|trans }}{% endblock %}
+{% block step_title %}{{ "form.change-password"|trans }}{% endblock %}
 
-{% block page_content %}
-    <div class="max-w-2xl mx-auto">
-        <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-8">
-            <div class="flex items-center mb-6">
-                <div class="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mr-4">
-                    <!-- Heroicon: key -->
-                    {{ ux_icon('heroicons:key', {'class': 'w-6 h-6 text-blue-600'}) }}
-                </div>
-                <h2 class="text-xl font-semibold text-gray-900">{{ "form.change-password"|trans }}</h2>
+{% block step_description %}
+    <p class="text-gray-600">
+        {{ "account.password.subtitle"|trans }}
+    </p>
+{% endblock %}
+
+{% block step_content %}
+
+    <div class="mb-6 bg-amber-50 border border-amber-200 rounded-lg p-4">
+        <div class="flex items-start">
+            {{ ux_icon('heroicons:exclamation-triangle', {'class': 'w-5 h-5 text-amber-400 mt-0.5 mr-3 flex-shrink-0'}) }}
+            <div class="text-sm text-amber-700 leading-relaxed">
+                {{ "account.password.help"|trans|safe_html }}
             </div>
-
-            <div class="mb-6 bg-amber-50 border border-amber-200 rounded-lg p-4">
-                <div class="flex items-start">
-                    {{ ux_icon('heroicons:exclamation-triangle', {'class': 'w-5 h-5 text-amber-400 mt-0.5 mr-3 flex-shrink-0'}) }}
-                    <div class="text-sm text-amber-700 leading-relaxed">
-                        {{ "account.password.help"|trans|safe_html }}
-                    </div>
-                </div>
-            </div>
-
-            {{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
-            {{ form_errors(form) }}
-
-            <div>
-                {{ form_label(form.password, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
-                {{ form_errors(form.password) }}
-                {{ form_widget(form.password) }}
-            </div>
-
-            <div class="space-y-4">
-                {{ form_label(form.newPassword.first, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
-                {{ form_errors(form.newPassword.first) }}
-                {{ form_widget(form.newPassword.first) }}
-
-                {{ form_label(form.newPassword.second, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2 mt-4'}}) }}
-                {{ form_widget(form.newPassword.second) }}
-            </div>
-
-            <div class="pt-4 flex items-center justify-between">
-                {{ form_widget(form.submit) }}
-            </div>
-            {{ form_end(form) }}
         </div>
     </div>
+
+    {{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
+    {{ form_errors(form) }}
+
+    <div>
+        {{ form_label(form.password, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
+        {{ form_errors(form.password) }}
+        {{ form_widget(form.password) }}
+    </div>
+
+    <div class="space-y-4">
+        {{ form_label(form.newPassword.first, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
+        {{ form_errors(form.newPassword.first) }}
+        {{ form_widget(form.newPassword.first) }}
+
+        {{ form_label(form.newPassword.second, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2 mt-4'}}) }}
+        {{ form_widget(form.newPassword.second) }}
+    </div>
+
+    <div class="pt-4 flex items-center justify-between">
+        {{ form_widget(form.submit) }}
+    </div>
+    {{ form_end(form) }}
 {% endblock %}

--- a/templates/Account/password.html.twig
+++ b/templates/Account/password.html.twig
@@ -19,49 +19,37 @@
                 <h2 class="text-xl font-semibold text-gray-900">{{ "form.change-password"|trans }}</h2>
             </div>
 
+            <div class="mb-6 bg-amber-50 border border-amber-200 rounded-lg p-4">
+                <div class="flex items-start">
+                    {{ ux_icon('heroicons:exclamation-triangle', {'class': 'w-5 h-5 text-amber-400 mt-0.5 mr-3 flex-shrink-0'}) }}
+                    <div class="text-sm text-amber-700 leading-relaxed">
+                        {{ "account.password.help"|trans|safe_html }}
+                    </div>
+                </div>
+            </div>
+
             {{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
             {{ form_errors(form) }}
 
             <div>
                 {{ form_label(form.password, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
                 {{ form_errors(form.password) }}
-                {{ form_widget(form.password, {
-                    'attr': {
-                        'placeholder': 'Password'|trans
-                    }
-                }) }}
+                {{ form_widget(form.password) }}
             </div>
 
             <div class="space-y-4">
                 {{ form_label(form.newPassword.first, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
                 {{ form_errors(form.newPassword.first) }}
-                {{ form_widget(form.newPassword.first, {
-                    'attr': {
-                        'placeholder': 'New password'|trans
-                    }
-                }) }}
+                {{ form_widget(form.newPassword.first) }}
 
                 {{ form_label(form.newPassword.second, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2 mt-4'}}) }}
-                {{ form_widget(form.newPassword.second, {
-                    'attr': {
-                        'placeholder': 'Confirm new password'|trans
-                    }
-                }) }}
+                {{ form_widget(form.newPassword.second) }}
             </div>
 
             <div class="pt-4 flex items-center justify-between">
                 {{ form_widget(form.submit) }}
             </div>
             {{ form_end(form) }}
-
-            <div class="mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <div class="flex">
-                    {{ ux_icon('heroicons:information-circle-solid', {'class': 'w-5 h-5 text-blue-500 mt-0.5 mr-3'}) }}
-                    <div class="text-sm text-blue-700">
-                        {{ "account.password.help"|trans|safe_html }}
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Moved the password policy box over the form and changed the color to yellow. I also used the `base_step` layout to make it more consistent with other single/multi-step processes.

<img width="2560" height="1840" alt="grafik" src="https://github.com/user-attachments/assets/ad616c33-2aa9-41bc-8c89-2e710989388d" />
