### PR TITLE
🗃️  Add missing database indices

### DIFF
--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -23,9 +23,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\AssociationOverrides([new AssociationOverride(name: 'domain', joinColumns: new ORM\JoinColumn(nullable: true))])]
 #[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'virtual_aliases')]
-#[Index(name: 'source_deleted_idx', columns: ['source', 'deleted'])]
-#[Index(name: 'destination_deleted_idx', columns: ['destination', 'deleted'])]
-#[Index(name: 'user_deleted_idx', columns: ['user_id', 'deleted'])]
+#[Index(columns: ['source', 'deleted'], name: 'source_deleted_idx')]
+#[Index(columns: ['destination', 'deleted'], name: 'destination_deleted_idx')]
+#[Index(columns: ['user_id', 'deleted'], name: 'user_deleted_idx')]
 class Alias implements SoftDeletableInterface, Stringable
 {
     use IdTrait;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -43,6 +43,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: 'virtual_users')]
 #[Index(columns: ['email'], name: 'email_idx')]
+#[Index(columns: ['creation_time'], name: 'creation_time_idx')]
+#[Index(columns: ['deleted'], name: 'deleted_idx')]
+#[Index(columns: ['email', 'deleted'], name: 'email_deleted_idx')]
+#[Index(columns: ['domain_id', 'deleted'], name: 'domain_deleted_idx')]
+#[Index(columns: ['email', 'domain_id'], name: 'email_domain_idx')]
 #[EmailDomain]
 class User implements UserInterface, PasswordAuthenticatedUserInterface, PasswordHasherAwareInterface, TwoFactorInterface, BackupCodeInterface, Stringable
 {


### PR DESCRIPTION
This pull request updates the database indexing for`User` entity to improve query performance and maintain consistency in index definitions. The most important changes are grouped below by entity:

**User Entity Index Additions:**

* Added new indexes in `src/Entity/User.php` to optimize queries involving user creation time, deletion status, and combinations of email, domain, and deletion status:
  - Index on `creation_time` (`creation_time_idx`)
  - Index on `deleted` (`deleted_idx`)
  - Composite indexes for `email` and `deleted` (`email_deleted_idx`), `domain_id` and `deleted` (`domain_deleted_idx`), and `email` and `domain_id` (`email_domain_idx`)