### PR TITLE
Improve navbar for edge cases

### DIFF
--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -92,61 +92,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // Mobile user dropdown functionality
-    const mobileUserMenu = document.getElementById('mobile-user-menu');
-    const mobileUserMenuButton = document.getElementById('mobile-user-menu-button');
-    const mobileUserMenuDropdown = document.getElementById('mobile-user-menu-dropdown');
-    const mobileUserMenuArrow = document.getElementById('mobile-user-menu-arrow');
-
-    if (mobileUserMenu && mobileUserMenuButton && mobileUserMenuDropdown && mobileUserMenuArrow) {
-        let isMobileUserMenuOpen = false;
-
-        function openMobileUserMenu() {
-            isMobileUserMenuOpen = true;
-            mobileUserMenuDropdown.classList.remove('opacity-0', 'scale-95', 'pointer-events-none');
-            mobileUserMenuDropdown.classList.add('opacity-100', 'scale-100');
-            mobileUserMenuArrow.classList.add('rotate-180');
-            mobileUserMenuButton.setAttribute('aria-expanded', 'true');
-        }
-
-        function closeMobileUserMenu() {
-            isMobileUserMenuOpen = false;
-            mobileUserMenuDropdown.classList.remove('opacity-100', 'scale-100');
-            mobileUserMenuDropdown.classList.add('opacity-0', 'scale-95', 'pointer-events-none');
-            mobileUserMenuArrow.classList.remove('rotate-180');
-            mobileUserMenuButton.setAttribute('aria-expanded', 'false');
-        }
-
-        function toggleMobileUserMenu() {
-            if (isMobileUserMenuOpen) {
-                closeMobileUserMenu();
-            } else {
-                openMobileUserMenu();
-            }
-        }
-
-        mobileUserMenuButton.addEventListener('click', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleMobileUserMenu();
-        });
-
-        // Close dropdown when clicking outside
-        document.addEventListener('click', function(e) {
-            if (!mobileUserMenu.contains(e.target)) {
-                closeMobileUserMenu();
-            }
-        });
-
-        // Close dropdown on escape key
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && isMobileUserMenuOpen) {
-                closeMobileUserMenu();
-                mobileUserMenuButton.focus();
-            }
-        });
-    }
-
     // Mobile menu functionality
     const mobileMenuButton = document.getElementById('mobile-menu-button');
     const mobileMenu = document.getElementById('mobile-menu');

