### PR TITLE
Fix: Show admin menu for domain admins

### DIFF
--- a/templates/_navbar_desktop.html.twig
+++ b/templates/_navbar_desktop.html.twig
@@ -36,7 +36,7 @@
         </a>
 
         {# Admin Link (if user has admin rights) #}
-        {% if is_granted('ROLE_ADMIN') %}
+        {% if is_granted('ROLE_DOMAIN_ADMIN') %}
             <a href="{{ path('sonata_admin_dashboard') }}"
                class="flex items-center justify-center px-3 xl:px-4 py-2 rounded-2xl text-sm font-medium text-gray-300 hover:bg-white/10 hover:text-white transition-all duration-300 hover:scale-105"
                title="{{ "navbar_right.admin"|trans }}">

--- a/templates/_navbar_mobile.html.twig
+++ b/templates/_navbar_mobile.html.twig
@@ -42,7 +42,7 @@
                 {{ "navbar.account"|trans }}
             </a>
 
-            {% if is_granted('ROLE_ADMIN') %}
+            {% if is_granted('ROLE_DOMAIN_ADMIN') %}
                 <a href="{{ path('sonata_admin_dashboard') }}"
                    class="flex items-center px-3 sm:px-4 py-2 sm:py-3 rounded-2xl text-sm sm:text-base font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-all duration-300">
                     {{ ux_icon('heroicons:shield-check-solid', {class: 'w-4 h-4 sm:w-5 sm:h-5 mr-3 flex-shrink-0'}) }}

--- a/templates/_navbar_tablet.html.twig
+++ b/templates/_navbar_tablet.html.twig
@@ -36,7 +36,7 @@
         </a>
 
         {# Admin Link (if user has admin rights) #}
-        {% if is_granted('ROLE_ADMIN') %}
+        {% if is_granted('ROLE_DOMAIN_ADMIN') %}
             <a href="{{ path('sonata_admin_dashboard') }}"
                class="flex items-center justify-center px-2 md:px-3 py-2 rounded-2xl text-sm font-medium text-gray-300 hover:bg-white/10 hover:text-white transition-all duration-300 hover:scale-105"
                title="{{ "navbar_right.admin"|trans }}">


### PR DESCRIPTION
Since the UI update users with the _DOMAIN_ADMIN_ role can't access the admin dashboard because the permission is bound to the _ADMIN_ role.