### PR TITLE
🔒️ Use session instead of query to transport the new recovery token

### DIFF
--- a/src/Controller/RecoveryController.php
+++ b/src/Controller/RecoveryController.php
@@ -83,10 +83,11 @@ class RecoveryController extends AbstractController
                     // Recovery process is pending, but waiting period didn't elapse yet
                     $recoveryActiveTime = $recoveryStartTime->add(new DateInterval('P2D'));
                 } else {
+                    $this->addFlash('recoveryToken', $recoveryToken);
+
                     // Recovery process successful, go on with the form to reset password
                     return $this->redirectToRoute('recovery_reset_password', [
                         'email' => $email,
-                        'recoveryToken' => $recoveryToken,
                     ]);
                 }
 
@@ -107,7 +108,7 @@ class RecoveryController extends AbstractController
     public function recoveryResetPassword(Request $request): Response
     {
         $email = $request->query->get('email');
-        $recoveryToken = $request->query->get('recoveryToken');
+        $recoveryToken = $request->getSession()->getFlashBag()->get('recoveryToken')[0];
         if (null === $email || null === $recoveryToken) {
             throw new InvalidParameterException('Email and recoveryToken must be provided');
         }


### PR DESCRIPTION
This pull request updates the password recovery flow in `RecoveryController.php` to improve security and user experience by changing how the recovery token is passed between requests. Instead of passing the token as a query parameter, it is now stored in a flash session.

**Password Recovery Flow Improvements:**

* The recovery token is now added to the session flash bag instead of being sent as a query parameter when redirecting to the password reset form.
* The password reset form now retrieves the recovery token from the session flash bag, rather than from the query string, reducing exposure of sensitive data in URLs.