### PR TITLE
♻️ Use convention over configuration (Autowire)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -47,50 +47,14 @@ services:
       $appUrl: "%env(APP_URL)%"
       $projectName: "%env(PROJECT_NAME)%"
 
-  App\Command\UsersMailCryptCommand:
-    arguments:
-      $mailCrypt: "%env(MAIL_CRYPT)%"
-
-  App\Command\UsersRegistrationMailCommand:
-    arguments:
-      $defaultLocale: "%kernel.default_locale%"
-
-  App\Command\UsersRemoveCommand:
-    arguments:
-      $mailLocation: "%env(DOVECOT_MAIL_LOCATION)%"
-
-  App\Command\UsersResetCommand:
-    arguments:
-      $mailLocation: "%env(DOVECOT_MAIL_LOCATION)%"
-
   App\Command\VoucherCreateCommand:
     arguments:
       $appUrl: "%env(APP_URL)%"
-
-  App\Controller\DovecotController:
-    arguments:
-      $mailCryptEnv: "%env(MAIL_CRYPT)%"
-      $mailLocation: "%env(DOVECOT_MAIL_LOCATION)%"
-      $mailUid: "%env(DOVECOT_MAIL_UID)%"
-      $mailGid: "%env(DOVECOT_MAIL_GID)%"
 
   App\EventListener\:
     resource: "../src/EventListener/*"
     tags:
       - { name: kernel.event_subscriber }
-
-  App\EventListener\LoginListener:
-    arguments:
-      $mailCryptEnv: "%env(MAIL_CRYPT)%"
-
-  App\EventListener\LocaleListener:
-    arguments:
-      $defaultLocale: "%locale%"
-      $supportedLocales: "%supported_locales%"
-
-  App\EventListener\JsonExceptionListener:
-    arguments:
-      $environment: '%kernel.environment%'
 
   App\Handler\MailHandler:
     arguments:
@@ -101,33 +65,9 @@ services:
     arguments:
       $to: "%env(NOTIFICATION_ADDRESS)%"
 
-  App\Handler\UserRestoreHandler:
-    arguments:
-      $mailCryptEnv: "%env(MAIL_CRYPT)%"
-
-  App\Handler\RegistrationHandler:
-    arguments:
-      $registrationOpen: "%env(REGISTRATION_OPEN)%"
-      $mailCrypt: "%env(MAIL_CRYPT)%"
-
   App\Handler\SuspiciousChildrenHandler:
     arguments:
       $to: "%env(NOTIFICATION_ADDRESS)%"
-
-  App\Handler\WkdHandler:
-    arguments:
-      $wkdDirectory: "%env(WKD_DIRECTORY)%"
-      $wkdFormat: "%env(WKD_FORMAT)%"
-
-  App\EventListener\AliasCreationListener:
-    arguments:
-      $sendMail: "%env(SEND_MAIL)%"
-      $defaultLocale: "%kernel.default_locale%"
-
-  App\EventListener\RecoveryProcessListener:
-    arguments:
-      $sendMail: "%env(SEND_MAIL)%"
-      $defaultLocale: "%kernel.default_locale%"
 
   userli.admin.user:
     class: App\Admin\UserAdmin

--- a/src/Command/UsersMailCryptCommand.php
+++ b/src/Command/UsersMailCryptCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsCommand(name: 'app:users:mailcrypt', description: 'Get MailCrypt values for user')]
 class UsersMailCryptCommand extends AbstractUsersCommand
@@ -18,9 +19,9 @@ class UsersMailCryptCommand extends AbstractUsersCommand
         EntityManagerInterface                     $manager,
         private readonly UserAuthenticationHandler $handler,
         private readonly MailCryptKeyHandler       $mailCryptKeyHandler,
+        #[Autowire(env: 'MAIL_CRYPT')]
         private readonly int                       $mailCrypt
-    )
-    {
+    ) {
         parent::__construct($manager);
     }
 
