### PR TITLE
🚨 Fix MissingOverrideAttribute Issue

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -36,9 +36,7 @@
             - LOW: MissingOverrideAttribute, PropertyNotSetInConstructor
         -->
 
-        <!-- LOW PRIORITY - Code Style / Modernization (230 MissingOverrideAttribute, 17
-        PropertyNotSetInConstructor) -->
-        <MissingOverrideAttribute errorLevel="suppress" />
+        <!-- LOW PRIORITY - Code Style / Modernization (17 PropertyNotSetInConstructor) -->
         <PropertyNotSetInConstructor errorLevel="suppress" />
 
         <!-- Symfony Psalm Plugin Issues (e.g. QueryBuilderSetParameter) -->

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Admin;
 
+use Override;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 
@@ -14,6 +15,7 @@ use Sonata\AdminBundle\Datagrid\DatagridInterface;
  */
 abstract class Admin extends AbstractAdmin
 {
+    #[Override]
     protected function configureDefaultSortValues(array &$sortValues): void
     {
         $sortValues[DatagridInterface::PAGE] = 1;

--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -8,6 +8,7 @@ use App\Entity\Alias;
 use App\Enum\Roles;
 use App\Traits\DomainGuesserAwareTrait;
 use DateTime;
+use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -28,11 +29,13 @@ class AliasAdmin extends Admin
         parent::__construct();
     }
 
+    #[Override]
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
         return 'alias';
     }
 
+    #[Override]
     protected function configureFormFields(FormMapper $form): void
     {
         $form
@@ -46,6 +49,7 @@ class AliasAdmin extends Admin
         }
     }
 
+    #[Override]
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
@@ -55,6 +59,7 @@ class AliasAdmin extends Admin
             ->add('deleted');
     }
 
+    #[Override]
     protected function configureListFields(ListMapper $list): void
     {
         $list
@@ -84,11 +89,13 @@ class AliasAdmin extends Admin
             ->add('deleted');
     }
 
+    #[Override]
     protected function configureBatchActions($actions): array
     {
         return [];
     }
 
+    #[Override]
     protected function prePersist(object $object): void
     {
         assert($object instanceof Alias);
@@ -106,6 +113,7 @@ class AliasAdmin extends Admin
         }
     }
 
+    #[Override]
     protected function preUpdate(object $object): void
     {
         assert($object instanceof Alias);

--- a/src/Admin/DomainAdmin.php
+++ b/src/Admin/DomainAdmin.php
@@ -7,6 +7,7 @@ namespace App\Admin;
 use App\Creator\DomainCreator;
 use App\Entity\Domain;
 use App\Event\DomainCreatedEvent;
+use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -23,23 +24,27 @@ class DomainAdmin extends Admin
 
     private EventDispatcherInterface $eventDispatcher;
 
+    #[Override]
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
         return 'domain';
     }
 
+    #[Override]
     protected function configureFormFields(FormMapper $form): void
     {
         $form
             ->add('name', TextType::class, ['disabled' => !$this->isNewObject()]);
     }
 
+    #[Override]
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
             ->add('name');
     }
 
+    #[Override]
     protected function configureListFields(ListMapper $list): void
     {
         $list
@@ -57,16 +62,19 @@ class DomainAdmin extends Admin
             ->add('updatedTime');
     }
 
+    #[Override]
     protected function configureRoutes(RouteCollectionInterface $collection): void
     {
         $collection->remove('delete');
     }
 
+    #[Override]
     protected function prePersist(object $object): void
     {
         $this->domainCreator->validate($object, ['Default', 'unique']);
     }
 
+    #[Override]
     protected function postPersist(object $object): void
     {
         $this->eventDispatcher->dispatch(new DomainCreatedEvent($object), DomainCreatedEvent::NAME);

--- a/src/Admin/ReservedNameAdmin.php
+++ b/src/Admin/ReservedNameAdmin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Admin;
 
 use App\Entity\ReservedName;
+use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -15,23 +16,27 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 class ReservedNameAdmin extends Admin
 {
+    #[Override]
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
         return 'reservedname';
     }
 
+    #[Override]
     protected function configureFormFields(FormMapper $form): void
     {
         $form
             ->add('name', TextType::class, ['disabled' => !$this->isNewObject()]);
     }
 
+    #[Override]
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
             ->add('name');
     }
 
+    #[Override]
     protected function configureListFields(ListMapper $list): void
     {
         $list

--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -11,6 +11,7 @@ use App\Handler\MailCryptKeyHandler;
 use App\Helper\PasswordUpdater;
 use App\Traits\DomainGuesserAwareTrait;
 use Exception;
+use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -41,11 +42,13 @@ class UserAdmin extends Admin
 
     private Security $security;
 
+    #[Override]
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
         return 'user';
     }
 
+    #[Override]
     protected function alterNewInstance(object $object): void
     {
         /* @var $object User */
@@ -53,6 +56,7 @@ class UserAdmin extends Admin
         $object->setPasswordChangeRequired(true);
     }
 
+    #[Override]
     protected function configureFormFields(FormMapper $form): void
     {
         /** @var User $currentUser */
@@ -96,6 +100,7 @@ class UserAdmin extends Admin
             ->add('deleted', CheckboxType::class, ['disabled' => true]);
     }
 
+    #[Override]
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
@@ -141,6 +146,7 @@ class UserAdmin extends Admin
             ->add('deleted');
     }
 
+    #[Override]
     protected function configureListFields(ListMapper $list): void
     {
         $list
@@ -166,6 +172,7 @@ class UserAdmin extends Admin
             ->add('deleted');
     }
 
+    #[Override]
     protected function configureBatchActions($actions): array
     {
         if ($this->hasRoute('edit') && $this->hasAccess('edit')) {
@@ -180,6 +187,7 @@ class UserAdmin extends Admin
     /**
      * @throws Exception
      */
+    #[Override]
     protected function prePersist(object $object): void
     {
         assert($object instanceof User);
@@ -193,6 +201,7 @@ class UserAdmin extends Admin
         }
     }
 
+    #[Override]
     protected function preUpdate(object $object): void
     {
         assert($object instanceof User);

--- a/src/Admin/UserNotificationAdmin.php
+++ b/src/Admin/UserNotificationAdmin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Admin;
 
 use App\Entity\UserNotification;
+use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Route\RouteCollectionInterface;
@@ -14,11 +15,13 @@ use Sonata\AdminBundle\Route\RouteCollectionInterface;
  */
 class UserNotificationAdmin extends Admin
 {
+    #[Override]
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
         return 'user-notification';
     }
 
+    #[Override]
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
@@ -30,6 +33,7 @@ class UserNotificationAdmin extends Admin
             ]);
     }
 
+    #[Override]
     protected function configureListFields(ListMapper $list): void
     {
         $list
@@ -44,6 +48,7 @@ class UserNotificationAdmin extends Admin
             ->add('creationTime');
     }
 
+    #[Override]
     protected function configureRoutes(RouteCollectionInterface $collection): void
     {
         $collection->remove('create');

--- a/src/Admin/VoucherAdmin.php
+++ b/src/Admin/VoucherAdmin.php
@@ -6,6 +6,7 @@ namespace App\Admin;
 
 use App\Entity\Voucher;
 use App\Helper\RandomStringGenerator;
+use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -24,17 +25,20 @@ class VoucherAdmin extends Admin
         parent::__construct();
     }
 
