### PR TITLE
🧑‍💻 Make APP_ENV flexible in container setup

### DIFF
--- a/.env
+++ b/.env
@@ -35,6 +35,7 @@ WKD_FORMAT="advanced"
 
 ###> symfony/framework-bundle ###
 APP_ENV="dev"
+APP_DEBUG="true"
 APP_SECRET="165e25e3846534bb4665d7078a851c0b"
 TRUSTED_PROXIES=""
 ###< symfony/framework-bundle ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: docker/userli/Dockerfile
     volumes:
       - ./docker/userli/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini:ro
+      - ./docker/userli/php-override.ini:/usr/local/etc/php/conf.d/override.ini:ro
       - ./:/var/www/html
     ports:
       - 8000:80

--- a/docker/userli/Dockerfile
+++ b/docker/userli/Dockerfile
@@ -25,8 +25,7 @@ RUN apt-get update && \
     docker-php-ext-configure intl && \
     docker-php-ext-install -j$(nproc) gd opcache pdo_mysql pdo_sqlite sodium zip intl && \
     pecl install xdebug && \
-    docker-php-ext-enable xdebug && \
-    echo "memory_limit = 512M" > /usr/local/etc/php/conf.d/memory_limit.ini
+    docker-php-ext-enable xdebug
 
 COPY --from=builder /var/www/html /var/www/html
 COPY docker/userli/apache.conf /etc/apache2/sites-available/000-default.conf

--- a/docker/userli/apache.conf
+++ b/docker/userli/apache.conf
@@ -4,6 +4,4 @@
     <Directory /var/www/html/public>
         AllowOverride All
     </Directory>
-
-    SetEnv APP_ENV dev
 </VirtualHost>

--- a/docker/userli/php-override.ini
+++ b/docker/userli/php-override.ini
@@ -1,0 +1,1 @@
+memory_limit = 512M


### PR DESCRIPTION
Sometimes (as you want to test error pages), you need to switch the APP_ENV to prod to test locally. This change makes it possible.