@@ -31,7 +32,8 @@ class UsersMailCryptCommand extends AbstractUsersCommand
             ->addArgument(
                 'password',
                 InputOption::VALUE_OPTIONAL,
-                'password of supplied email address');
+                'password of supplied email address'
+            );
     }
 
     /**

--- a/src/Command/UsersRegistrationMailCommand.php
+++ b/src/Command/UsersRegistrationMailCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
 #[AsCommand(name: 'app:users:registration:mail', description: 'Send a registration mail to a user')]
@@ -19,10 +20,10 @@ class UsersRegistrationMailCommand extends Command
     public function __construct(
         private readonly EntityManagerInterface $manager,
         private readonly WelcomeMessageSender $welcomeMessageSender,
-        private readonly string $defaultLocale,
-        ?string $name = null)
-    {
-        parent::__construct($name);
+        #[Autowire('kernel.default_locale')]
+        private readonly string $defaultLocale
+    ) {
+        parent::__construct();
     }
 
     /**

--- a/src/Command/UsersRemoveCommand.php
+++ b/src/Command/UsersRemoveCommand.php
@@ -9,17 +9,19 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 #[AsCommand(name: 'app:users:remove', description: 'Removes all mailboxes from deleted users')]
 class UsersRemoveCommand extends Command
 {
-    public function __construct(private readonly EntityManagerInterface $manager,
-                                private readonly string $mailLocation,
-                                ?string $name = null)
-    {
-        parent::__construct($name);
+    public function __construct(
+        private readonly EntityManagerInterface $manager,
+        #[Autowire(env: 'DOVECOT_MAIL_LOCATION')]
+        private readonly string                 $mailLocation,
+    ) {
+        parent::__construct();
     }
 
     /**
@@ -51,8 +53,8 @@ class UsersRemoveCommand extends Command
             }
 
             $domain = $user->getDomain()->getName();
-            $name = str_replace('@'.$domain, '', (string) $user->getEmail());
-            $path = $this->mailLocation.DIRECTORY_SEPARATOR.$domain.DIRECTORY_SEPARATOR.$name;
+            $name = str_replace('@' . $domain, '', (string)$user->getEmail());
+            $path = $this->mailLocation . DIRECTORY_SEPARATOR . $domain . DIRECTORY_SEPARATOR . $name;
 
             if ($input->getOption('dry-run')) {
                 $output->writeln(sprintf('Would delete directory for user: %s', $user));
@@ -70,7 +72,7 @@ class UsersRemoveCommand extends Command
                 try {
                     $filesystem->remove($path);
                 } catch (IOException $e) {
-                    $output->writeln('<error>'.$e->getMessage().'</error>');
+                    $output->writeln('<error>' . $e->getMessage() . '</error>');
                 }
             } else {
                 $output->writeln(sprintf('Directory for user does not exist: %s', $user));

--- a/src/Command/UsersResetCommand.php
+++ b/src/Command/UsersResetCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
@@ -23,12 +24,14 @@ class UsersResetCommand extends AbstractUsersCommand
     /**
      * RegistrationMailCommand constructor.
      */
