### PR TITLE
PlainPassword: Disallow empty string and null

### DIFF
--- a/features/registration.feature
+++ b/features/registration.feature
@@ -59,6 +59,19 @@ Feature: registration
     And I should see "The invite code is invalid."
 
   @registration
+  Scenario: Register with empty password
+    When I am on "/register"
+    And I fill in the following:
+      | registration[voucher]               | ABCD         |
+      | registration[email]                 | user1        |
+      | registration[plainPassword][first]  |              |
+      | registration[plainPassword][second] |              |
+    And I press "Submit"
+
+    Then I should be on "/register"
+    And I should see "This value should not be blank."
+
+  @registration
   Scenario: Register with invalid voucher
     When I am on "/register"
     And I fill in the following:

--- a/src/Traits/PlainPasswordTrait.php
+++ b/src/Traits/PlainPasswordTrait.php
@@ -11,6 +11,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 trait PlainPasswordTrait
 {
     #[PasswordPolicy]
+    #[Assert\NotBlank]
     #[Assert\NotCompromisedPassword( skipOnError: 'true')]
     private ?string $plainPassword = null;
 


### PR DESCRIPTION
Fixes Type Error
```
Uncaught PHP Exception TypeError: App\Helper\PasswordUpdater[REDACTED_IPv6]updatePassword(): Argument #2 ($plainPassword) must be of type string, null given
```