### PR TITLE
👷 Adjust Docker build platforms for main branch conditionally

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -191,14 +191,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
       - name: Build & Push
         uses: docker/build-push-action@v6
         with:
           push: ${{ github.ref == 'refs/heads/main' }}
           file: docker/userli/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           tags: systemli/userli:latest
           cache-from: |
             type=registry,ref=systemli/userli:buildcache


### PR DESCRIPTION
This pull request updates the workflow configuration in `.github/workflows/integration.yml` to conditionally build and push Docker images for multiple platforms only when running on the `main` branch. For all other branches, images are built for `linux/amd64` only.

Workflow configuration improvements:

* The `platforms` parameter for both the Docker Buildx setup and the Build & Push steps now uses a conditional expression to select `linux/amd64,linux/arm64` only when the workflow runs on the `main` branch; otherwise, it defaults to `linux/amd64`. This optimizes build resources and speeds up CI for non-main branches.