-    public function __construct(EntityManagerInterface $manager,
-                                private readonly PasswordUpdater $passwordUpdater,
-                                private readonly MailCryptKeyHandler $mailCryptKeyHandler,
-                                private readonly RecoveryTokenHandler $recoveryTokenHandler,
-                                private readonly string $mailLocation)
-    {
+    public function __construct(
+        EntityManagerInterface $manager,
+        private readonly PasswordUpdater $passwordUpdater,
+        private readonly MailCryptKeyHandler $mailCryptKeyHandler,
+        private readonly RecoveryTokenHandler $recoveryTokenHandler,
+        #[Autowire(env: 'DOVECOT_MAIL_LOCATION')]
+        private readonly string $mailLocation
+    ) {
         parent::__construct($manager);
     }
 

--- a/src/Controller/DovecotController.php
+++ b/src/Controller/DovecotController.php
@@ -14,6 +14,7 @@ use App\Handler\UserAuthenticationHandler;
 use App\Security\RequireApiScope;
 use Exception;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
@@ -38,9 +39,13 @@ class DovecotController extends AbstractController
     public function __construct(
         private readonly MailCryptKeyHandler $mailCryptKeyHandler,
         private readonly UserAuthenticationHandler $authHandler,
+        #[Autowire(env: 'DOVECOT_MAIL_LOCATION')]
         private readonly string $mailLocation,
+        #[Autowire(env: 'MAIL_CRYPT')]
         private readonly int $mailCryptEnv,
+        #[Autowire(env: 'DOVECOT_MAIL_UID')]
         private readonly int $mailUid,
+        #[Autowire(env: 'DOVECOT_MAIL_GID')]
         private readonly int $mailGid,
     ) {
         $this->mailCrypt = MailCrypt::from($this->mailCryptEnv);

--- a/src/EventListener/AliasCreationListener.php
+++ b/src/EventListener/AliasCreationListener.php
@@ -5,21 +5,18 @@ namespace App\EventListener;
 use Exception;
 use App\Event\AliasCreatedEvent;
 use App\Sender\AliasCreatedMessageSender;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class AliasCreationListener implements EventSubscriberInterface
+readonly class AliasCreationListener implements EventSubscriberInterface
 {
-    /**
-     * AliasCreationListener constructor.
-     */
     public function __construct(
-        private readonly RequestStack $request,
-        private readonly AliasCreatedMessageSender $sender,
-        private readonly bool $sendMail,
-        private readonly string $defaultLocale,
-    )
-    {
+        private RequestStack $request,
+        private AliasCreatedMessageSender $sender,
+        #[Autowire('kernel.default_locale')]
+        private string $defaultLocale,
+    ) {
     }
 
     /**
@@ -27,10 +24,6 @@ class AliasCreationListener implements EventSubscriberInterface
      */
     public function onAliasCreated(AliasCreatedEvent $event): void
     {
-        if (!$this->sendMail) {
-            return;
-        }
-
         if (null === $alias = $event->getAlias()) {
             throw new Exception('Alias should not be null');
         }

--- a/src/EventListener/JsonExceptionListener.php
+++ b/src/EventListener/JsonExceptionListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventListener;
 
 use App\Helper\JsonRequestHelper;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -14,9 +15,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
 readonly class JsonExceptionListener implements EventSubscriberInterface
 {
     public function __construct(
+        #[Autowire('kernel.environment')]
         private string $environment
-    )
-    {
+    ) {
     }
 
     public static function getSubscribedEvents(): array

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -2,17 +2,19 @@
 
 namespace App\EventListener;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class LocaleListener implements EventSubscriberInterface
+readonly class LocaleListener implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly string $defaultLocale,
-        private readonly array $supportedLocales,
-    )
-    {
+        #[Autowire(param: 'locale')]
+        private string $defaultLocale,
+        #[Autowire(param: 'supported_locales')]
+        private array $supportedLocales,
+    ) {
     }
 
     public function onKernelRequest(RequestEvent $event): void

--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -6,6 +6,7 @@ use App\Entity\User;
 use App\Enum\MailCrypt;
 use App\Event\LoginEvent;
 use App\Service\UserLastLoginUpdateService;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -20,9 +21,9 @@ readonly class LoginListener implements EventSubscriberInterface
         private UserLastLoginUpdateService $userLastLoginUpdateService,
         private MailCryptKeyHandler        $mailCryptKeyHandler,
         private LoggerInterface            $logger,
+        #[Autowire(env: 'MAIL_CRYPT')]
         private int                        $mailCryptEnv,
-    )
-    {
+    ) {
         $this->mailCrypt = MailCrypt::from($this->mailCryptEnv);
     }
 

--- a/src/EventListener/RecoveryProcessListener.php
+++ b/src/EventListener/RecoveryProcessListener.php
@@ -6,21 +6,18 @@ use Exception;
 use App\Event\RecoveryProcessEvent;
 use App\Event\UserEvent;
 use App\Sender\RecoveryProcessMessageSender;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class RecoveryProcessListener implements EventSubscriberInterface
+readonly class RecoveryProcessListener implements EventSubscriberInterface
 {
-    /**
-     * RecoveryProcessListener constructor.
-     */
     public function __construct(
-        private readonly RequestStack $request,
-        private readonly RecoveryProcessMessageSender $sender,
-        private readonly bool $sendMail,
-        private readonly string $defaultLocale,
-    )
-    {
+        private RequestStack $request,
+        private RecoveryProcessMessageSender $sender,
+        #[Autowire('kernel.default_locale')]
+        private string $defaultLocale,
+    ) {
     }
 
     /**
@@ -38,10 +35,6 @@ class RecoveryProcessListener implements EventSubscriberInterface
      */
     public function onRecoveryProcessStarted(UserEvent $event): void
     {
-        if (!$this->sendMail) {
-            return;
-        }
-
         if (null === $user = $event->getUser()) {
             throw new Exception('User should not be null');
         }

--- a/src/Handler/RegistrationHandler.php
+++ b/src/Handler/RegistrationHandler.php
@@ -12,13 +12,11 @@ use App\Form\Model\Registration;
 use App\Guesser\DomainGuesser;
 use App\Helper\PasswordUpdater;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 readonly class RegistrationHandler
 {
-    /**
-     * Constructor.
-     */
     public function __construct(
         private EntityManagerInterface   $manager,
         private DomainGuesser            $domainGuesser,
@@ -26,10 +24,11 @@ readonly class RegistrationHandler
         private PasswordUpdater          $passwordUpdater,
         private MailCryptKeyHandler      $mailCryptKeyHandler,
         private RecoveryTokenHandler     $recoveryTokenHandler,
+        #[Autowire(env: 'REGISTRATION_OPEN')]
         private bool                     $registrationOpen,
+        #[Autowire(env: 'MAIL_CRYPT')]
         private bool                     $mailCrypt
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Handler/UserRestoreHandler.php
+++ b/src/Handler/UserRestoreHandler.php
@@ -8,23 +8,26 @@ use App\Event\UserEvent;
 use App\Helper\PasswordUpdater;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-class UserRestoreHandler
+readonly class UserRestoreHandler
 {
     private MailCrypt $mailCrypt;
 
     public function __construct(
-        private readonly EntityManagerInterface $manager,
-        private readonly PasswordUpdater $passwordUpdater,
-        private readonly MailCryptKeyHandler $mailCryptKeyHandler,
-        private readonly RecoveryTokenHandler $recoveryTokenHandler,
-        private readonly EventDispatcherInterface $eventDispatcher,
-        readonly int $mailCryptEnv,
+        private EntityManagerInterface $manager,
+        private PasswordUpdater $passwordUpdater,
+        private MailCryptKeyHandler $mailCryptKeyHandler,
+        private RecoveryTokenHandler $recoveryTokenHandler,
+        private EventDispatcherInterface $eventDispatcher,
+        #[Autowire(env: 'MAIL_CRYPT')]
+        int $mailCryptEnv,
     ) {
         $this->mailCrypt = MailCrypt::from($mailCryptEnv);
     }
 
-    public function restoreUser(User $user, string $password): ?string {
+    public function restoreUser(User $user, string $password): ?string
+    {
         $user->setDeleted(false);
         $this->passwordUpdater->updatePassword($user, $password);
 
@@ -43,7 +46,7 @@ class UserRestoreHandler
 
         $this->manager->flush();
 
-    $this->eventDispatcher->dispatch(new UserEvent($user), UserEvent::USER_CREATED);
+        $this->eventDispatcher->dispatch(new UserEvent($user), UserEvent::USER_CREATED);
 
         return $recoveryToken;
     }

--- a/src/Handler/WkdHandler.php
+++ b/src/Handler/WkdHandler.php
@@ -11,19 +11,20 @@ use App\Importer\GpgKeyImporter;
 use App\Repository\OpenPgpKeyRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Tuupola\Base32;
 
-class WkdHandler
+readonly class WkdHandler
 {
-    private readonly OpenPgpKeyRepository $repository;
+    private OpenPgpKeyRepository $repository;
 
-    /**
-     * WkdHandler constructor.
-     */
-    public function __construct(private readonly EntityManagerInterface $manager,
-                                private readonly string $wkdDirectory,
-                                private readonly string $wkdFormat)
-    {
+    public function __construct(
+        private EntityManagerInterface $manager,
+        #[Autowire(env: 'WKD_DIRECTORY')]
+        private string $wkdDirectory,
+        #[Autowire(env: 'WKD_FORMAT')]
+        private string $wkdFormat
+    ) {
         $this->repository = $manager->getRepository(OpenPgpKey::class);
     }
 


### PR DESCRIPTION
This pull request refactors how environment variables and parameters are injected into service classes and event listeners throughout the codebase. Instead of configuring constructor arguments in `config/services.yaml`, it leverages Symfony's `#[Autowire]` attribute directly in constructors for dependency injection. This approach streamlines configuration, reduces duplication, and makes the codebase more maintainable and idiomatic to modern Symfony practices.

This refactor makes dependency management clearer and more robust, and aligns with best practices for modern Symfony development.