### PR TITLE
✨ Implement role hierarchy and reachable roles functionality

### DIFF
--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -56,8 +56,14 @@ class UserAdmin extends Admin
      */
     protected function configureFormFields(FormMapper $form): void
     {
+        /** @var User $currentUser */
+        $currentUser = $this->security->getUser();
         $user = $this->getRoot()->getSubject();
         $userId = $user->getId();
+
+        // Determine which roles the current user is allowed to assign
+        $availableRoles = Roles::getReachableRoles($currentUser?->getRoles() ?? []);
+        $availableRoleChoices = array_combine($availableRoles, $availableRoles) ?: [];
 
         $form
             ->add('email', EmailType::class, ['disabled' => !$this->isNewObject()])
@@ -76,7 +82,7 @@ class UserAdmin extends Admin
                 'help' => 'Can only be enabled by user',
             ])
             ->add('roles', ChoiceType::class, [
-                'choices' => [Roles::getAll()],
+                'choices' => $availableRoleChoices,
                 'multiple' => true,
                 'expanded' => false,
                 'label' => 'form.roles',

--- a/src/Enum/Roles.php
+++ b/src/Enum/Roles.php
@@ -1,25 +1,58 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Enum;
 
 final class Roles
 {
+    /**
+     * Role for users that should not be deleted (e.g. the main admin account).
+     */
     public const PERMANENT = 'ROLE_PERMANENT';
 
+    /**
+     * Role for users that can create voucher codes.
+     */
     public const MULTIPLIER = 'ROLE_MULTIPLIER';
 
+    /**
+     * Role for users that are marked as spammers and can't send emails.
+     */
     public const SPAM = 'ROLE_SPAM';
 
+    /**
+     * Role for users that are marked as suspicious and don't receive voucher codes.
+     */
     public const SUSPICIOUS = 'ROLE_SUSPICIOUS';
 
+    /**
+     * Basic role for all authenticated users.
+     */
     public const USER = 'ROLE_USER';
 
+    /**
+     * Role for users that can manage users within their domain.
+     */
     public const DOMAIN_ADMIN = 'ROLE_DOMAIN_ADMIN';
 
+    /**
+     * Role for users that can manage everything.
+     */
     public const ADMIN = 'ROLE_ADMIN';
 
-    public const KEYCLOAK = 'ROLE_KEYCLOAK';
-
+    /**
+     * Returns a canonical list of all defined roles.
+     *
+     * The array is associative and maps each role name to itself. This shape is convenient
+     * for Symfony's ChoiceType (choices: [label => value]) and for simple existence checks.
+     *
+     * Example consumer usage:
+     *   $choices = Roles::getAll();            // ['ROLE_USER' => 'ROLE_USER', ...]
+     *   $isKnown = isset($choices[$someRole]); // constant-time membership check
+     *
+     * @return array<string, string> Map of role => role
+     */
     public static function getAll(): array
     {
         return [
@@ -30,7 +63,65 @@ final class Roles
             self::USER => self::USER,
             self::DOMAIN_ADMIN => self::DOMAIN_ADMIN,
             self::ADMIN => self::ADMIN,
-            self::KEYCLOAK => self::KEYCLOAK,
+        ];
+    }
+
+    /**
+     * Returns all roles that are reachable (implied) from the given roles.
+     *
+     * If a provided role is not part of the defined hierarchy, it's ignored.
+     * This method performs a direct lookup in the hierarchy table and does not compute
+     * transitive closure dynamically. Duplicates are removed while preserving order
+     * of appearance.
+     *
+     * Examples:
+     *   Roles::getReachableRoles([Roles::ADMIN]);
+     *   // -> ['ROLE_ADMIN', 'ROLE_DOMAIN_ADMIN', 'ROLE_USER', 'ROLE_PERMANENT', 'ROLE_SPAM', 'ROLE_MULTIPLIER', 'ROLE_SUSPICIOUS']
+     *
+     *   Roles::getReachableRoles([Roles::DOMAIN_ADMIN, Roles::SPAM]);
+     *   // -> ['ROLE_USER', 'ROLE_PERMANENT']
+     *
+     * @param array<int, string> $roles List of role names
+     * @return string[] List of role names implied by any given role
+     */
+    public static function getReachableRoles(array $roles): array
+    {
+        $hierarchy = self::getRoleHierarchy();
+
+        $reachableMap = [];
+        foreach ($roles as $role) {
+            if (!isset($hierarchy[$role])) {
+                continue;
+            }
+
+            foreach ($hierarchy[$role] as $implied) {
+                $reachableMap[$implied] = true;
+            }
+        }
+
+        return array_keys($reachableMap);
+    }
+
+    /**
+     * Returns the role hierarchy used within the application.
+     *
+     * The array maps a "root" role to a list of roles that are considered reachable when
+     * a user has that root role. To simplify authorization checks, the lists may include
+     * the root role itself if desired (see ADMIN below).
+     *
+     * Expected shape:
+     *   [
+     *     'ROOT_ROLE' => ['ROLE_A', 'ROLE_B', ...],
+     *     // ...
+     *   ]
+     *
+     * @return array<string, string[]> Map of root role => list of reachable roles
+     */
+    public static function getRoleHierarchy(): array
+    {
+        return [
+            self::DOMAIN_ADMIN => [self::USER, self::PERMANENT],
+            self::ADMIN => [self::ADMIN, self::DOMAIN_ADMIN, self::USER, self::PERMANENT, self::SPAM, self::MULTIPLIER, self::SUSPICIOUS],
         ];
     }
 }

--- a/tests/Enum/RolesTest.php
+++ b/tests/Enum/RolesTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Tests\Enum;
+
+use App\Enum\Roles;
+use PHPUnit\Framework\TestCase;
+
+class RolesTest extends TestCase
+{
+    public function testReachableRolesForAdmin(): void
+    {
+        $reachable = Roles::getReachableRoles([Roles::ADMIN]);
+
+        $this->assertSame([
+            Roles::ADMIN,
+            Roles::DOMAIN_ADMIN,
+            Roles::USER,
+            Roles::PERMANENT,
+            Roles::SPAM,
+            Roles::MULTIPLIER,
+            Roles::SUSPICIOUS,
+        ], $reachable);
+    }
+
+    public function testReachableRolesForDomainAdmin(): void
+    {
+        $reachable = Roles::getReachableRoles([Roles::DOMAIN_ADMIN]);
+        $this->assertSame([
+            Roles::USER,
+            Roles::PERMANENT,
+        ], $reachable);
+    }
+
+    public function testReachableRolesEmptyInput(): void
+    {
+        $this->assertSame([], Roles::getReachableRoles([]));
+    }
+
+    public function testReachableRolesIgnoresUnknownRole(): void
+    {
+        $this->assertSame([], Roles::getReachableRoles(['ROLE_UNKNOWN']));
+    }
+
+    public function testReachableRolesNonRootRoleHasNoImplied(): void
+    {
+        // SPAM is not a root key in the hierarchy; expect none
+        $this->assertSame([], Roles::getReachableRoles([Roles::SPAM]));
+    }
+
+    public function testReachableRolesMergesAndDeduplicates(): void
+    {
+        // ADMIN already implies everything DOMAIN_ADMIN implies; expect ADMIN's list
+        $reachable = Roles::getReachableRoles([Roles::ADMIN, Roles::DOMAIN_ADMIN]);
+        $this->assertSame([
+            Roles::ADMIN,
+            Roles::DOMAIN_ADMIN,
+            Roles::USER,
+            Roles::PERMANENT,
+            Roles::SPAM,
+            Roles::MULTIPLIER,
+            Roles::SUSPICIOUS,
+        ], $reachable);
+    }
+}
+


### PR DESCRIPTION
This pull request improves the role management system by introducing a clear role hierarchy and ensuring that users can only assign roles they are permitted to manage. It adds utility methods to the `Roles` enum for determining assignable roles, updates the user admin form to respect these permissions, and introduces comprehensive tests to verify the new logic.

**Related**

- #432