+    #[Override]
     protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
     {
         return 'voucher';
     }
 
+    #[Override]
     protected function alterNewInstance(object $object): void
     {
         $object->setUser($this->security->getUser());
         $object->setCode(RandomStringGenerator::generate(6, true));
     }
 
+    #[Override]
     protected function configureFormFields(FormMapper $form): void
     {
         $disabled = true;
@@ -47,6 +51,7 @@ class VoucherAdmin extends Admin
             ->add('code', null, ['disabled' => !$this->isNewObject()]);
     }
 
+    #[Override]
     protected function configureListFields(ListMapper $list): void
     {
         $list
@@ -61,6 +66,7 @@ class VoucherAdmin extends Admin
             ->add('redeemedTime');
     }
 
+    #[Override]
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
@@ -84,6 +90,7 @@ class VoucherAdmin extends Admin
             ]);
     }
 
+    #[Override]
     protected function configureBatchActions($actions): array
     {
         return [];

--- a/src/Block/StatisticsBlockService.php
+++ b/src/Block/StatisticsBlockService.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Entity\Voucher;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\BlockServiceInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
@@ -24,6 +25,7 @@ class StatisticsBlockService implements BlockServiceInterface
     {
     }
 
+    #[Override]
     public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {
         $settings = $blockContext->getSettings();
@@ -46,6 +48,7 @@ class StatisticsBlockService implements BlockServiceInterface
         return $response->setContent($rendered);
     }
 
+    #[Override]
     public function configureSettings(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
@@ -57,6 +60,7 @@ class StatisticsBlockService implements BlockServiceInterface
         );
     }
 
+    #[Override]
     public function getCacheKeys(BlockInterface $block): array
     {
         return [
@@ -65,6 +69,7 @@ class StatisticsBlockService implements BlockServiceInterface
         ];
     }
 
+    #[Override]
     public function load(BlockInterface $block): void
     {
     }

--- a/src/Command/AbstractUsersCommand.php
+++ b/src/Command/AbstractUsersCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,6 +20,7 @@ abstract class AbstractUsersCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this

--- a/src/Command/AdminPasswordCommand.php
+++ b/src/Command/AdminPasswordCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Helper\AdminPasswordUpdater;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -24,6 +25,7 @@ class AdminPasswordCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -31,6 +33,7 @@ class AdminPasswordCommand extends Command
             ->addArgument('password', InputArgument::OPTIONAL, 'Admin password');
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $password = $input->getArgument('password');

--- a/src/Command/AliasDeleteCommand.php
+++ b/src/Command/AliasDeleteCommand.php
@@ -8,6 +8,7 @@ use App\Entity\Alias;
 use App\Entity\User;
 use App\Handler\DeleteHandler;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,6 +23,7 @@ class AliasDeleteCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -30,6 +32,7 @@ class AliasDeleteCommand extends Command
             ->addOption('dry-run', null, InputOption::VALUE_NONE);
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $email = $input->getOption('user');

--- a/src/Command/ApiTokenCreateCommand.php
+++ b/src/Command/ApiTokenCreateCommand.php
@@ -8,6 +8,7 @@ use App\Enum\ApiScope;
 use App\Form\Model\ApiToken as ApiTokenModel;
 use App\Service\ApiTokenManager;
 use Exception;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,6 +30,7 @@ class ApiTokenCreateCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -42,6 +44,7 @@ class ApiTokenCreateCommand extends Command
             );
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Command/ApiTokenDeleteCommand.php
+++ b/src/Command/ApiTokenDeleteCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Service\ApiTokenManager;
 use Exception;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,12 +26,14 @@ class ApiTokenDeleteCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
             ->addOption('token', 't', InputOption::VALUE_REQUIRED, 'The plain API token to delete');
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Command/MetricsCommand.php
+++ b/src/Command/MetricsCommand.php
@@ -10,6 +10,7 @@ use App\Entity\OpenPgpKey;
 use App\Entity\User;
 use App\Entity\Voucher;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,6 +34,7 @@ class MetricsCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $usersTotal = $this->manager->getRepository(User::class)->countUsers();

--- a/src/Command/OpenPgpDeleteKeyCommand.php
+++ b/src/Command/OpenPgpDeleteKeyCommand.php
@@ -8,6 +8,7 @@ use App\Entity\OpenPgpKey;
 use App\Handler\WkdHandler;
 use App\Repository\OpenPgpKeyRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,6 +26,7 @@ class OpenPgpDeleteKeyCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -34,6 +36,7 @@ class OpenPgpDeleteKeyCommand extends Command
                 'email address of the OpenPGP key');
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // parse arguments

--- a/src/Command/OpenPgpExportKeysCommand.php
+++ b/src/Command/OpenPgpExportKeysCommand.php
@@ -10,6 +10,7 @@ use App\Handler\WkdHandler;
 use App\Repository\DomainRepository;
 use App\Repository\OpenPgpKeyRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,6 +30,7 @@ class OpenPgpExportKeysCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // create Web Key Directories (WKD) for all domains

--- a/src/Command/OpenPgpImportKeyCommand.php
+++ b/src/Command/OpenPgpImportKeyCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Exception\MultipleGpgKeysForUserException;
 use App\Exception\NoGpgKeyForUserException;
 use App\Handler\WkdHandler;
+use Override;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -22,6 +23,7 @@ class OpenPgpImportKeyCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -35,6 +37,7 @@ class OpenPgpImportKeyCommand extends Command
                 'file to read the key from');
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // parse arguments

--- a/src/Command/OpenPgpShowKeyCommand.php
+++ b/src/Command/OpenPgpShowKeyCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Entity\OpenPgpKey;
 use App\Repository\OpenPgpKeyRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,6 +25,7 @@ class OpenPgpShowKeyCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -33,6 +35,7 @@ class OpenPgpShowKeyCommand extends Command
                 'email address of the OpenPGP key');
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // parse arguments

--- a/src/Command/ReportWeeklyCommand.php
+++ b/src/Command/ReportWeeklyCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Handler\UserRegistrationInfoHandler;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,6 +19,7 @@ class ReportWeeklyCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->handler->sendReport();

--- a/src/Command/ReservedNamesImportCommand.php
+++ b/src/Command/ReservedNamesImportCommand.php
@@ -8,6 +8,7 @@ use App\Creator\ReservedNameCreator;
 use App\Entity\ReservedName;
 use App\Exception\ValidationException;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,6 +27,7 @@ class ReservedNamesImportCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -41,6 +43,7 @@ class ReservedNamesImportCommand extends Command
     /**
      * @throws ValidationException
      */
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $repository = $this->manager->getRepository(ReservedName::class);

--- a/src/Command/UsersDeleteCommand.php
+++ b/src/Command/UsersDeleteCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Handler\DeleteHandler;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,11 +21,13 @@ class UsersDeleteCommand extends AbstractUsersCommand
         parent::__construct($manager);
     }
 
