### PR TITLE
🚨 Fix MissingTemplateParam Issue

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -36,9 +36,7 @@
             - LOW: MissingOverrideAttribute, PropertyNotSetInConstructor
         -->
 
-        <!-- MEDIUM PRIORITY - Type-Safety Improvements (34 MissingTemplateParam, 32
-        UndefinedInterfaceMethod) -->
-        <MissingTemplateParam errorLevel="suppress" />
+        <!-- MEDIUM PRIORITY - Type-Safety Improvements (32 UndefinedInterfaceMethod) -->
         <UndefinedInterfaceMethod errorLevel="suppress" />
         <UndefinedDocblockClass errorLevel="suppress" />
 

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -7,6 +7,11 @@ namespace App\Admin;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 
+/**
+ * @template T of object
+ *
+ * @extends AbstractAdmin<T>
+ */
 abstract class Admin extends AbstractAdmin
 {
     protected function configureDefaultSortValues(array &$sortValues): void

--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -16,6 +16,9 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 
+/**
+ * @extends Admin<Alias>
+ */
 class AliasAdmin extends Admin
 {
     use DomainGuesserAwareTrait;

--- a/src/Admin/DomainAdmin.php
+++ b/src/Admin/DomainAdmin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Admin;
 
 use App\Creator\DomainCreator;
+use App\Entity\Domain;
 use App\Event\DomainCreatedEvent;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -13,6 +14,9 @@ use Sonata\AdminBundle\Route\RouteCollectionInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @extends Admin<Domain>
+ */
 class DomainAdmin extends Admin
 {
     private DomainCreator $domainCreator;

--- a/src/Admin/ReservedNameAdmin.php
+++ b/src/Admin/ReservedNameAdmin.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Admin;
 
+use App\Entity\ReservedName;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
+/**
+ * @extends Admin<ReservedName>
+ */
 class ReservedNameAdmin extends Admin
 {
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string

--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -26,6 +26,9 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+/**
+ * @extends Admin<User>
+ */
 class UserAdmin extends Admin
 {
     use DomainGuesserAwareTrait;

--- a/src/Admin/UserNotificationAdmin.php
+++ b/src/Admin/UserNotificationAdmin.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace App\Admin;
 
+use App\Entity\UserNotification;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Route\RouteCollectionInterface;
 
+/**
+ * @extends Admin<UserNotification>
+ */
 class UserNotificationAdmin extends Admin
 {
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string

--- a/src/Admin/VoucherAdmin.php
+++ b/src/Admin/VoucherAdmin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Admin;
 
+use App\Entity\Voucher;
 use App\Helper\RandomStringGenerator;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -13,6 +14,9 @@ use Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter;
 use Sonata\Form\Type\DateRangePickerType;
 use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @extends Admin<Voucher>
+ */
 class VoucherAdmin extends Admin
 {
     public function __construct(protected Security $security)

--- a/src/Controller/AliasCRUDController.php
+++ b/src/Controller/AliasCRUDController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\Alias;
 use App\Handler\DeleteHandler;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -11,6 +12,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @extends CRUDController<Alias>
+ */
 class AliasCRUDController extends CRUDController
 {
     public function __construct(private readonly DeleteHandler $deleteHandler)

--- a/src/Controller/UserCRUDController.php
+++ b/src/Controller/UserCRUDController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\User;
 use App\Handler\DeleteHandler;
 use App\Remover\VoucherRemover;
 use Sonata\AdminBundle\Controller\CRUDController;
@@ -13,6 +14,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Traversable;
 
+/**
+ * @extends CRUDController<User>
+ */
 class UserCRUDController extends CRUDController
 {
     public function __construct(private readonly DeleteHandler $deleteHandler, private readonly VoucherRemover $voucherRemover)

--- a/src/Form/AliasDeleteType.php
+++ b/src/Form/AliasDeleteType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<Delete>
+ */
 class AliasDeleteType extends AbstractType
 {
     public const NAME = 'delete_alias';

--- a/src/Form/ApiTokenType.php
+++ b/src/Form/ApiTokenType.php
@@ -12,6 +12,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<ApiToken>
+ */
 class ApiTokenType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Form/CustomAliasCreateType.php
+++ b/src/Form/CustomAliasCreateType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<AliasCreate>
+ */
 class CustomAliasCreateType extends AbstractType
 {
     public const NAME = 'create_custom_alias';

--- a/src/Form/DataTransformer/TextToEmailTransformer.php
+++ b/src/Form/DataTransformer/TextToEmailTransformer.php
@@ -6,6 +6,9 @@ namespace App\Form\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
 
+/**
+ * @implements DataTransformerInterface<string, string>
+ */
 class TextToEmailTransformer implements DataTransformerInterface
 {
     /**

--- a/src/Form/DomainCreateType.php
+++ b/src/Form/DomainCreateType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<DomainCreate>
+ */
 class DomainCreateType extends AbstractType
 {
     public const NAME = 'create_domain';

--- a/src/Form/OpenPgpDeleteType.php
+++ b/src/Form/OpenPgpDeleteType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<Delete>
+ */
 class OpenPgpDeleteType extends AbstractType
 {
     public const NAME = 'delete_openpgp';

--- a/src/Form/OpenPgpKeyType.php
+++ b/src/Form/OpenPgpKeyType.php
@@ -18,6 +18,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @extends AbstractType<OpenPgpKey>
+ */
 class OpenPgpKeyType extends AbstractType implements EventSubscriberInterface
 {
     public const NAME = 'upload_openpgp_key';

--- a/src/Form/PasswordType.php
+++ b/src/Form/PasswordType.php
@@ -12,6 +12,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<Password>
+ */
 class PasswordType extends AbstractType
 {
     public const NAME = 'password';

--- a/src/Form/PlainPasswordType.php
+++ b/src/Form/PlainPasswordType.php
@@ -12,6 +12,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<PlainPassword>
+ */
 class PlainPasswordType extends AbstractType
 {
     public const NAME = 'plain_password';

--- a/src/Form/RandomAliasCreateType.php
+++ b/src/Form/RandomAliasCreateType.php
@@ -10,6 +10,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<AliasCreate>
+ */
 class RandomAliasCreateType extends AbstractType
 {
     public const NAME = 'create_alias';

--- a/src/Form/RecoveryProcessType.php
+++ b/src/Form/RecoveryProcessType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<RecoveryProcess>
+ */
 class RecoveryProcessType extends AbstractType
 {
     public const NAME = 'recovery_process';

--- a/src/Form/RecoveryResetPasswordType.php
+++ b/src/Form/RecoveryResetPasswordType.php
@@ -13,6 +13,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<RecoveryResetPassword>
+ */
 class RecoveryResetPasswordType extends AbstractType
 {
     public const NAME = 'recovery_reset_password';

--- a/src/Form/RecoveryTokenConfirmType.php
+++ b/src/Form/RecoveryTokenConfirmType.php
@@ -12,6 +12,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<RecoveryTokenConfirm>
+ */
 class RecoveryTokenConfirmType extends AbstractType
 {
     public const NAME = 'recovery_token_confirm';

--- a/src/Form/RecoveryTokenType.php
+++ b/src/Form/RecoveryTokenType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<RecoveryToken>
+ */
 class RecoveryTokenType extends AbstractType
 {
     public const NAME = 'recovery_token';

--- a/src/Form/RegistrationType.php
+++ b/src/Form/RegistrationType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Class RegistrationType.
+ * @extends AbstractType<Registration>
  */
 class RegistrationType extends AbstractType
 {

--- a/src/Form/SettingsType.php
+++ b/src/Form/SettingsType.php
@@ -21,6 +21,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
+/**
+ * @extends AbstractType<array<string, mixed>>
+ */
 class SettingsType extends AbstractType
 {
     public function __construct(

--- a/src/Form/TwofactorBackupConfirmType.php
+++ b/src/Form/TwofactorBackupConfirmType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<TwofactorBackupConfirm>
+ */
 class TwofactorBackupConfirmType extends AbstractType
 {
     public const NAME = 'twofactor_backup_confirm';

--- a/src/Form/TwofactorConfirmType.php
+++ b/src/Form/TwofactorConfirmType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<TwofactorConfirm>
+ */
 class TwofactorConfirmType extends AbstractType
 {
     public const NAME = 'twofactor_confirm';

--- a/src/Form/TwofactorType.php
+++ b/src/Form/TwofactorType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<Twofactor>
+ */
 class TwofactorType extends AbstractType
 {
     public const NAME = 'twofactor';

--- a/src/Form/UserDeleteType.php
+++ b/src/Form/UserDeleteType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<Delete>
+ */
 class UserDeleteType extends AbstractType
 {
     public const NAME = 'delete_user';

--- a/src/Form/VoucherCreateType.php
+++ b/src/Form/VoucherCreateType.php
@@ -10,6 +10,9 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<VoucherCreate>
+ */
 class VoucherCreateType extends AbstractType
 {
     public const NAME = 'create_voucher';

--- a/src/Form/WebhookEndpointType.php
+++ b/src/Form/WebhookEndpointType.php
@@ -14,6 +14,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<WebhookEndpointModel>
+ */
 class WebhookEndpointType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Repository/AliasRepository.php
+++ b/src/Repository/AliasRepository.php
@@ -8,6 +8,9 @@ use App\Entity\Alias;
 use App\Entity\User;
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * @extends EntityRepository<Alias>
+ */
 class AliasRepository extends EntityRepository
 {
     public function findOneBySource(string $email, ?bool $includeDeleted = false): ?Alias

--- a/src/Repository/DomainRepository.php
+++ b/src/Repository/DomainRepository.php
@@ -7,6 +7,9 @@ namespace App\Repository;
 use App\Entity\Domain;
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * @extends EntityRepository<Domain>
+ */
 class DomainRepository extends EntityRepository
 {
     public function findByName(string $name): ?Domain

--- a/src/Repository/OpenPgpKeyRepository.php
+++ b/src/Repository/OpenPgpKeyRepository.php
@@ -8,6 +8,9 @@ use App\Entity\OpenPgpKey;
 use App\Entity\User;
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * @extends EntityRepository<OpenPgpKey>
+ */
 class OpenPgpKeyRepository extends EntityRepository
 {
     /**

--- a/src/Repository/ReservedNameRepository.php
+++ b/src/Repository/ReservedNameRepository.php
@@ -7,6 +7,9 @@ namespace App\Repository;
 use App\Entity\ReservedName;
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * @extends EntityRepository<ReservedName>
+ */
 class ReservedNameRepository extends EntityRepository
 {
     public function findByName(string $name): ?ReservedName

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -17,6 +17,9 @@ use Exception;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 
+/**
+ * @extends EntityRepository<User>
+ */
 class UserRepository extends EntityRepository implements PasswordUpgraderInterface
 {
     public function findById(int $id): ?User

--- a/src/Repository/VoucherRepository.php
+++ b/src/Repository/VoucherRepository.php
@@ -9,6 +9,9 @@ use App\Entity\Voucher;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * @extends EntityRepository<Voucher>
+ */
 class VoucherRepository extends EntityRepository
 {
     /**

--- a/src/Security/UserProvider.php
+++ b/src/Security/UserProvider.php
@@ -12,6 +12,9 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
+/**
+ * @implements UserProviderInterface<User>
+ */
 class UserProvider implements UserProviderInterface
 {
     public function __construct(private readonly EntityManagerInterface $manager)

--- a/src/Voter/AliasVoter.php
+++ b/src/Voter/AliasVoter.php
@@ -9,6 +9,9 @@ use App\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
+/**
+ * @extends Voter<string, Alias>
+ */
 class AliasVoter extends Voter
 {
     public const DELETE = 'delete';

--- a/src/Voter/DomainVoter.php
+++ b/src/Voter/DomainVoter.php
@@ -13,6 +13,9 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
+/**
+ * @extends Voter<string, Alias|User>
+ */
 class DomainVoter extends Voter
 {
     /**


### PR DESCRIPTION
This pull request introduces PHPStan/Psalm template annotations to multiple admin, controller, and form classes to improve type safety and static analysis. By specifying generic types for base classes and interfaces, the codebase becomes easier to understand and maintain, reducing the likelihood of type-related errors. Additionally, a redundant suppressed error for missing template parameters is removed from the static analysis configuration.