--- a/templates/_navbar_mobile.html.twig
+++ b/templates/_navbar_mobile.html.twig
@@ -1,33 +1,71 @@
 {# Mobile menu, show/hide based on menu state (only on small screens) #}
 <div class="md:hidden hidden mt-3" id="mobile-menu">
-    <div class="bg-white/95 backdrop-blur-md rounded-3xl shadow-2xl ring-1 ring-black/10 p-4 space-y-2">
-        <a href="{{ path('start') }}"
-           class="block px-4 py-3 rounded-2xl text-base font-medium transition-all duration-300 {{ current_route == 'start' ? 'bg-gray-900 text-white shadow-lg' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900' }}">
-            {{ "navbar.home"|trans }}
-        </a>
+    <div class="bg-white/95 backdrop-blur-md rounded-3xl shadow-2xl ring-1 ring-black/10 divide-y divide-gray-100/50 max-h-[calc(100vh-8rem)] overflow-y-auto">
+        {# User Info Section #}
+        <div class="p-3 sm:p-4">
+            <div class="flex items-center space-x-3">
+                <div class="flex-shrink-0">
+                    {{ ux_icon('heroicons:user-solid', {class: 'w-6 h-6 sm:w-8 sm:h-8 text-gray-500'}) }}
+                </div>
+                <div class="min-w-0 flex-1">
+                    <div class="font-semibold text-gray-900 break-all text-xs sm:text-sm leading-4 sm:leading-5">{{ app.user.email }}</div>
+                    <div class="text-xs text-gray-500">{{ "navbar.signed-in-as"|trans }}</div>
+                </div>
+            </div>
+        </div>
 
-        {% if app.user.domain == domain and not is_granted('ROLE_SUSPICIOUS') %}
-            <a href="{{ path('vouchers') }}"
-               class="block px-4 py-3 rounded-2xl text-base font-medium transition-all duration-300 {{ current_route == 'vouchers' ? 'bg-gray-900 text-white shadow-lg' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900' }}">
-                {{ "navbar.vouchers"|trans }}
+        {# Main Navigation #}
+        <div class="p-3 sm:p-4 space-y-1 sm:space-y-2">
+            <a href="{{ path('start') }}"
+               class="flex items-center px-3 sm:px-4 py-2 sm:py-3 rounded-2xl text-sm sm:text-base font-medium transition-all duration-300 {{ current_route == 'start' ? 'bg-gray-900 text-white shadow-lg' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900' }}">
+                {{ ux_icon('heroicons:home-solid', {class: 'w-4 h-4 sm:w-5 sm:h-5 mr-3 flex-shrink-0'}) }}
+                {{ "navbar.home"|trans }}
             </a>
-        {% endif %}
 
-        <a href="{{ path('aliases') }}"
-           class="block px-4 py-3 rounded-2xl text-base font-medium transition-all duration-300 {{ current_route == 'aliases' ? 'bg-gray-900 text-white shadow-lg' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900' }}">
-            {{ "navbar.aliases"|trans }}
-        </a>
+            {% if app.user.domain == domain and not is_granted('ROLE_SUSPICIOUS') %}
+                <a href="{{ path('vouchers') }}"
+                   class="flex items-center px-3 sm:px-4 py-2 sm:py-3 rounded-2xl text-sm sm:text-base font-medium transition-all duration-300 {{ current_route == 'vouchers' ? 'bg-gray-900 text-white shadow-lg' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900' }}">
+                    {{ ux_icon('heroicons:ticket-solid', {class: 'w-4 h-4 sm:w-5 sm:h-5 mr-3 flex-shrink-0'}) }}
+                    {{ "navbar.vouchers"|trans }}
+                </a>
+            {% endif %}
 
-        <a href="{{ path('account') }}"
-           class="block px-4 py-3 rounded-2xl text-base font-medium transition-all duration-300 {{ current_route == 'account' ? 'bg-gray-900 text-white shadow-lg' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900' }}">
-            {{ "navbar.account"|trans }}
-        </a>
-
-        {% if is_granted('ROLE_ADMIN') %}
-            <a href="{{ path('sonata_admin_dashboard') }}"
-               class="block px-4 py-3 rounded-2xl text-base font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-all duration-300">
-                {{ "navbar_right.admin"|trans }}
+            <a href="{{ path('aliases') }}"
+               class="flex items-center px-3 sm:px-4 py-2 sm:py-3 rounded-2xl text-sm sm:text-base font-medium transition-all duration-300 {{ current_route == 'aliases' ? 'bg-gray-900 text-white shadow-lg' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900' }}">
+                {{ ux_icon('heroicons:at-symbol', {class: 'w-4 h-4 sm:w-5 sm:h-5 mr-3 flex-shrink-0'}) }}
+                {{ "navbar.aliases"|trans }}
             </a>
-        {% endif %}
+
+            <a href="{{ path('account') }}"
+               class="flex items-center px-3 sm:px-4 py-2 sm:py-3 rounded-2xl text-sm sm:text-base font-medium transition-all duration-300 {{ current_route == 'account' ? 'bg-gray-900 text-white shadow-lg' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900' }}">
+                {{ ux_icon('heroicons:cog-6-tooth-solid', {class: 'w-4 h-4 sm:w-5 sm:h-5 mr-3 flex-shrink-0'}) }}
+                {{ "navbar.account"|trans }}
+            </a>
+
+            {% if is_granted('ROLE_ADMIN') %}
+                <a href="{{ path('sonata_admin_dashboard') }}"
+                   class="flex items-center px-3 sm:px-4 py-2 sm:py-3 rounded-2xl text-sm sm:text-base font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-all duration-300">
+                    {{ ux_icon('heroicons:shield-check-solid', {class: 'w-4 h-4 sm:w-5 sm:h-5 mr-3 flex-shrink-0'}) }}
+                    {{ "navbar_right.admin"|trans }}
+                </a>
+            {% endif %}
+        </div>
+
+        {# Language Switcher Section #}
+        <div class="p-3 sm:p-4">
+            <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2 sm:mb-3">
+                {{ "navbar.language"|trans }}
+            </div>
+            {% include '_locale_switcher.html.twig' with {'dropdown_mode': true} %}
+        </div>
+
+        {# Logout Section #}
+        <div class="p-3 sm:p-4">
+            <a href="{{ path('logout') }}"
+               class="flex items-center px-3 sm:px-4 py-2 sm:py-3 rounded-2xl text-sm sm:text-base font-medium text-red-600 hover:bg-red-50 hover:text-red-700 transition-all duration-300">
+                {{ ux_icon('heroicons:arrow-right-on-rectangle', {class: 'w-4 h-4 sm:w-5 sm:h-5 mr-3 flex-shrink-0'}) }}
+                {{ "navbar_right.logout"|trans }}
+            </a>
+        </div>
     </div>
 </div>

--- a/templates/_navbar_tablet.html.twig
+++ b/templates/_navbar_tablet.html.twig
@@ -1,42 +1,47 @@
-{# Tablet navigation with icons only (md to xl screens) #}
+{# Tablet navigation with icons and text labels (md to xl screens) #}
 <div class="hidden md:flex xl:hidden flex-1 items-center justify-center">
-    <div class="flex items-center space-x-0.5">
+    <div class="flex items-center space-x-1">
         {# Home #}
         <a href="{{ path('start') }}"
-           class="flex items-center justify-center px-2 py-2 rounded-2xl text-sm font-medium transition-all duration-300 hover:scale-105 {{ current_route == 'start' ? 'bg-white/20 text-white shadow-lg' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}"
+           class="flex items-center justify-center px-2 md:px-3 py-2 rounded-2xl text-sm font-medium transition-all duration-300 hover:scale-105 {{ current_route == 'start' ? 'bg-white/20 text-white shadow-lg' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}"
            title="{{ "navbar.home"|trans }}">
-            {{ ux_icon('heroicons:home-solid', {'class': 'w-4 h-4 flex-shrink-0'}) }}
+            {{ ux_icon('heroicons:home-solid', {'class': 'w-4 h-4 mr-1 flex-shrink-0'}) }}
+            <span class="text-xs md:text-sm">{{ "navbar.home"|trans }}</span>
         </a>
 
         {# Einladungscodes (only for eligible users) #}
         {% if app.user.domain == domain and not is_granted('ROLE_SUSPICIOUS') %}
             <a href="{{ path('vouchers') }}"
-               class="flex items-center justify-center px-2 py-2 rounded-2xl text-sm font-medium transition-all duration-300 hover:scale-105 {{ current_route == 'vouchers' ? 'bg-white/20 text-white shadow-lg' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}"
+               class="flex items-center justify-center px-2 md:px-3 py-2 rounded-2xl text-sm font-medium transition-all duration-300 hover:scale-105 {{ current_route == 'vouchers' ? 'bg-white/20 text-white shadow-lg' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}"
                title="{{ "navbar.vouchers"|trans }}">
-                {{ ux_icon('heroicons:plus-solid', {'class': 'w-4 h-4 flex-shrink-0'}) }}
+                {{ ux_icon('heroicons:ticket-solid', {'class': 'w-4 h-4 mr-1 flex-shrink-0'}) }}
+                <span class="text-xs md:text-sm">{{ "navbar.vouchers"|trans }}</span>
             </a>
         {% endif %}
 
         {# Aliases #}
         <a href="{{ path('aliases') }}"
-           class="flex items-center justify-center px-2 py-2 rounded-2xl text-sm font-medium transition-all duration-300 hover:scale-105 {{ current_route == 'aliases' ? 'bg-white/20 text-white shadow-lg' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}"
+           class="flex items-center justify-center px-2 md:px-3 py-2 rounded-2xl text-sm font-medium transition-all duration-300 hover:scale-105 {{ current_route == 'aliases' ? 'bg-white/20 text-white shadow-lg' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}"
            title="{{ "navbar.aliases"|trans }}">
-            {{ ux_icon('heroicons:at-symbol', {'class': 'w-4 h-4 flex-shrink-0'}) }}
+            {{ ux_icon('heroicons:at-symbol', {'class': 'w-4 h-4 mr-1 flex-shrink-0'}) }}
+            <span class="text-xs md:text-sm">{{ "navbar.aliases"|trans }}</span>
         </a>
 
         {# Konto #}
         <a href="{{ path('account') }}"
-           class="flex items-center justify-center px-2 py-2 rounded-2xl text-sm font-medium transition-all duration-300 hover:scale-105 {{ current_route == 'account' ? 'bg-white/20 text-white shadow-lg' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}"
+           class="flex items-center justify-center px-2 md:px-3 py-2 rounded-2xl text-sm font-medium transition-all duration-300 hover:scale-105 {{ current_route == 'account' ? 'bg-white/20 text-white shadow-lg' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}"
            title="{{ "navbar.account"|trans }}">
-            {{ ux_icon('heroicons:cog-solid', {'class': 'w-4 h-4 flex-shrink-0'}) }}
+            {{ ux_icon('heroicons:cog-6-tooth-solid', {'class': 'w-4 h-4 mr-1 flex-shrink-0'}) }}
+            <span class="text-xs md:text-sm">{{ "navbar.account"|trans }}</span>
         </a>
 
         {# Admin Link (if user has admin rights) #}
         {% if is_granted('ROLE_ADMIN') %}
             <a href="{{ path('sonata_admin_dashboard') }}"
-               class="flex items-center justify-center px-2 py-2 rounded-2xl text-sm font-medium text-gray-300 hover:bg-white/10 hover:text-white transition-all duration-300 hover:scale-105"
+               class="flex items-center justify-center px-2 md:px-3 py-2 rounded-2xl text-sm font-medium text-gray-300 hover:bg-white/10 hover:text-white transition-all duration-300 hover:scale-105"
                title="{{ "navbar_right.admin"|trans }}">
-                {{ ux_icon('heroicons:shield-check-solid', {'class': 'w-4 h-4 flex-shrink-0'}) }}
+                {{ ux_icon('heroicons:shield-check-solid', {'class': 'w-4 h-4 mr-1 flex-shrink-0'}) }}
+                <span class="text-xs md:text-sm">{{ "navbar_right.admin"|trans }}</span>
             </a>
         {% endif %}
     </div>

--- a/templates/_navbar_user_menu.html.twig
+++ b/templates/_navbar_user_menu.html.twig
@@ -48,56 +48,8 @@
             </div>
         </div>
 
-        {# Mobile: User dropdown + Menu button (only on small screens) #}
-        <div class="md:hidden flex items-center space-x-2">
-            {# Mobile User Dropdown #}
-            <div class="relative" id="mobile-user-menu">
-                <button type="button"
-                        class="bg-white/10 hover:bg-white/20 flex text-sm rounded-2xl focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-transparent transition-all duration-300 hover:scale-105 backdrop-blur-sm"
-                        id="mobile-user-menu-button"
-                        aria-expanded="false"
-                        aria-haspopup="true">
-                    <span class="sr-only">{{ "navbar.open-user-menu"|trans }}</span>
-                    <div class="flex items-center px-2 py-1 space-x-1">
-                        {{ ux_icon('heroicons:user-solid', {class: 'w-4 h-4 text-gray-300'}) }}
-                        {{ ux_icon('heroicons:chevron-down', {class: 'w-3 h-3 text-gray-300 transition-transform duration-200', id: 'mobile-user-menu-arrow'}) }}
-                    </div>
-                </button>
-
-                {# Mobile Dropdown menu #}
-                <div class="absolute right-0 z-50 mt-3 w-72 sm:w-80 origin-top-right bg-white/95 backdrop-blur-md rounded-3xl shadow-2xl ring-1 ring-black/10 divide-y divide-gray-100/50 focus:outline-none opacity-0 scale-95 pointer-events-none transition-all duration-300"
-                     id="mobile-user-menu-dropdown"
-                     role="menu"
-                     aria-orientation="vertical"
-                     aria-labelledby="mobile-user-menu-button">
-                    <div class="py-2" role="none">
-                        <div class="px-5 py-3 text-sm text-gray-700 border-b border-gray-100/50">
-                            <div class="font-semibold break-all text-sm leading-5">{{ app.user.email }}</div>
-                            <div class="text-xs text-gray-500 mt-1">{{ "navbar.signed-in-as"|trans }}</div>
-                        </div>
-                    </div>
-
-                    {# Language Switcher Section #}
-                    <div class="py-2" role="none">
-                        <div class="px-5 py-3 border-b border-gray-100/50">
-                            <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-                                {{ "navbar.language"|trans }}
-                            </div>
-                            {% include '_locale_switcher.html.twig' with {'dropdown_mode': true} %}
-                        </div>
-                    </div>
-
-                    <div class="py-2" role="none">
-                        <a href="{{ path('logout') }}"
-                           class="group flex items-center px-5 py-3 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900 transition-all duration-300 rounded-2xl mx-2"
-                           role="menuitem">
-                            {{ ux_icon('heroicons:arrow-right-on-rectangle', {class: 'w-4 h-4 mr-3 text-gray-400 group-hover:text-gray-500'}) }}
-                            {{ "navbar_right.logout"|trans }}
-                        </a>
-                    </div>
-                </div>
-            </div>
-
+        {# Mobile: Only hamburger menu button (only on small screens) #}
+        <div class="md:hidden flex items-center">
             {# Mobile menu button #}
             <button type="button"
                     class="bg-white/10 hover:bg-white/20 inline-flex items-center justify-center p-2 rounded-2xl text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/50 transition-all duration-300 hover:scale-105 backdrop-blur-sm"

--- a/templates/_navbar_user_menu.html.twig
+++ b/templates/_navbar_user_menu.html.twig
@@ -4,27 +4,27 @@
         {# User Dropdown - Visible on md screens and up #}
         <div class="hidden md:block relative" id="user-menu">
             <button type="button"
-                    class="bg-white/10 hover:bg-white/20 flex text-sm rounded-2xl focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-transparent transition-all duration-300 hover:scale-105 backdrop-blur-sm"
+                    class="bg-white/10 hover:bg-white/20 flex text-sm rounded-2xl focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-transparent transition-all duration-300 hover:scale-105 backdrop-blur-sm max-w-xs"
                     id="user-menu-button"
                     aria-expanded="false"
                     aria-haspopup="true">
                 <span class="sr-only">{{ "navbar.open-user-menu"|trans }}</span>
-                <div class="flex items-center px-2 lg:px-3 py-2 space-x-2">
-                    {{ ux_icon('heroicons:user-solid', {class: 'w-5 h-5 text-gray-300'}) }}
-                    <span class="text-gray-300 text-sm font-medium hidden lg:block">{{ app.user.email }}</span>
-                    {{ ux_icon('heroicons:chevron-down', {class: 'w-4 h-4 text-gray-300 transition-transform duration-200', id: 'user-menu-arrow'}) }}
+                <div class="flex items-center px-2 lg:px-3 py-2 space-x-2 min-w-0">
+                    {{ ux_icon('heroicons:user-solid', {class: 'w-5 h-5 text-gray-300 flex-shrink-0'}) }}
+                    <span class="text-gray-300 text-sm font-medium hidden lg:block truncate min-w-0" title="{{ app.user.email }}">{{ app.user.email }}</span>
+                    {{ ux_icon('heroicons:chevron-down', {class: 'w-4 h-4 text-gray-300 transition-transform duration-200 flex-shrink-0', id: 'user-menu-arrow'}) }}
                 </div>
             </button>
 
             {# Dropdown menu #}
-            <div class="absolute right-0 z-50 mt-3 w-56 origin-top-right bg-white/95 backdrop-blur-md rounded-3xl shadow-2xl ring-1 ring-black/10 divide-y divide-gray-100/50 focus:outline-none opacity-0 scale-95 pointer-events-none transition-all duration-300"
+            <div class="absolute right-0 z-50 mt-3 w-72 sm:w-80 origin-top-right bg-white/95 backdrop-blur-md rounded-3xl shadow-2xl ring-1 ring-black/10 divide-y divide-gray-100/50 focus:outline-none opacity-0 scale-95 pointer-events-none transition-all duration-300"
                  id="user-menu-dropdown"
                  role="menu"
                  aria-orientation="vertical"
                  aria-labelledby="user-menu-button">
                 <div class="py-2" role="none">
                     <div class="px-5 py-3 text-sm text-gray-700 border-b border-gray-100/50">
-                        <div class="font-semibold">{{ app.user.email }}</div>
+                        <div class="font-semibold break-all text-sm leading-5">{{ app.user.email }}</div>
                         <div class="text-xs text-gray-500 mt-1">{{ "navbar.signed-in-as"|trans }}</div>
                     </div>
                 </div>
@@ -65,14 +65,14 @@
                 </button>
 
                 {# Mobile Dropdown menu #}
-                <div class="absolute right-0 z-50 mt-3 w-56 origin-top-right bg-white/95 backdrop-blur-md rounded-3xl shadow-2xl ring-1 ring-black/10 divide-y divide-gray-100/50 focus:outline-none opacity-0 scale-95 pointer-events-none transition-all duration-300"
+                <div class="absolute right-0 z-50 mt-3 w-72 sm:w-80 origin-top-right bg-white/95 backdrop-blur-md rounded-3xl shadow-2xl ring-1 ring-black/10 divide-y divide-gray-100/50 focus:outline-none opacity-0 scale-95 pointer-events-none transition-all duration-300"
                      id="mobile-user-menu-dropdown"
                      role="menu"
                      aria-orientation="vertical"
                      aria-labelledby="mobile-user-menu-button">
                     <div class="py-2" role="none">
                         <div class="px-5 py-3 text-sm text-gray-700 border-b border-gray-100/50">
-                            <div class="font-semibold">{{ app.user.email }}</div>
+                            <div class="font-semibold break-all text-sm leading-5">{{ app.user.email }}</div>
                             <div class="text-xs text-gray-500 mt-1">{{ "navbar.signed-in-as"|trans }}</div>
                         </div>
                     </div>


### PR DESCRIPTION
The navbar has been improved for really long email addresses and on small screens (smartphones). On smartphones, the menu is unified into a single menu with a dropdown. Also, on tablets, the menu titles are now shown.

<img width="1640" height="2360" alt="grafik" src="https://github.com/user-attachments/assets/780ec49b-e0df-459f-8ef5-19553b6954fa" />

<img width="390" alt="grafik" src="https://github.com/user-attachments/assets/2c914a97-a3d9-44fc-b716-94e9e8e1e324" />

<img width="390" alt="grafik" src="https://github.com/user-attachments/assets/3b5e8f5c-8046-474f-b911-fc7fa0ca68e7" />