+    #[Override]
     protected function configure(): void
     {
         parent::configure();
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $user = $this->getUser($input);

--- a/src/Command/UsersListCommand.php
+++ b/src/Command/UsersListCommand.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Enum\Roles;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -29,6 +30,7 @@ class UsersListCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -39,6 +41,7 @@ class UsersListCommand extends Command
                 'List users inactive for X days (ignores admins and users with ROLE_PERMANENT)');
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $inactiveDays = $input->getOption('inactive-days');

--- a/src/Command/UsersMailCryptCommand.php
+++ b/src/Command/UsersMailCryptCommand.php
@@ -8,6 +8,7 @@ use App\Handler\MailCryptKeyHandler;
 use App\Handler\UserAuthenticationHandler;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -27,6 +28,7 @@ class UsersMailCryptCommand extends AbstractUsersCommand
         parent::__construct($manager);
     }
 
+    #[Override]
     protected function configure(): void
     {
         parent::configure();
@@ -41,6 +43,7 @@ class UsersMailCryptCommand extends AbstractUsersCommand
     /**
      * @throws Exception
      */
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($this->mailCrypt <= 0) {

--- a/src/Command/UsersQuotaCommand.php
+++ b/src/Command/UsersQuotaCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -11,11 +12,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:users:quota', description: 'Get quota of user if set')]
 class UsersQuotaCommand extends AbstractUsersCommand
 {
+    #[Override]
     protected function configure(): void
     {
         parent::configure();
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $user = $this->getUser($input);

--- a/src/Command/UsersRegistrationMailCommand.php
+++ b/src/Command/UsersRegistrationMailCommand.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Sender\WelcomeMessageSender;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,6 +29,7 @@ class UsersRegistrationMailCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -38,6 +40,7 @@ class UsersRegistrationMailCommand extends Command
     /**
      * @throws Exception
      */
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $email = $input->getOption('user');

--- a/src/Command/UsersRemoveCommand.php
+++ b/src/Command/UsersRemoveCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,6 +29,7 @@ class UsersRemoveCommand extends Command
         parent::__construct();
     }
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -35,6 +37,7 @@ class UsersRemoveCommand extends Command
             ->addOption('list', null, InputOption::VALUE_NONE);
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var User[] $users */

--- a/src/Command/UsersResetCommand.php
+++ b/src/Command/UsersResetCommand.php
@@ -10,6 +10,7 @@ use App\Handler\RecoveryTokenHandler;
 use App\Helper\PasswordUpdater;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,6 +41,7 @@ class UsersResetCommand extends AbstractUsersCommand
         parent::__construct($manager);
     }
 
+    #[Override]
     protected function configure(): void
     {
         parent::configure();
@@ -48,6 +50,7 @@ class UsersResetCommand extends AbstractUsersCommand
     /**
      * @throws Exception
      */
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $user = $this->getUser($input);

--- a/src/Command/UsersRestoreCommand.php
+++ b/src/Command/UsersRestoreCommand.php
@@ -8,6 +8,7 @@ use App\Handler\PasswordStrengthHandler;
 use App\Handler\UserRestoreHandler;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,6 +26,7 @@ class UsersRestoreCommand extends AbstractUsersCommand
         parent::__construct($manager);
     }
 
+    #[Override]
     protected function configure(): void
     {
         parent::configure();
@@ -33,6 +35,7 @@ class UsersRestoreCommand extends AbstractUsersCommand
     /**
      * @throws Exception
      */
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $user = $this->getUser($input);

--- a/src/Command/VoucherCountCommand.php
+++ b/src/Command/VoucherCountCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Entity\Voucher;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,11 +13,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:voucher:count', description: 'Get count of vouchers for a specific user')]
 class VoucherCountCommand extends AbstractUsersCommand
 {
+    #[Override]
     protected function configure(): void
     {
         parent::configure();
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $user = $this->getUser($input);

--- a/src/Command/VoucherCreateCommand.php
+++ b/src/Command/VoucherCreateCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Creator\VoucherCreator;
 use App\Service\SettingsService;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,6 +26,7 @@ class VoucherCreateCommand extends AbstractUsersCommand
         parent::__construct($manager);
     }
 
+    #[Override]
     protected function configure(): void
     {
         parent::configure();
@@ -34,6 +36,7 @@ class VoucherCreateCommand extends AbstractUsersCommand
             ->addOption('print-links', 'l', InputOption::VALUE_NONE, 'Show links to vouchers');
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $user = $this->getUser($input);

--- a/src/Controller/AliasCRUDController.php
+++ b/src/Controller/AliasCRUDController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use App\Entity\Alias;
 use App\Handler\DeleteHandler;
+use Override;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -21,6 +22,7 @@ class AliasCRUDController extends CRUDController
     {
     }
 
+    #[Override]
     public function deleteAction(Request $request): Response
     {
         $object = $this->assertObjectExists($request, true);
@@ -49,6 +51,7 @@ class AliasCRUDController extends CRUDController
         return $this->redirectToList();
     }
 
+    #[Override]
     public function batchActionDelete(ProxyQueryInterface $query): RedirectResponse
     {
         $this->admin->checkAccess('batchDelete');

--- a/src/Controller/UserCRUDController.php
+++ b/src/Controller/UserCRUDController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Entity\User;
 use App\Handler\DeleteHandler;
 use App\Remover\VoucherRemover;
+use Override;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -40,6 +41,7 @@ class UserCRUDController extends CRUDController
         return $this->redirectToList();
     }
 
+    #[Override]
     public function deleteAction(Request $request): Response
     {
         $object = $this->assertObjectExists($request, true);
@@ -68,6 +70,7 @@ class UserCRUDController extends CRUDController
         return $this->redirectToList();
     }
 
+    #[Override]
     public function batchActionDelete(ProxyQueryInterface $query): RedirectResponse
     {
         $this->admin->checkAccess('batchDelete');

--- a/src/DataFixtures/LoadAliasData.php
+++ b/src/DataFixtures/LoadAliasData.php
@@ -10,9 +10,11 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
+use Override;
 
 class LoadAliasData extends Fixture implements FixtureGroupInterface, DependentFixtureInterface
 {
+    #[Override]
     public function load(ObjectManager $manager): void
     {
         $user = $manager->getRepository(User::class)->findByEmail('user2@example.org');
@@ -26,11 +28,13 @@ class LoadAliasData extends Fixture implements FixtureGroupInterface, DependentF
         $manager->clear();
     }
 
+    #[Override]
     public static function getGroups(): array
     {
         return ['basic'];
     }
 
+    #[Override]
     public function getDependencies(): array
     {
         return [

--- a/src/DataFixtures/LoadApiTokenData.php
+++ b/src/DataFixtures/LoadApiTokenData.php
@@ -9,6 +9,7 @@ use App\Service\ApiTokenManager;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Persistence\ObjectManager;
+use Override;
 
 class LoadApiTokenData extends Fixture implements FixtureGroupInterface
 {
@@ -27,6 +28,7 @@ class LoadApiTokenData extends Fixture implements FixtureGroupInterface
     ) {
     }
 
+    #[Override]
     public function load(ObjectManager $manager): void
     {
         // Create retention token
@@ -65,6 +67,7 @@ class LoadApiTokenData extends Fixture implements FixtureGroupInterface
         );
     }
 
+    #[Override]
     public static function getGroups(): array
     {
         return ['basic'];

--- a/src/DataFixtures/LoadDomainData.php
+++ b/src/DataFixtures/LoadDomainData.php
@@ -8,6 +8,7 @@ use App\Entity\Domain;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Persistence\ObjectManager;
+use Override;
 
 class LoadDomainData extends Fixture implements FixtureGroupInterface
 {
@@ -16,6 +17,7 @@ class LoadDomainData extends Fixture implements FixtureGroupInterface
         'example.com',
     ];
 
+    #[Override]
     public function load(ObjectManager $manager): void
     {
         foreach ($this->domains as $name) {
@@ -29,6 +31,7 @@ class LoadDomainData extends Fixture implements FixtureGroupInterface
         $manager->clear();
     }
 
+    #[Override]
     public static function getGroups(): array
     {
         return ['basic'];

--- a/src/DataFixtures/LoadRandomAliasData.php
+++ b/src/DataFixtures/LoadRandomAliasData.php
@@ -10,9 +10,11 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
+use Override;
 
 class LoadRandomAliasData extends Fixture implements FixtureGroupInterface, DependentFixtureInterface
 {
+    #[Override]
     public function load(ObjectManager $manager): void
     {
         $user = $manager->getRepository(User::class)->findByEmail('admin@example.org');
@@ -39,11 +41,13 @@ class LoadRandomAliasData extends Fixture implements FixtureGroupInterface, Depe
         $manager->clear();
     }
 
+    #[Override]
     public static function getGroups(): array
     {
         return ['advanced'];
     }
 
+    #[Override]
     public function getDependencies(): array
     {
         return [

--- a/src/DataFixtures/LoadRandomUserData.php
+++ b/src/DataFixtures/LoadRandomUserData.php
@@ -9,9 +9,11 @@ use App\Enum\Roles;
 use DateTime;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Persistence\ObjectManager;
+use Override;
 
 class LoadRandomUserData extends AbstractUserData implements FixtureGroupInterface
 {
+    #[Override]
     public function load(ObjectManager $manager): void
     {
         $domainRepository = $manager->getRepository(Domain::class);
@@ -43,6 +45,7 @@ class LoadRandomUserData extends AbstractUserData implements FixtureGroupInterfa
         $manager->clear();
     }
 
+    #[Override]
     public static function getGroups(): array
     {
         return ['advanced'];

--- a/src/DataFixtures/LoadReservedNameData.php
+++ b/src/DataFixtures/LoadReservedNameData.php
@@ -9,6 +9,7 @@ use App\Exception\ValidationException;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Persistence\ObjectManager;
+use Override;
 
 class LoadReservedNameData extends Fixture implements FixtureGroupInterface
 {
@@ -22,6 +23,7 @@ class LoadReservedNameData extends Fixture implements FixtureGroupInterface
     /**
      * @throws ValidationException
      */
+    #[Override]
     public function load(ObjectManager $manager): void
     {
         $handle = fopen(
@@ -44,6 +46,7 @@ class LoadReservedNameData extends Fixture implements FixtureGroupInterface
         }
     }
 
+    #[Override]
     public static function getGroups(): array
     {
         return ['basic'];

--- a/src/DataFixtures/LoadUserData.php
+++ b/src/DataFixtures/LoadUserData.php
@@ -10,6 +10,7 @@ use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Exception;
+use Override;
 
 class LoadUserData extends AbstractUserData implements DependentFixtureInterface, FixtureGroupInterface
 {
@@ -31,6 +32,7 @@ class LoadUserData extends AbstractUserData implements DependentFixtureInterface
     /**
      * @throws Exception
      */
+    #[Override]
     public function load(ObjectManager $manager): void
     {
         foreach ($this->users as $user) {
@@ -65,6 +67,7 @@ class LoadUserData extends AbstractUserData implements DependentFixtureInterface
         $manager->clear();
     }
 
+    #[Override]
     public function getDependencies(): array
     {
         return [
@@ -72,6 +75,7 @@ class LoadUserData extends AbstractUserData implements DependentFixtureInterface
         ];
     }
 
+    #[Override]
     public static function getGroups(): array
     {
         return ['basic'];

--- a/src/DataFixtures/LoadVoucherData.php
+++ b/src/DataFixtures/LoadVoucherData.php
@@ -12,12 +12,14 @@ use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Exception;
+use Override;
 
 class LoadVoucherData extends Fixture implements FixtureGroupInterface, DependentFixtureInterface
 {
     /**
      * @throws Exception
      */
+    #[Override]
     public function load(ObjectManager $manager): void
     {
         $users = $manager->getRepository(User::class)->findAll();
@@ -56,11 +58,13 @@ class LoadVoucherData extends Fixture implements FixtureGroupInterface, Dependen
         $manager->clear();
     }
 
+    #[Override]
     public static function getGroups(): array
     {
         return ['advanced'];
     }
 
+    #[Override]
     public function getDependencies(): array
     {
         return [

--- a/src/DependencyInjection/Configuration/SettingsConfiguration.php
+++ b/src/DependencyInjection/Configuration/SettingsConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\DependencyInjection\Configuration;
 
+use Override;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -13,6 +14,7 @@ class SettingsConfiguration implements ConfigurationInterface
     /**
      * @psalm-suppress UndefinedInterfaceMethod
      */
+    #[Override]
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('settings');

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -18,6 +18,7 @@ use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\AssociationOverride;
 use Doctrine\ORM\Mapping\Index;
+use Override;
 use Stringable;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -86,6 +87,7 @@ class Alias implements SoftDeletableInterface, Stringable
         $this->destination = null;
     }
 
+    #[Override]
     public function __toString(): string
     {
         if ($this->source === null) {

--- a/src/Entity/Domain.php
+++ b/src/Entity/Domain.php
@@ -11,6 +11,7 @@ use App\Traits\NameTrait;
 use App\Traits\UpdatedTimeTrait;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Stringable;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
@@ -32,6 +33,7 @@ class Domain implements Stringable
         $this->updatedTime = $currentDateTime;
     }
 
+    #[Override]
     public function __toString(): string
     {
         return ($this->getName()) ?: '';

--- a/src/Entity/Filter/DomainFilter.php
+++ b/src/Entity/Filter/DomainFilter.php
@@ -8,9 +8,11 @@ use App\Entity\Domain;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use InvalidArgumentException;
+use Override;
 
 class DomainFilter extends SQLFilter
 {
+    #[Override]
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias): string
     {
         if (null === $domainId = $this->getDomainId()) {

--- a/src/Entity/ReservedName.php
+++ b/src/Entity/ReservedName.php
@@ -11,6 +11,7 @@ use App\Traits\NameTrait;
 use App\Traits\UpdatedTimeTrait;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Stringable;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
@@ -34,6 +35,7 @@ class ReservedName implements Stringable
         $this->updatedTime = $currentDateTime;
     }
 
+    #[Override]
     public function __toString(): string
     {
         return ($this->getName()) ?: '';

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -34,6 +34,7 @@ use DateTime;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Index;
+use Override;
 use Scheb\TwoFactorBundle\Model\BackupCodeInterface;
 use Scheb\TwoFactorBundle\Model\Totp\TwoFactorInterface;
 use Stringable;
@@ -100,11 +101,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
         $this->updatedTime = $currentDateTime;
     }
 
+    #[Override]
     public function __toString(): string
     {
         return ($this->getEmail()) ?: '';
     }
 
+    #[Override]
     public function getRoles(): array
     {
         return !empty($this->roles) ? $this->roles : [Roles::USER];
@@ -128,11 +131,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
         return $this->getUserIdentifier();
     }
 
+    #[Override]
     public function getUserIdentifier(): string
     {
         return $this->email ?? '';
     }
 
+    #[Override]
     public function getPasswordHasherName(): ?string
     {
         if ($this->getPasswordVersion() < self::CURRENT_PASSWORD_VERSION) {
@@ -143,6 +148,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
         return null;
     }
 
+    #[Override]
     public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here

--- a/src/Entity/Voucher.php
+++ b/src/Entity/Voucher.php
@@ -12,6 +12,7 @@ use App\Validator\VoucherUser;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Index;
+use Override;
 use Stringable;
 
 #[ORM\Entity(repositoryClass: VoucherRepository::class)]
@@ -74,6 +75,7 @@ class Voucher implements Stringable
         $this->invitedUser = $invitedUser;
     }
 
+    #[Override]
     public function __toString(): string
     {
         return (string) $this->code;

--- a/src/EventListener/AliasCreationListener.php
+++ b/src/EventListener/AliasCreationListener.php
@@ -7,6 +7,7 @@ namespace App\EventListener;
 use App\Event\AliasCreatedEvent;
 use App\Sender\AliasCreatedMessageSender;
 use Exception;
+use Override;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -38,6 +39,7 @@ readonly class AliasCreationListener implements EventSubscriberInterface
         $this->sender->send($user, $alias, $locale);
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/ApiScopeListener.php
+++ b/src/EventListener/ApiScopeListener.php
@@ -6,6 +6,7 @@ namespace App\EventListener;
 
 use App\Entity\ApiToken;
 use App\Security\RequireApiScope;
+use Override;
 use ReflectionClass;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
@@ -13,6 +14,7 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class ApiScopeListener implements EventSubscriberInterface
 {
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/BeforeRequestListener.php
+++ b/src/EventListener/BeforeRequestListener.php
@@ -7,6 +7,7 @@ namespace App\EventListener;
 use App\Entity\User;
 use App\Enum\Roles;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -41,6 +42,7 @@ class BeforeRequestListener implements EventSubscriberInterface
         return $this->entityManager->getRepository(User::class)->findByEmail($user->getUserIdentifier());
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [KernelEvents::REQUEST => [['onKernelRequest']]];

--- a/src/EventListener/CompromisedPasswordListener.php
+++ b/src/EventListener/CompromisedPasswordListener.php
@@ -7,6 +7,7 @@ namespace App\EventListener;
 use App\Entity\User;
 use App\Event\LoginEvent;
 use App\Service\PasswordCompromisedService;
+use Override;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
@@ -21,6 +22,7 @@ readonly class CompromisedPasswordListener implements EventSubscriberInterface
     ) {
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/DomainCreationListener.php
+++ b/src/EventListener/DomainCreationListener.php
@@ -10,6 +10,7 @@ use App\Event\DomainCreatedEvent;
 use App\Handler\WkdHandler;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
+use Override;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class DomainCreationListener implements EventSubscriberInterface
@@ -46,6 +47,7 @@ class DomainCreationListener implements EventSubscriberInterface
         $this->handler->getDomainWkdPath($domain->getName());
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/JsonExceptionListener.php
+++ b/src/EventListener/JsonExceptionListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventListener;
 
 use App\Helper\JsonRequestHelper;
+use Override;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,6 +21,7 @@ readonly class JsonExceptionListener implements EventSubscriberInterface
     ) {
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
+use Override;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -47,6 +48,7 @@ readonly class LocaleListener implements EventSubscriberInterface
         $request->setLocale($sessionLocale);
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         // must be registered before (i.e. with a higher priority than) the default Locale listener

--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -9,6 +9,7 @@ use App\Enum\MailCrypt;
 use App\Event\LoginEvent;
 use App\Handler\MailCryptKeyHandler;
 use App\Service\UserLastLoginUpdateService;
+use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -73,6 +74,7 @@ readonly class LoginListener implements EventSubscriberInterface
         $this->mailCryptKeyHandler->create($user, $password, true);
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/LogoutListener.php
+++ b/src/EventListener/LogoutListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
+use Override;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
@@ -17,6 +18,7 @@ class LogoutListener implements EventSubscriberInterface
         $session->getFlashBag()->add('success', 'flashes.logout-successful');
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/PasswordChangeListener.php
+++ b/src/EventListener/PasswordChangeListener.php
@@ -10,6 +10,7 @@ use App\Enum\UserNotificationType;
 use App\Event\UserEvent;
 use App\Helper\JsonRequestHelper;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -27,6 +28,7 @@ readonly class PasswordChangeListener implements EventSubscriberInterface
     ) {
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/RandomAliasCreationListener.php
+++ b/src/EventListener/RandomAliasCreationListener.php
@@ -9,6 +9,7 @@ use App\Entity\Domain;
 use App\Event\RandomAliasCreatedEvent;
 use App\Helper\RandomStringGenerator;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class RandomAliasCreationListener implements EventSubscriberInterface
@@ -33,6 +34,7 @@ class RandomAliasCreationListener implements EventSubscriberInterface
         }
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/RecoveryProcessListener.php
+++ b/src/EventListener/RecoveryProcessListener.php
@@ -8,6 +8,7 @@ use App\Event\RecoveryProcessEvent;
 use App\Event\UserEvent;
 use App\Sender\RecoveryProcessMessageSender;
 use Exception;
+use Override;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -22,6 +23,7 @@ readonly class RecoveryProcessListener implements EventSubscriberInterface
     ) {
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/TwigGlobalListener.php
+++ b/src/EventListener/TwigGlobalListener.php
@@ -6,6 +6,7 @@ namespace App\EventListener;
 
 use App\Entity\Domain;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -30,6 +31,7 @@ class TwigGlobalListener implements EventSubscriberInterface
         }
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [KernelEvents::CONTROLLER => 'injectGlobalVariables'];

--- a/src/EventListener/WebhookListener.php
+++ b/src/EventListener/WebhookListener.php
@@ -7,6 +7,7 @@ namespace App\EventListener;
 use App\Enum\WebhookEvent;
 use App\Event\UserEvent;
 use App\Service\WebhookDispatcher;
+use Override;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 readonly class WebhookListener implements EventSubscriberInterface
@@ -25,6 +26,7 @@ readonly class WebhookListener implements EventSubscriberInterface
         $this->dispatcher->dispatchUserEvent($event->getUser(), WebhookEvent::USER_DELETED);
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/WelcomeMailListener.php
+++ b/src/EventListener/WelcomeMailListener.php
@@ -7,6 +7,7 @@ namespace App\EventListener;
 use App\Entity\User;
 use App\Event\UserEvent;
 use App\Message\WelcomeMail;
+use Override;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -19,6 +20,7 @@ readonly class WelcomeMailListener implements EventSubscriberInterface
     ) {
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Form/AliasDeleteType.php
+++ b/src/Form/AliasDeleteType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\Delete;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -18,6 +19,7 @@ class AliasDeleteType extends AbstractType
 {
     public const NAME = 'delete_alias';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -25,11 +27,13 @@ class AliasDeleteType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.delete-alias']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => Delete::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/ApiTokenType.php
+++ b/src/Form/ApiTokenType.php
@@ -6,6 +6,7 @@ namespace App\Form;
 
 use App\Enum\ApiScope;
 use App\Form\Model\ApiToken;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -17,6 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ApiTokenType extends AbstractType
 {
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $choices = array_combine(ApiScope::all(), ApiScope::all());
@@ -31,6 +33,7 @@ class ApiTokenType extends AbstractType
             ->add('submit', SubmitType::class);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Form/CustomAliasCreateType.php
+++ b/src/Form/CustomAliasCreateType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\AliasCreate;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -18,6 +19,7 @@ class CustomAliasCreateType extends AbstractType
 {
     public const NAME = 'create_custom_alias';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -25,11 +27,13 @@ class CustomAliasCreateType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.create-custom-alias']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => AliasCreate::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/DataTransformer/TextToEmailTransformer.php
+++ b/src/Form/DataTransformer/TextToEmailTransformer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Form\DataTransformer;
 
+use Override;
 use Symfony\Component\Form\DataTransformerInterface;
 
 /**
@@ -18,6 +19,7 @@ class TextToEmailTransformer implements DataTransformerInterface
     {
     }
 
+    #[Override]
     public function transform(mixed $value): mixed
     {
         if (null === $value) {
@@ -29,6 +31,7 @@ class TextToEmailTransformer implements DataTransformerInterface
         return false === $pos ? (string) $value : substr((string) $value, 0, $pos);
     }
 
+    #[Override]
     public function reverseTransform(mixed $value): mixed
     {
         if (null === $value || '' === $value) {

--- a/src/Form/DomainCreateType.php
+++ b/src/Form/DomainCreateType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\DomainCreate;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -18,6 +19,7 @@ class DomainCreateType extends AbstractType
 {
     public const NAME = 'create_domain';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -25,11 +27,13 @@ class DomainCreateType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.add']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => DomainCreate::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/OpenPgpDeleteType.php
+++ b/src/Form/OpenPgpDeleteType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\Delete;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -18,6 +19,7 @@ class OpenPgpDeleteType extends AbstractType
 {
     public const NAME = 'delete_openpgp';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -25,11 +27,13 @@ class OpenPgpDeleteType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'openpgp-delete']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => Delete::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/OpenPgpKeyType.php
+++ b/src/Form/OpenPgpKeyType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\OpenPgpKey;
+use Override;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -29,6 +30,7 @@ class OpenPgpKeyType extends AbstractType implements EventSubscriberInterface
     {
     }
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -57,16 +59,19 @@ class OpenPgpKeyType extends AbstractType implements EventSubscriberInterface
         $builder->addEventSubscriber($this);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => OpenPgpKey::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;
     }
 
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Form/PasswordType.php
+++ b/src/Form/PasswordType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\Password;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType as BasePasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -19,6 +20,7 @@ class PasswordType extends AbstractType
 {
     public const NAME = 'password';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -32,11 +34,13 @@ class PasswordType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.submit']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => Password::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/PlainPasswordType.php
+++ b/src/Form/PlainPasswordType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\PlainPassword;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -19,6 +20,7 @@ class PlainPasswordType extends AbstractType
 {
     public const NAME = 'plain_password';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -31,11 +33,13 @@ class PlainPasswordType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.submit']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => PlainPassword::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/RandomAliasCreateType.php
+++ b/src/Form/RandomAliasCreateType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\AliasCreate;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,17 +18,20 @@ class RandomAliasCreateType extends AbstractType
 {
     public const NAME = 'create_alias';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('submit', SubmitType::class, ['label' => 'form.create-random-alias']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => AliasCreate::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/RecoveryProcessType.php
+++ b/src/Form/RecoveryProcessType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\RecoveryProcess;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -18,6 +19,7 @@ class RecoveryProcessType extends AbstractType
 {
     public const NAME = 'recovery_process';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -26,11 +28,13 @@ class RecoveryProcessType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.recovery-start']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => RecoveryProcess::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/RecoveryResetPasswordType.php
+++ b/src/Form/RecoveryResetPasswordType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\RecoveryResetPassword;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -20,6 +21,7 @@ class RecoveryResetPasswordType extends AbstractType
 {
     public const NAME = 'recovery_reset_password';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -34,11 +36,13 @@ class RecoveryResetPasswordType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.submit']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => RecoveryResetPassword::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/RecoveryTokenConfirmType.php
+++ b/src/Form/RecoveryTokenConfirmType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\RecoveryTokenConfirm;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -19,6 +20,7 @@ class RecoveryTokenConfirmType extends AbstractType
 {
     public const NAME = 'recovery_token_confirm';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -30,11 +32,13 @@ class RecoveryTokenConfirmType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.registration-recovery-token-next-button']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => RecoveryTokenConfirm::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/RecoveryTokenType.php
+++ b/src/Form/RecoveryTokenType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\RecoveryToken;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -18,6 +19,7 @@ class RecoveryTokenType extends AbstractType
 {
     public const NAME = 'recovery_token';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -25,11 +27,13 @@ class RecoveryTokenType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.generate-recovery-token']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => RecoveryToken::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/RegistrationType.php
+++ b/src/Form/RegistrationType.php
@@ -8,6 +8,7 @@ use App\Entity\Domain;
 use App\Form\DataTransformer\TextToEmailTransformer;
 use App\Form\Model\Registration;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -33,6 +34,7 @@ class RegistrationType extends AbstractType
         $this->domain = $manager->getRepository(Domain::class)->getDefaultDomain()->getName();
     }
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $transformer = new TextToEmailTransformer($this->domain);
@@ -59,11 +61,13 @@ class RegistrationType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.submit']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => Registration::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/SettingsType.php
+++ b/src/Form/SettingsType.php
@@ -6,6 +6,7 @@ namespace App\Form;
 
 use App\Service\SettingsConfigService;
 use App\Service\SettingsService;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -32,6 +33,7 @@ class SettingsType extends AbstractType
     ) {
     }
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $definitions = $this->configService->getSettings();
@@ -173,6 +175,7 @@ class SettingsType extends AbstractType
         return $constraints;
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([]);

--- a/src/Form/TwofactorBackupConfirmType.php
+++ b/src/Form/TwofactorBackupConfirmType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\TwofactorBackupConfirm;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -18,6 +19,7 @@ class TwofactorBackupConfirmType extends AbstractType
 {
     public const NAME = 'twofactor_backup_confirm';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -28,11 +30,13 @@ class TwofactorBackupConfirmType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.verify']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => TwofactorBackupConfirm::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/TwofactorConfirmType.php
+++ b/src/Form/TwofactorConfirmType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\TwofactorConfirm;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -18,6 +19,7 @@ class TwofactorConfirmType extends AbstractType
 {
     public const NAME = 'twofactor_confirm';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -28,11 +30,13 @@ class TwofactorConfirmType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.verify']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => TwofactorConfirm::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/TwofactorType.php
+++ b/src/Form/TwofactorType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\Twofactor;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -18,6 +19,7 @@ class TwofactorType extends AbstractType
 {
     public const NAME = 'twofactor';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -25,11 +27,13 @@ class TwofactorType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'account.twofactor.setup-button']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => Twofactor::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/UserDeleteType.php
+++ b/src/Form/UserDeleteType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\Delete;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -18,6 +19,7 @@ class UserDeleteType extends AbstractType
 {
     public const NAME = 'delete_user';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -25,11 +27,13 @@ class UserDeleteType extends AbstractType
             ->add('submit', SubmitType::class, ['label' => 'form.delete-account']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => Delete::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/VoucherCreateType.php
+++ b/src/Form/VoucherCreateType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Form\Model\VoucherCreate;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,17 +18,20 @@ class VoucherCreateType extends AbstractType
 {
     public const NAME = 'create_voucher';
 
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('submit', SubmitType::class, ['label' => 'form.create-voucher']);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => VoucherCreate::class]);
     }
 
+    #[Override]
     public function getBlockPrefix(): string
     {
         return self::NAME;

--- a/src/Form/WebhookEndpointType.php
+++ b/src/Form/WebhookEndpointType.php
@@ -6,6 +6,7 @@ namespace App\Form;
 
 use App\Enum\WebhookEvent;
 use App\Form\Model\WebhookEndpointModel;
+use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -19,6 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class WebhookEndpointType extends AbstractType
 {
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $events = WebhookEvent::all();
@@ -37,6 +39,7 @@ class WebhookEndpointType extends AbstractType
             ->add('submit', SubmitType::class);
     }
 
+    #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Importer/GpgKeyImporter.php
+++ b/src/Importer/GpgKeyImporter.php
@@ -17,6 +17,7 @@ use Crypt_GPG_KeyNotFoundException;
 use Crypt_GPG_NoDataException;
 use DateTime;
 use Exception;
+use Override;
 use PEAR_Exception;
 use RuntimeException;
 
@@ -54,6 +55,7 @@ class GpgKeyImporter implements OpenPgpKeyImporterInterface
      * @throws MultipleGpgKeysForUserException
      * @throws RuntimeException
      */
+    #[Override]
     public static function import(string $email, string $data): OpenPgpKey
     {
         $tempDir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'userli_'.mt_rand().microtime(true);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -14,6 +14,7 @@ use Doctrine\Common\Collections\Selectable;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\LazyCriteriaCollection;
 use Exception;
+use Override;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 
@@ -136,6 +137,7 @@ class UserRepository extends EntityRepository implements PasswordUpgraderInterfa
         )->count();
     }
 
+    #[Override]
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
     {
         assert($user instanceof User);

--- a/src/Schedule/MaintenanceSchedule.php
+++ b/src/Schedule/MaintenanceSchedule.php
@@ -8,6 +8,7 @@ use App\Message\PruneUserNotifications;
 use App\Message\PruneWebhookDeliveries;
 use App\Message\UnlinkRedeemedVouchers;
 use DateTimeImmutable;
+use Override;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
@@ -16,6 +17,7 @@ use Symfony\Component\Scheduler\ScheduleProviderInterface;
 #[AsSchedule('maintenance')]
 final class MaintenanceSchedule implements ScheduleProviderInterface
 {
+    #[Override]
     public function getSchedule(): Schedule
     {
         return (new Schedule())

--- a/src/Security/ApiTokenAuthenticator.php
+++ b/src/Security/ApiTokenAuthenticator.php
@@ -6,6 +6,7 @@ namespace App\Security;
 
 use App\Security\Badge\ApiTokenBadge;
 use App\Service\ApiTokenManager;
+use Override;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,11 +24,13 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
     {
     }
 
+    #[Override]
     public function supports(Request $request): ?bool
     {
         return str_starts_with($request->getPathInfo(), '/api/');
     }
 
+    #[Override]
     public function authenticate(Request $request): Passport
     {
         $plainToken = $this->extractToken($request);
@@ -51,11 +54,13 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
         );
     }
 
+    #[Override]
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
         return null;
     }
 
+    #[Override]
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
         return new JsonResponse([

--- a/src/Security/Badge/ApiTokenBadge.php
+++ b/src/Security/Badge/ApiTokenBadge.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Security\Badge;
 
 use App\Entity\ApiToken;
+use Override;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 
 readonly class ApiTokenBadge implements BadgeInterface
@@ -18,6 +19,7 @@ readonly class ApiTokenBadge implements BadgeInterface
         return $this->apiToken;
     }
 
+    #[Override]
     public function isResolved(): bool
     {
         return true;

--- a/src/Security/Encoder/LegacyPasswordHasher.php
+++ b/src/Security/Encoder/LegacyPasswordHasher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Security\Encoder;
 
 use LogicException;
+use Override;
 use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
 use Symfony\Component\PasswordHasher\Hasher\CheckPasswordLengthTrait;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
@@ -24,11 +25,13 @@ class LegacyPasswordHasher implements PasswordHasherInterface
     {
     }
 
+    #[Override]
     public function needsRehash(string $hashedPassword): bool
     {
         return true;
     }
 
+    #[Override]
     public function hash(string $plainPassword): string
     {
         if ($this->isPasswordTooLong($plainPassword)) {
@@ -48,6 +51,7 @@ class LegacyPasswordHasher implements PasswordHasherInterface
         return $this->encodeHashAsBase64 ? base64_encode($digest) : $digest;
     }
 
+    #[Override]
     public function verify(string $hashedPassword, $plainPassword): bool
     {
         if ('' === $plainPassword || $this->isPasswordTooLong($plainPassword)) {

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\Security;
 
 use App\Entity\User;
+use Override;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserChecker implements UserCheckerInterface
 {
+    #[Override]
     public function checkPreAuth(UserInterface $user): void
     {
         if (!$user instanceof User) {
@@ -22,6 +24,7 @@ class UserChecker implements UserCheckerInterface
         }
     }
 
+    #[Override]
     public function checkPostAuth(UserInterface $user): void
     {
     }

--- a/src/Security/UserProvider.php
+++ b/src/Security/UserProvider.php
@@ -7,6 +7,7 @@ namespace App\Security;
 use App\Entity\Domain;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -26,6 +27,7 @@ class UserProvider implements UserProviderInterface
         return $this->loadUserByIdentifier($username);
     }
 
+    #[Override]
     public function loadUserByIdentifier(string $identifier): UserInterface
     {
         if (!str_contains($identifier, '@')) {
@@ -42,6 +44,7 @@ class UserProvider implements UserProviderInterface
         return $user;
     }
 
+    #[Override]
     public function refreshUser(UserInterface $user): UserInterface
     {
         if (!$user instanceof User) {
@@ -56,6 +59,7 @@ class UserProvider implements UserProviderInterface
         return $reloadedUser;
     }
 
+    #[Override]
     public function supportsClass($class): bool
     {
         $userClass = User::class;

--- a/src/Service/SettingsAwareTotpAuthenticator.php
+++ b/src/Service/SettingsAwareTotpAuthenticator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use Override;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface;
 
 readonly class SettingsAwareTotpAuthenticator implements TotpAuthenticatorInterface
@@ -14,6 +15,7 @@ readonly class SettingsAwareTotpAuthenticator implements TotpAuthenticatorInterf
     ) {
     }
 
+    #[Override]
     public function getQRContent($user): string
     {
         // Get the original QR content
@@ -44,11 +46,13 @@ readonly class SettingsAwareTotpAuthenticator implements TotpAuthenticatorInterf
         return $this->buildUrl($parsedUrl);
     }
 
+    #[Override]
     public function generateSecret(): string
     {
         return $this->decoratedAuthenticator->generateSecret();
     }
 
+    #[Override]
     public function checkCode($user, string $code): bool
     {
         return $this->decoratedAuthenticator->checkCode($user, $code);

--- a/src/Twig/SafeHtmlExtension.php
+++ b/src/Twig/SafeHtmlExtension.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Twig;
 
+use Override;
 use Twig\Extension\AbstractExtension;
 use Twig\Markup;
 use Twig\TwigFilter;
 
 class SafeHtmlExtension extends AbstractExtension
 {
+    #[Override]
     public function getFilters(): array
     {
         return [

--- a/src/Twig/SettingsExtension.php
+++ b/src/Twig/SettingsExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Twig;
 
 use App\Service\SettingsService;
+use Override;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -15,6 +16,7 @@ class SettingsExtension extends AbstractExtension
     ) {
     }
 
+    #[Override]
     public function getFunctions(): array
     {
         return [

--- a/src/Twig/UserNotificationExtension.php
+++ b/src/Twig/UserNotificationExtension.php
@@ -6,6 +6,7 @@ namespace App\Twig;
 
 use App\Entity\UserNotification;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Bundle\SecurityBundle\Security;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -18,6 +19,7 @@ class UserNotificationExtension extends AbstractExtension
     ) {
     }
 
+    #[Override]
     public function getFunctions(): array
     {
         return [

--- a/src/Validator/EmailAddressValidator.php
+++ b/src/Validator/EmailAddressValidator.php
@@ -9,6 +9,7 @@ use App\Entity\Domain;
 use App\Entity\ReservedName;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -19,6 +20,7 @@ class EmailAddressValidator extends ConstraintValidator
     {
     }
 
+    #[Override]
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof EmailAddress) {

--- a/src/Validator/EmailDomain.php
+++ b/src/Validator/EmailDomain.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Validator;
 
 use Attribute;
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -13,6 +14,7 @@ use Symfony\Component\Validator\Constraint;
 #[Attribute]
 class EmailDomain extends Constraint
 {
+    #[Override]
     public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;

--- a/src/Validator/EmailDomainValidator.php
+++ b/src/Validator/EmailDomainValidator.php
@@ -7,6 +7,7 @@ namespace App\Validator;
 use App\Entity\Domain;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -16,6 +17,7 @@ class EmailDomainValidator extends ConstraintValidator
     {
     }
 
+    #[Override]
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$value instanceof User) {

--- a/src/Validator/EmailLengthValidator.php
+++ b/src/Validator/EmailLengthValidator.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class EmailLengthValidator extends ConstraintValidator
 {
+    #[Override]
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof EmailLength) {

--- a/src/Validator/LowercaseValidator.php
+++ b/src/Validator/LowercaseValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -11,6 +12,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class LowercaseValidator extends ConstraintValidator
 {
+    #[Override]
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof Lowercase) {

--- a/src/Validator/PasswordPolicyValidator.php
+++ b/src/Validator/PasswordPolicyValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Validator;
 
 use App\Handler\PasswordStrengthHandler;
+use Override;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -14,6 +15,7 @@ class PasswordPolicyValidator extends ConstraintValidator
     {
     }
 
+    #[Override]
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (empty($value) || !is_string($value)) {

--- a/src/Validator/TotpSecretValidator.php
+++ b/src/Validator/TotpSecretValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
+use Override;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Validator\Constraint;
@@ -17,6 +18,7 @@ class TotpSecretValidator extends ConstraintValidator
     {
     }
 
+    #[Override]
     public function validate($value, Constraint $constraint): bool
     {
         if (!$constraint instanceof TotpSecret) {

--- a/src/Validator/VoucherExistsValidator.php
+++ b/src/Validator/VoucherExistsValidator.php
@@ -9,6 +9,7 @@ use App\Entity\Voucher;
 use App\Enum\Roles;
 use App\Repository\VoucherRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -22,6 +23,7 @@ class VoucherExistsValidator extends ConstraintValidator
         $this->voucherRepository = $manager->getRepository(Voucher::class);
     }
 
+    #[Override]
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof VoucherExists) {

--- a/src/Validator/VoucherUser.php
+++ b/src/Validator/VoucherUser.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Validator;
 
 use Attribute;
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute]
 class VoucherUser extends Constraint
 {
+    #[Override]
     public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;

--- a/src/Validator/VoucherUserValidator.php
+++ b/src/Validator/VoucherUserValidator.php
@@ -6,12 +6,14 @@ namespace App\Validator;
 
 use App\Entity\Voucher;
 use App\Enum\Roles;
+use Override;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class VoucherUserValidator extends ConstraintValidator
 {
+    #[Override]
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof VoucherUser) {

--- a/src/Voter/AliasVoter.php
+++ b/src/Voter/AliasVoter.php
@@ -6,6 +6,7 @@ namespace App\Voter;
 
 use App\Entity\Alias;
 use App\Entity\User;
+use Override;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
@@ -16,6 +17,7 @@ class AliasVoter extends Voter
 {
     public const DELETE = 'delete';
 
+    #[Override]
     protected function supports(string $attribute, mixed $subject): bool
     {
         if ($attribute !== self::DELETE) {
@@ -29,6 +31,7 @@ class AliasVoter extends Voter
         return true;
     }
 
+    #[Override]
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();

--- a/src/Voter/DomainVoter.php
+++ b/src/Voter/DomainVoter.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Enum\Roles;
 use App\Guesser\DomainGuesser;
 use Doctrine\ORM\EntityManagerInterface;
+use Override;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -33,6 +34,7 @@ class DomainVoter extends Voter
      *
      * @return bool True if the attribute and subject are supported, false otherwise
      */
+    #[Override]
     protected function supports($attribute, $subject): bool
     {
         // only vote on User and Alias objects inside this voter
@@ -62,6 +64,7 @@ class DomainVoter extends Voter
      *
      * @param string $attribute
      */
+    #[Override]
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
         // normal admins can do everything


### PR DESCRIPTION
This pull request introduces the use of the `#[Override]` attribute throughout the codebase to explicitly mark methods that override parent class methods. This improves code clarity and helps static analysis tools identify overridden methods. Additionally, a minor configuration change was made to the `psalm.xml` file to remove suppression for the `MissingOverrideAttribute` issue, reflecting the new usage of the attribute.