### PR TITLE
♻️ Email is required in User constructor

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -611,8 +611,7 @@ class CreateUserCommandHandler
 
     public function __invoke(CreateUserCommand $command): User
     {
-        $user = new User();
-        $user->setEmail($command->email);
+        $user = new User($command->email);
         $user->setPassword(
             $this->passwordHasher->hashPassword($user, $command->password)
         );

--- a/src/Command/UsersRemoveCommand.php
+++ b/src/Command/UsersRemoveCommand.php
@@ -54,7 +54,7 @@ final class UsersRemoveCommand extends Command
             }
 
             $domain = $user->getDomain()->getName();
-            $name = str_replace('@'.$domain, '', (string) $user->getEmail());
+            $name = str_replace('@'.$domain, '', $user->getEmail());
             $path = $this->mailLocation.DIRECTORY_SEPARATOR.$domain.DIRECTORY_SEPARATOR.$name;
 
             if ($input->getOption('dry-run')) {

--- a/src/Command/UsersResetCommand.php
+++ b/src/Command/UsersResetCommand.php
@@ -121,7 +121,7 @@ final class UsersResetCommand extends AbstractUsersCommand
         $this->manager->flush();
 
         // Clear users mailbox
-        [$localPart, $domain] = explode('@', (string) $user->getEmail());
+        [$localPart, $domain] = explode('@', $user->getEmail());
         $path = $this->mailLocation.DIRECTORY_SEPARATOR.$domain.DIRECTORY_SEPARATOR.$localPart.DIRECTORY_SEPARATOR.'Maildir';
         $filesystem = new Filesystem();
         if ($filesystem->exists($path)) {

--- a/src/DataFixtures/AbstractUserData.php
+++ b/src/DataFixtures/AbstractUserData.php
@@ -22,16 +22,15 @@ abstract class AbstractUserData extends Fixture
         public readonly TotpAuthenticatorInterface $totpAuthenticator,
         public readonly MailCryptKeyHandler $mailCryptKeyHandler,
     ) {
-        $user = new User();
+        $user = new User('');
         $passwordUpdater->updatePassword($user, self::PASSWORD);
         $this->passwordHash = $user->getPassword();
     }
 
     protected function buildUser(Domain $domain, string $email, array $roles): User
     {
-        $user = new User();
+        $user = new User($email);
         $user->setDomain($domain);
-        $user->setEmail($email);
         $user->setRoles($roles);
         $user->setPassword($this->passwordHash);
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -91,8 +91,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
     /**
      * User constructor.
      */
-    public function __construct()
+    public function __construct(string $email)
     {
+        $this->email = $email;
         $this->deleted = false;
         $this->passwordVersion = self::CURRENT_PASSWORD_VERSION;
         $this->passwordChangeRequired = false;
@@ -104,7 +105,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
     #[Override]
     public function __toString(): string
     {
-        return ($this->getEmail()) ?: '';
+        return $this->getEmail();
     }
 
     #[Override]
@@ -134,7 +135,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
     #[Override]
     public function getUserIdentifier(): string
     {
-        return $this->email ?? '';
+        return $this->email;
     }
 
     #[Override]

--- a/src/Handler/RegistrationHandler.php
+++ b/src/Handler/RegistrationHandler.php
@@ -68,8 +68,7 @@ final readonly class RegistrationHandler
 
     private function buildUser(Registration $registration): User
     {
-        $user = new User();
-        $user->setEmail(strtolower((string) $registration->getEmail()));
+        $user = new User(strtolower((string) $registration->getEmail()));
         $user->setRoles([Roles::USER]);
 
         if (null !== $domain = $this->domainGuesser->guess($registration->getEmail())) {

--- a/src/Helper/AdminPasswordUpdater.php
+++ b/src/Helper/AdminPasswordUpdater.php
@@ -26,8 +26,7 @@ final class AdminPasswordUpdater
         $admin = $this->manager->getRepository(User::class)->findByEmail($adminEmail);
         if (null === $admin) {
             // create admin user
-            $admin = new User();
-            $admin->setEmail($adminEmail);
+            $admin = new User($adminEmail);
             $admin->setRoles([Roles::ADMIN]);
             $admin->setDomain($domain);
         }

--- a/src/Traits/EmailTrait.php
+++ b/src/Traits/EmailTrait.php
@@ -14,9 +14,9 @@ trait EmailTrait
     #[Assert\NotNull]
     #[Lowercase]
     #[Assert\Email]
-    private ?string $email = '';
+    private string $email;
 
-    public function getEmail(): ?string
+    public function getEmail(): string
     {
         return $this->email;
     }

--- a/src/Validator/EmailDomainValidator.php
+++ b/src/Validator/EmailDomainValidator.php
@@ -24,7 +24,7 @@ final class EmailDomainValidator extends ConstraintValidator
             return;
         }
 
-        $name = substr(strrchr((string) $value->getEmail(), '@'), 1);
+        $name = substr(strrchr($value->getEmail(), '@'), 1);
         $domain = $this->manager->getRepository(Domain::class)->findOneBy(['name' => $name]);
 
         if (null === $domain) {

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -123,7 +123,12 @@ class FeatureContext extends MinkContext
     public function theFollowingUserExists(TableNode $table): void
     {
         foreach ($table->getColumnsHash() as $data) {
-            $user = new User();
+            $email = $data['email'] ?? '';
+            $user = new User($email);
+
+            if (null !== $domain = $this->domainGuesser->guess($email)) {
+                $user->setDomain($domain);
+            }
 
             foreach ($data as $key => $value) {
                 if (empty($value)) {
@@ -132,12 +137,7 @@ class FeatureContext extends MinkContext
 
                 switch ($key) {
                     case 'email':
-                        $user->setEmail($value);
-
-                        if (null !== $domain = $this->domainGuesser->guess($value)) {
-                            $user->setDomain($domain);
-                        }
-
+                        // Already handled above
                         break;
                     case 'password':
                         $this->passwordUpdater->updatePassword($user, $value);

--- a/tests/Command/AliasDeleteCommandTest.php
+++ b/tests/Command/AliasDeleteCommandTest.php
@@ -21,8 +21,7 @@ class AliasDeleteCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $user = new User();
-        $user->setEmail('user@example.org');
+        $user = new User('user@example.org');
 
         $userRepository = $this->getMockBuilder(UserRepository::class)
             ->disableOriginalConstructor()

--- a/tests/Command/UsersDeleteCommandTest.php
+++ b/tests/Command/UsersDeleteCommandTest.php
@@ -20,8 +20,7 @@ class UsersDeleteCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $user = new User();
-        $user->setEmail('user@example.org');
+        $user = new User('user@example.org');
 
         $repository = $this->getMockBuilder(UserRepository::class)
             ->disableOriginalConstructor()

--- a/tests/Command/UsersResetCommandTest.php
+++ b/tests/Command/UsersResetCommandTest.php
@@ -24,8 +24,7 @@ class UsersResetCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->user = new User();
-        $this->user->setEmail('user@example.org');
+        $this->user = new User('user@example.org');
         $this->user->setTotpSecret('secret');
         $this->user->setTotpConfirmed(true);
         $this->user->addBackupCode('123456');

--- a/tests/Command/UsersRestoreCommandTest.php
+++ b/tests/Command/UsersRestoreCommandTest.php
@@ -23,8 +23,7 @@ class UsersRestoreCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->user = new User();
-        $this->user->setEmail('deleted@example.org');
+        $this->user = new User('deleted@example.org');
         $this->user->setDeleted(true);
 
         $repository = $this->getMockBuilder(UserRepository::class)

--- a/tests/Command/VoucherCountCommandTest.php
+++ b/tests/Command/VoucherCountCommandTest.php
@@ -21,8 +21,7 @@ class VoucherCountCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $user = new User();
-        $user->setEmail('user@example.org');
+        $user = new User('user@example.org');
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->method('findByEmail')->willReturnMap(
             [

--- a/tests/Command/VoucherCreateCommandTest.php
+++ b/tests/Command/VoucherCreateCommandTest.php
@@ -86,8 +86,7 @@ class VoucherCreateCommandTest extends TestCase
         $baseUrl = 'https://users.example.org';
         $voucherCode = 'code';
 
-        $user = new User();
-        $user->setEmail('user@example.org');
+        $user = new User('user@example.org');
         $this->repository->method('findByEmail')
             ->willReturn($user);
 
@@ -147,8 +146,7 @@ class VoucherCreateCommandTest extends TestCase
         $baseUrl = 'https://users.example.org';
         $voucherCode = 'code';
 
-        $user = new User();
-        $user->setEmail('suspicious@example.org');
+        $user = new User('suspicious@example.org');
         $this->repository->method('findByEmail')
             ->willReturn($user);
 
@@ -187,8 +185,7 @@ class VoucherCreateCommandTest extends TestCase
         $baseUrl = 'https://users.example.org';
         $voucherCode = 'abc123';
 
-        $user = new User();
-        $user->setEmail($email);
+        $user = new User($email);
 
         $this->repository->expects(self::once())
             ->method('findByEmail')
@@ -237,8 +234,7 @@ class VoucherCreateCommandTest extends TestCase
         $baseUrl = 'https://users.example.org';
         $voucherCode = 'xyz789';
 
-        $user = new User();
-        $user->setEmail($email);
+        $user = new User($email);
 
         $this->repository->expects(self::once())
             ->method('findByEmail')

--- a/tests/Creator/AliasCreatorTest.php
+++ b/tests/Creator/AliasCreatorTest.php
@@ -40,7 +40,7 @@ class AliasCreatorTest extends TestCase
     {
         $domain = new Domain();
         $domain->setName('example.org');
-        $user = new User();
+        $user = new User('user@example.org');
         $user->setDomain($domain);
 
         return $user;

--- a/tests/Creator/VoucherCreatorTest.php
+++ b/tests/Creator/VoucherCreatorTest.php
@@ -34,7 +34,7 @@ class VoucherCreatorTest extends TestCase
 
         $creator = new VoucherCreator($manager, $validator, $eventDispatcher);
 
-        $user = new User();
+        $user = new User('test@example.org');
 
         $voucher = $creator->create($user);
 
@@ -54,7 +54,7 @@ class VoucherCreatorTest extends TestCase
 
         $creator = new VoucherCreator($manager, $validator, $eventDispatcher);
 
-        $user = new User();
+        $user = new User('test@example.org');
 
         $this->expectException(ValidationException::class);
 

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -17,7 +17,7 @@ class UserTest extends TestCase
 {
     public function testGetRoles(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $this->hasOnlyValidRoles($user->getRoles());
 
         $user->setRoles([Roles::SUSPICIOUS]);
@@ -37,13 +37,13 @@ class UserTest extends TestCase
 
     public function testUserIsUserByDefault(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         self::assertTrue($user->hasRole(Roles::USER));
     }
 
     public function testHasRole(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setRoles([Roles::DOMAIN_ADMIN]);
         self::assertTrue($user->hasRole(Roles::DOMAIN_ADMIN));
         self::assertFalse($user->hasRole(Roles::ADMIN));
@@ -51,7 +51,7 @@ class UserTest extends TestCase
 
     public function testGetPasswordHasherName(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         self::assertNull($user->getPasswordHasherName());
         $user->setPasswordVersion(1);
         self::assertEquals('legacy', $user->getPasswordHasherName());
@@ -59,7 +59,7 @@ class UserTest extends TestCase
 
     public function testHasRecoverySecretBox(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         self::assertFalse($user->hasRecoverySecretBox());
         $user->setRecoverySecretBox('testsecret');
         self::assertTrue($user->hasRecoverySecretBox());
@@ -67,7 +67,7 @@ class UserTest extends TestCase
 
     public function testPlainRecoveryToken(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         self::assertNull($user->getPlainRecoveryToken());
         $user->setPlainRecoveryToken('testtoken');
         self::assertEquals('testtoken', $user->getPlainRecoveryToken());
@@ -77,14 +77,14 @@ class UserTest extends TestCase
 
     public function testHasCreationTimeSet(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $today = new DateTime();
         self::assertEquals($user->getCreationTime()->format('Y-m-d'), $today->format('Y-m-d'));
     }
 
     public function testHasUpdatedTimeSet(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $today = new DateTime();
         self::assertEquals($user->getUpdatedTime()->format('Y-m-d'), $today->format('Y-m-d'));
     }
@@ -93,7 +93,7 @@ class UserTest extends TestCase
     {
         // totpSecret and totpConfirmed
         $totpSecret = 'secret';
-        $user = new User();
+        $user = new User('user@example.org');
         self::assertFalse($user->getTotpConfirmed());
         self::assertFalse($user->isTotpAuthenticationEnabled());
         $user->setTotpSecret($totpSecret);
@@ -104,7 +104,6 @@ class UserTest extends TestCase
 
         // getTotpAuthenticationUsername
         $email = 'user@example.org';
-        $user->setEmail($email);
         self::assertEquals($email, $user->getTotpAuthenticationUsername());
 
         // getTotpAuthenticationConfiguration

--- a/tests/EntityListener/UserChangedListenerTest.php
+++ b/tests/EntityListener/UserChangedListenerTest.php
@@ -48,7 +48,7 @@ class UserChangedListenerTest extends TestCase
 
     public function testPreUpdateNoRoleChanges(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $args = $this->createMock(PreUpdateEventArgs::class);
         $args->method('getEntityChangeSet')
             ->willReturn(['someField' => [0, 1]]);
@@ -61,7 +61,7 @@ class UserChangedListenerTest extends TestCase
 
     public function testPreUpdateOtherRoleChanges(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $args = $this->createMock(PreUpdateEventArgs::class);
         $args->method('getEntityChangeSet')
             ->willReturn(['roles' => [[Roles::USER], [Roles::USER, Roles::PERMANENT]]]);
@@ -74,7 +74,7 @@ class UserChangedListenerTest extends TestCase
 
     public function testPreUpdateRoleSuspiciousRemoved(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $args = $this->createMock(PreUpdateEventArgs::class);
         $args->method('getEntityChangeSet')
             ->willReturn(['roles' => [[Roles::USER, Roles::SUSPICIOUS], [Roles::USER]]]);
@@ -87,18 +87,15 @@ class UserChangedListenerTest extends TestCase
 
     public function testPreUpdateRoleSuspiciousAdded(): void
     {
-        $user = new User();
-        $user->setEmail('user@example.org');
+        $user = new User('user@example.org');
         $args = $this->createMock(PreUpdateEventArgs::class);
         $args->method('getEntityChangeSet')
             ->willReturn(['roles' => [[Roles::USER], [Roles::USER, Roles::SUSPICIOUS]]]);
 
-        $invitedUser1 = new User();
-        $invitedUser1->setEmail('invited1@example.org');
+        $invitedUser1 = new User('invited1@example.org');
         $voucher1 = new Voucher();
         $voucher1->setInvitedUser($invitedUser1);
-        $invitedUser2 = new User();
-        $invitedUser2->setEmail('invited2@example.org');
+        $invitedUser2 = new User('invited2@example.org');
         $voucher2 = new Voucher();
         $voucher2->setInvitedUser($invitedUser2);
         $this->voucherRepository->method('getRedeemedVouchersByUser')

--- a/tests/EventListener/BeforeRequestListenerTest.php
+++ b/tests/EventListener/BeforeRequestListenerTest.php
@@ -92,7 +92,7 @@ class BeforeRequestListenerTest extends TestCase
     {
         $domain = new Domain();
         $domain->setId(1);
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setDomain($domain);
 
         return $user;

--- a/tests/EventListener/LoginListenerTest.php
+++ b/tests/EventListener/LoginListenerTest.php
@@ -134,7 +134,7 @@ class LoginListenerTest extends TestCase
 
         return array_map(
             function ($enable, $create) {
-                $user = new User();
+                $user = new User('test@example.org');
                 if ($enable === false || $enable === true) {
                     $user->setMailCryptEnabled($enable);
                 }

--- a/tests/EventListener/PasswordChangeListenerTest.php
+++ b/tests/EventListener/PasswordChangeListenerTest.php
@@ -64,7 +64,7 @@ class PasswordChangeListenerTest extends TestCase
 
     public function testReturnsWhenNotFullyAuthenticated(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setPasswordChangeRequired(true);
 
         $this->security->method('getUser')->willReturn($user);
@@ -85,7 +85,7 @@ class PasswordChangeListenerTest extends TestCase
 
     public function testReturnsWhenUserDoesNotRequirePasswordChange(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setPasswordChangeRequired(false);
 
         $this->security->method('getUser')->willReturn($user);
@@ -109,7 +109,7 @@ class PasswordChangeListenerTest extends TestCase
      */
     public function testAllowsAccessToPasswordRoutes(string $routeName): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setPasswordChangeRequired(true);
 
         $this->security->method('getUser')->willReturn($user);
@@ -140,7 +140,7 @@ class PasswordChangeListenerTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setPasswordChangeRequired(true);
 
         $this->security->method('getUser')->willReturn($user);
@@ -161,7 +161,7 @@ class PasswordChangeListenerTest extends TestCase
 
     public function testRedirectsToPasswordPage(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setPasswordChangeRequired(true);
 
         $this->security->method('getUser')->willReturn($user);
@@ -194,7 +194,7 @@ class PasswordChangeListenerTest extends TestCase
 
     public function testOnPasswordChanged(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $event = new UserEvent($user);
         $repo = $this->createMock(UserNotificationRepository::class);
 

--- a/tests/EventListener/WebhookListenerTest.php
+++ b/tests/EventListener/WebhookListenerTest.php
@@ -15,7 +15,7 @@ class WebhookListenerTest extends TestCase
 {
     public function testOnUserCreated(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $dispatcher = $this->createMock(WebhookDispatcher::class);
         $dispatcher->expects($this->once())->method('dispatchUserEvent')->with($user, WebhookEvent::USER_CREATED);
         $listener = new WebhookListener($dispatcher);
@@ -24,7 +24,7 @@ class WebhookListenerTest extends TestCase
 
     public function testOnUserDeleted(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $dispatcher = $this->createMock(WebhookDispatcher::class);
         $dispatcher->expects($this->once())->method('dispatchUserEvent')->with($user, WebhookEvent::USER_DELETED);
         $listener = new WebhookListener($dispatcher);

--- a/tests/EventListener/WelcomeMailListenerTest.php
+++ b/tests/EventListener/WelcomeMailListenerTest.php
@@ -25,8 +25,7 @@ class WelcomeMailListenerTest extends TestCase
 
     public function testOnUserCreatedDispatchesWelcomeMailWithLocale(): void
     {
-        $user = new User();
-        $user->setEmail('newuser@example.test');
+        $user = new User('newuser@example.test');
         $locale = 'fr';
 
         $session = $this->createMock(SessionInterface::class);
@@ -56,8 +55,7 @@ class WelcomeMailListenerTest extends TestCase
 
     public function testOnUserCreatedWithSessionReturningNullLocaleFallsBackToDefault(): void
     {
-        $user = new User();
-        $user->setEmail('newuser@example.test');
+        $user = new User('newuser@example.test');
 
         $session = $this->createMock(SessionInterface::class);
         $session->expects($this->once())
@@ -86,8 +84,7 @@ class WelcomeMailListenerTest extends TestCase
 
     public function testOnUserCreatedWithNoRequestFallsBackToDefaultLocale(): void
     {
-        $user = new User();
-        $user->setEmail('newuser@example.test');
+        $user = new User('newuser@example.test');
 
         $requestStack = $this->createMock(RequestStack::class);
         $requestStack->method('getCurrentRequest')->willReturn(null);

--- a/tests/Factory/VoucherFactoryTest.php
+++ b/tests/Factory/VoucherFactoryTest.php
@@ -12,7 +12,7 @@ class VoucherFactoryTest extends TestCase
 {
     public function testCreate(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
 
         $voucher = VoucherFactory::create($user);
 

--- a/tests/Handler/AliasHandlerTest.php
+++ b/tests/Handler/AliasHandlerTest.php
@@ -30,7 +30,7 @@ class AliasHandlerTest extends TestCase
     public function testCheckAliasLimit(): void
     {
         $handler = $this->createHandler([]);
-        $user = new User();
+        $user = new User('test@example.org');
 
         self::assertTrue($handler->checkAliasLimit([]));
     }
@@ -38,7 +38,7 @@ class AliasHandlerTest extends TestCase
     public function testCreate(): void
     {
         $handler = $this->createHandler([]);
-        $user = new User();
+        $user = new User('test@example.org');
 
         self::assertInstanceOf(Alias::class, $handler->create($user, null));
     }
@@ -50,7 +50,7 @@ class AliasHandlerTest extends TestCase
             $list[] = 'dummy';
         }
         $handler = $this->createHandler($list);
-        $user = new User();
+        $user = new User('test@example.org');
 
         self::assertNull($handler->create($user, null));
     }

--- a/tests/Handler/DeleteHandlerTest.php
+++ b/tests/Handler/DeleteHandlerTest.php
@@ -46,11 +46,11 @@ class DeleteHandlerTest extends TestCase
     {
         $handler = $this->createHandler();
 
-        $user = new User();
+        $user = new User('alice@example.org');
         $alias = new Alias();
         $alias->setUser($user);
 
-        $user2 = new User();
+        $user2 = new User('bob@example.org');
         $handler->deleteAlias($alias, $user2);
 
         self::assertNotTrue($alias->isDeleted());
@@ -69,9 +69,8 @@ class DeleteHandlerTest extends TestCase
 
         $oldPassword = 'old_password';
 
-        $user = new User();
+        $user = new User('alice@example.org');
         $user->setPassword($oldPassword);
-        $user->setEmail('alice@example.org');
 
         $handler->deleteUser($user);
 

--- a/tests/Handler/MailCryptKeyHandlerTest.php
+++ b/tests/Handler/MailCryptKeyHandlerTest.php
@@ -48,7 +48,7 @@ UQ==
     public function testCreate(): void
     {
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $handler->create($user, 'password');
 
         self::assertNotEmpty($user->getMailCryptPublicKey());
@@ -61,7 +61,7 @@ UQ==
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(MailCryptKeyHandler::MESSAGE_SECRET_IS_NULL);
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $handler->update($user, 'oldPassword', 'newPassword');
     }
 
@@ -70,7 +70,7 @@ UQ==
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(MailCryptKeyHandler::MESSAGE_DECRYPTION_FAILED);
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $handler->create($user, 'password');
 
         $handler->update($user, 'wrongPassword', 'newPassword');
@@ -79,7 +79,7 @@ UQ==
     public function testUpdate(): void
     {
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $handler->create($user, 'password');
         $secret = $user->getMailCryptSecretBox();
 
@@ -92,7 +92,7 @@ UQ==
     public function testUpdateWithPrivateKey(): void
     {
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $handler->create($user, 'password');
         $secret = $user->getMailCryptSecretBox();
 
@@ -107,7 +107,7 @@ UQ==
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(MailCryptKeyHandler::MESSAGE_SECRET_IS_NULL);
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
 
         $handler->decrypt($user, 'password');
     }
@@ -117,7 +117,7 @@ UQ==
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(MailCryptKeyHandler::MESSAGE_DECRYPTION_FAILED);
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $handler->create($user, 'password');
         $handler->decrypt($user, 'wrong_password');
     }
@@ -125,7 +125,7 @@ UQ==
     public function testDecrypt(): void
     {
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $handler->create($user, 'password');
 
         self::assertNotNull($handler->decrypt($user, 'password'));

--- a/tests/Handler/RecoveryTokenHandlerTest.php
+++ b/tests/Handler/RecoveryTokenHandlerTest.php
@@ -26,7 +26,7 @@ class RecoveryTokenHandlerTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('plainMailCryptPrivateKey should not be null');
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
 
         $handler->create($user);
     }
@@ -34,7 +34,7 @@ class RecoveryTokenHandlerTest extends TestCase
     public function testCreate(): void
     {
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
 
         $user->setPlainMailCryptPrivateKey('dummyKey');
         $handler->create($user);
@@ -45,7 +45,7 @@ class RecoveryTokenHandlerTest extends TestCase
     public function testVerify(): void
     {
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
 
         self::assertFalse($handler->verify($user, 'recoveryToken'));
 
@@ -66,7 +66,7 @@ class RecoveryTokenHandlerTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('secret should not be null');
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
 
         $handler->decrypt($user, 'recoveryToken');
     }
@@ -76,7 +76,7 @@ class RecoveryTokenHandlerTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('decryption of recoverySecretBox failed');
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setPlainMailCryptPrivateKey('privateKey');
         $handler->create($user);
 
@@ -86,7 +86,7 @@ class RecoveryTokenHandlerTest extends TestCase
     public function testDecrypt(): void
     {
         $handler = $this->createHandler();
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setPlainMailCryptPrivateKey('privateKey');
         $handler->create($user);
         $recoveryToken = $user->getPlainRecoveryToken();

--- a/tests/Handler/UserAuthenticationHandlerTest.php
+++ b/tests/Handler/UserAuthenticationHandlerTest.php
@@ -19,7 +19,7 @@ class UserAuthenticationHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->user = new User();
+        $this->user = new User('test@example.org');
         $this->user->setPassword($this->password);
     }
 

--- a/tests/Handler/UserRestoreHandlerTest.php
+++ b/tests/Handler/UserRestoreHandlerTest.php
@@ -56,7 +56,7 @@ class UserRestoreHandlerTest extends TestCase
         $mailCryptEnv = 0;
         $handler = new UserRestoreHandler($this->entityManagerInterface, $this->passwordUpdater, $this->mailCryptKeyHandler, $this->recoveryTokenHandler, $this->eventDispatcher, $mailCryptEnv);
 
-        $user = new User();
+        $user = new User('deleted@example.org');
         $user->setDeleted(true);
 
         $recoveryToken = $handler->restoreUser($user, 'new_password');
@@ -75,7 +75,7 @@ class UserRestoreHandlerTest extends TestCase
         $mailCryptEnv = 2;
         $handler = new UserRestoreHandler($this->entityManagerInterface, $this->passwordUpdater, $this->mailCryptKeyHandler, $this->recoveryTokenHandler, $this->eventDispatcher, $mailCryptEnv);
 
-        $user = new User();
+        $user = new User('deleted@example.org');
         $user->setDeleted(true);
 
         $recoveryToken = $handler->restoreUser($user, 'new_password');

--- a/tests/Handler/VoucherHandlerTest.php
+++ b/tests/Handler/VoucherHandlerTest.php
@@ -30,7 +30,7 @@ class VoucherHandlerTest extends TestCase
 
         $handler = new VoucherHandler($manager, $creator);
 
-        $user = new User();
+        $user = new User('suspicious@example.org');
         $user->setRoles([Roles::SUSPICIOUS]);
 
         $vouchers = $handler->getVouchersByUser($user);
@@ -50,7 +50,7 @@ class VoucherHandlerTest extends TestCase
 
         $handler = new VoucherHandler($manager, $creator);
 
-        $user = new User();
+        $user = new User('new@example.org');
         $user->setCreationTime(new DateTime());
 
         $vouchers = $handler->getVouchersByUser($user);
@@ -70,7 +70,7 @@ class VoucherHandlerTest extends TestCase
 
         $handler = new VoucherHandler($manager, $creator);
 
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setCreationTime(new DateTime('-8 days'));
 
         $vouchers = $handler->getVouchersByUser($user);
@@ -97,7 +97,7 @@ class VoucherHandlerTest extends TestCase
 
         $handler = new VoucherHandler($manager, $creator);
 
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setCreationTime(new DateTime('-8 days'));
 
         $vouchers = $handler->getVouchersByUser($user);

--- a/tests/Handler/WkdHandlerTest.php
+++ b/tests/Handler/WkdHandlerTest.php
@@ -75,9 +75,8 @@ class WkdHandlerTest extends TestCase
     {
         $domain = new Domain();
         $domain->setName(explode('@', (string) $this->email)[1]);
-        $user = new User();
+        $user = new User($this->email);
         $user->setDomain($domain);
-        $user->setEmail($this->email);
         $expected = new OpenPgpKey();
         $expected->setEmail($this->email);
         $expected->setKeyId($this->keyId);

--- a/tests/Helper/AdminPasswordUpdaterTest.php
+++ b/tests/Helper/AdminPasswordUpdaterTest.php
@@ -27,7 +27,7 @@ class AdminPasswordUpdaterTest extends TestCase
 
     public function testUpdateAdminPassword(): void
     {
-        $admin = new User();
+        $admin = new User('postmaster@example.org');
         $admin->setPassword('impossible_login');
 
         $adminPasswordUpdater = new AdminPasswordUpdater(

--- a/tests/Helper/PasswordUpdaterTest.php
+++ b/tests/Helper/PasswordUpdaterTest.php
@@ -20,7 +20,7 @@ class PasswordUpdaterTest extends TestCase
         $passwordHasherFactory->method('getPasswordHasher')->willReturn($hasher);
         $updater = new PasswordUpdater($passwordHasherFactory);
 
-        $user = new User();
+        $user = new User('test@example.org');
         $updater->updatePassword($user, 'password');
 
         $password = $user->getPassword();

--- a/tests/Integration/TotpAuthenticatorIntegrationTest.php
+++ b/tests/Integration/TotpAuthenticatorIntegrationTest.php
@@ -129,8 +129,7 @@ class TotpAuthenticatorIntegrationTest extends KernelTestCase
     private function createTestUser(): User
     {
         // Create a minimal User instance for testing
-        $user = new User();
-        $user->setEmail('test@example.com');
+        $user = new User('test@example.com');
 
         return $user;
     }

--- a/tests/MessageHandler/UnlinkRedeemedVouchersHandlerTest.php
+++ b/tests/MessageHandler/UnlinkRedeemedVouchersHandlerTest.php
@@ -21,21 +21,21 @@ class UnlinkRedeemedVouchersHandlerTest extends TestCase
         $voucher1 = new Voucher();
         $voucher1->setCode('A');
         $voucher1->setRedeemedTime(new DateTime('-4 months')); // old
-        $user1 = new User();
+        $user1 = new User('user1@example.org');
         $user1->setInvitationVoucher($voucher1);
         $voucher1->setInvitedUser($user1);
 
         $voucher2 = new Voucher();
         $voucher2->setCode('B');
         $voucher2->setRedeemedTime(new DateTime('-5 months')); // old
-        $user2 = new User();
+        $user2 = new User('user2@example.org');
         $user2->setInvitationVoucher($voucher2);
         $voucher2->setInvitedUser($user2);
 
         $voucherRecent = new Voucher();
         $voucherRecent->setCode('C');
         $voucherRecent->setRedeemedTime(new DateTime('-1 month')); // recent (should not appear in result set)
-        $recentUser = new User();
+        $recentUser = new User('recent@example.org');
         $recentUser->setInvitationVoucher($voucherRecent);
         $voucherRecent->setInvitedUser($recentUser);
 

--- a/tests/MessageHandler/WelcomeMailHandlerTest.php
+++ b/tests/MessageHandler/WelcomeMailHandlerTest.php
@@ -19,8 +19,7 @@ class WelcomeMailHandlerTest extends TestCase
         $email = 'user@example.test';
         $locale = 'de';
 
-        $user = new User();
-        $user->setEmail($email);
+        $user = new User($email);
 
         $repo = $this->createMock(ObjectRepository::class);
         $repo->expects($this->once())

--- a/tests/Security/UserCheckerTest.php
+++ b/tests/Security/UserCheckerTest.php
@@ -19,11 +19,11 @@ class UserCheckerTest extends TestCase
 
     public function testPreAuth(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
 
         $this->userChecker->checkPreAuth($user);
 
-        $deletedUser = new User();
+        $deletedUser = new User('deleted@example.org');
         $deletedUser->setDeleted(true);
 
         $this->expectException('Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException');
@@ -32,7 +32,7 @@ class UserCheckerTest extends TestCase
 
     public function testPostAuth(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
 
         $this->userChecker->checkPostAuth($user);
 

--- a/tests/Security/UserProviderTest.php
+++ b/tests/Security/UserProviderTest.php
@@ -24,8 +24,8 @@ class UserProviderTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $userRepository->method('findByEmail')->willReturnMap([
-            ['admin@example.org', new User()],
-            ['admin', new User()],
+            ['admin@example.org', new User('admin@example.org')],
+            ['admin', new User('admin@example.org')],
         ]);
 
         $domain = new Domain();
@@ -56,8 +56,8 @@ class UserProviderTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $repository->method('findByEmail')->willReturnMap([
-            ['admin@example.org', new User()],
-            ['admin', new User()],
+            ['admin@example.org', new User('admin@example.org')],
+            ['admin', new User('admin@example.org')],
         ]);
 
         $manager = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
@@ -70,7 +70,7 @@ class UserProviderTest extends TestCase
 
     public function testRefreshUserSuccessful(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setId(1);
 
         $repository = $this->getMockBuilder(UserRepository::class)
@@ -122,7 +122,7 @@ class UserProviderTest extends TestCase
 
     public function userProvider(): array
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setId(1);
 
         return [

--- a/tests/Service/PasswordCompromisedServiceTest.php
+++ b/tests/Service/PasswordCompromisedServiceTest.php
@@ -42,8 +42,7 @@ class PasswordCompromisedServiceTest extends TestCase
 
     public function testCheckAndNotifyWhenRateLimitNotAllowed(): void
     {
-        $user = new User();
-        $user->setEmail('test@example.org');
+        $user = new User('test@example.org');
         $password = 'compromised_password';
         $locale = 'en';
 
@@ -68,8 +67,7 @@ class PasswordCompromisedServiceTest extends TestCase
 
     public function testCheckAndNotifyWhenPasswordNotCompromised(): void
     {
-        $user = new User();
-        $user->setEmail('test@example.org');
+        $user = new User('test@example.org');
         $password = 'secure_password';
         $locale = 'de';
 
@@ -103,8 +101,7 @@ class PasswordCompromisedServiceTest extends TestCase
 
     public function testCheckAndNotifyWhenPasswordIsCompromised(): void
     {
-        $user = new User();
-        $user->setEmail('test@example.org');
+        $user = new User('test@example.org');
         $password = 'compromised_password';
         $locale = 'fr';
 

--- a/tests/Service/UserLastLoginUpdateServiceTest.php
+++ b/tests/Service/UserLastLoginUpdateServiceTest.php
@@ -25,7 +25,7 @@ class UserLastLoginUpdateServiceTest extends TestCase
     public function testUpdateLastLoginWithNoExistingLastLogin(): void
     {
         // Arrange
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setLastLoginTime(null);
 
         // Assert that persist is called exactly once
@@ -56,7 +56,7 @@ class UserLastLoginUpdateServiceTest extends TestCase
     public function testUpdateLastLoginWithOldLastLogin(): void
     {
         // Arrange
-        $user = new User();
+        $user = new User('test@example.org');
         $oldLastLogin = (new DateTime())->modify('-1 week'); // Last week
         $user->setLastLoginTime($oldLastLogin);
 
@@ -89,7 +89,7 @@ class UserLastLoginUpdateServiceTest extends TestCase
     public function testUpdateLastLoginDoesNotUpdateWhenAlreadyCurrentWeek(): void
     {
         // Arrange
-        $user = new User();
+        $user = new User('test@example.org');
 
         // Set to current week start (same timestamp)
         $currentWeekStart = new DateTime();

--- a/tests/Service/UserNotificationRateLimiterTest.php
+++ b/tests/Service/UserNotificationRateLimiterTest.php
@@ -38,8 +38,7 @@ class UserNotificationRateLimiterTest extends TestCase
             $this->logger
         );
 
-        $this->user = new User();
-        $this->user->setEmail('test@example.org');
+        $this->user = new User('test@example.org');
         // Set an ID through reflection since it's normally set by Doctrine
         $reflection = new ReflectionClass($this->user);
         $idProperty = $reflection->getProperty('id');
@@ -287,8 +286,7 @@ class UserNotificationRateLimiterTest extends TestCase
     public function testCacheKeyGeneration(): void
     {
         // Test that different users generate different cache keys
-        $user2 = new User();
-        $user2->setEmail('user2@example.org');
+        $user2 = new User('user2@example.org');
         $reflection = new ReflectionClass($user2);
         $idProperty = $reflection->getProperty('id');
         $idProperty->setValue($user2, 456);

--- a/tests/Service/WebhookDispatcherTest.php
+++ b/tests/Service/WebhookDispatcherTest.php
@@ -20,8 +20,7 @@ class WebhookDispatcherTest extends TestCase
 {
     public function testDispatchUserEventPersistsAndDispatchesForMatchingEndpoints(): void
     {
-        $user = new User();
-        $user->setEmail('user@example.org');
+        $user = new User('user@example.org');
 
         $endpointAll = new WebhookEndpoint('https://example.test/a', 'secret-a');
         $endpointFilteredMatch = new WebhookEndpoint('https://example.test/b', 'secret-b');

--- a/tests/Validator/EmailAddressValidatorTest.php
+++ b/tests/Validator/EmailAddressValidatorTest.php
@@ -47,7 +47,7 @@ class EmailAddressValidatorTest extends ConstraintValidatorTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $userRepository->method('findOneBy')->willReturnMap([
-            [['email' => $this->userUsed], null, true, new User()],
+            [['email' => $this->userUsed], null, true, new User($this->userUsed)],
         ]);
         $reservedNameRepository = $this->getMockBuilder(ReservedNameRepository::class)
             ->disableOriginalConstructor()

--- a/tests/Validator/EmailDomainValidatorTest.php
+++ b/tests/Validator/EmailDomainValidatorTest.php
@@ -44,8 +44,7 @@ class EmailDomainValidatorTest extends ConstraintValidatorTestCase
 
     public function testDomainNotFound(): void
     {
-        $user = new User();
-        $user->setEmail('user@example.com');
+        $user = new User('user@example.com');
         $this->validator->validate($user, new EmailDomain());
 
         $this->buildViolation('form.missing-domain')

--- a/tests/Validator/TotpSecretValidatorTest.php
+++ b/tests/Validator/TotpSecretValidatorTest.php
@@ -22,7 +22,7 @@ class TotpSecretValidatorTest extends ConstraintValidatorTestCase
 
     protected function createValidator(): TotpSecretValidator
     {
-        $this->user = new User();
+        $this->user = new User('test@example.org');
         $tokenInterface = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Validator/VoucherExistsValidatorTest.php
+++ b/tests/Validator/VoucherExistsValidatorTest.php
@@ -24,7 +24,7 @@ class VoucherExistsValidatorTest extends ConstraintValidatorTestCase
 
     protected function createValidator(): VoucherExistsValidator
     {
-        $this->user = new User();
+        $this->user = new User('test@example.org');
         $this->voucher = new Voucher();
         $this->voucher->setCode('code');
         $this->voucher->setUser($this->user);

--- a/tests/Validator/VoucherUserValidatorTest.php
+++ b/tests/Validator/VoucherUserValidatorTest.php
@@ -33,7 +33,7 @@ class VoucherUserValidatorTest extends ConstraintValidatorTestCase
 
     public function testNoSuspiciousUser(): void
     {
-        $user = new User();
+        $user = new User('suspicious@example.org');
         $user->setRoles([Roles::USER, Roles::SUSPICIOUS]);
         $this->voucher->setUser($user);
         $this->validator->validate($this->voucher, new VoucherUser());
@@ -43,7 +43,7 @@ class VoucherUserValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidVoucherUser(): void
     {
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setRoles([Roles::USER]);
         $this->voucher->setUser($user);
         $this->validator->validate($this->voucher, new VoucherUser());

--- a/tests/Voter/AliasVoterTest.php
+++ b/tests/Voter/AliasVoterTest.php
@@ -30,14 +30,14 @@ class AliasVoterTest extends TestCase
     public function testSupportsReturnsFalseForNonAliasSubject(): void
     {
         $voter = new AliasVoter();
-        $user = new User();
+        $user = new User('test@example.org');
         $this->assertFalse($this->invokeSupports($voter, AliasVoter::DELETE, $user));
     }
 
     public function testVoteOnAttributeReturnsTrueIfUserOwnsAlias(): void
     {
         $voter = new AliasVoter();
-        $user = new User();
+        $user = new User('test@example.org');
         $alias = new Alias();
         $alias->setRandom(true);
         $alias->setUser($user);
@@ -49,8 +49,8 @@ class AliasVoterTest extends TestCase
     public function testVoteOnAttributeReturnsFalseIfUserDoesNotOwnAlias(): void
     {
         $voter = new AliasVoter();
-        $user = new User();
-        $otherUser = new User();
+        $user = new User('user@example.org');
+        $otherUser = new User('other@example.org');
         $alias = new Alias();
         $alias->setRandom(true);
         $alias->setUser($otherUser);

--- a/tests/Voter/DomainVoterTest.php
+++ b/tests/Voter/DomainVoterTest.php
@@ -33,7 +33,7 @@ class DomainVoterTest extends TestCase
     protected function setUp(): void
     {
         $this->domain = new Domain();
-        $user = new User();
+        $user = new User('test@example.org');
         $user->setDomain($this->domain);
         $repo = $this->getMockBuilder(UserRepository::class)
             ->disableOriginalConstructor()
@@ -56,13 +56,13 @@ class DomainVoterTest extends TestCase
     public function testSupports(): void
     {
         $method = self::getMethod('supports');
-        $this->assertTrue($method->invokeArgs($this->voter, ['ROLE_USERLI_ADMIN_USER_LIST', new User()]));
+        $this->assertTrue($method->invokeArgs($this->voter, ['ROLE_USERLI_ADMIN_USER_LIST', new User('test@example.org')]));
         $this->assertTrue($method->invokeArgs($this->voter, ['ROLE_USERLI_ADMIN_ALIAS_VIEW', new Alias()]));
     }
 
     public function testVoteOnAttribute(): void
     {
-        $otherUser = new User();
+        $otherUser = new User('other@example.org');
         $otherUser->setDomain($this->domain);
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
This pull request refactors how the `User` entity is constructed and how its email property is managed throughout the codebase. The primary change is making the user's email a required constructor argument, which enforces that a `User` always has an email address upon instantiation. This update leads to changes in the entity itself, its trait, and all usages in commands, handlers, fixtures, tests, and validators.

This refactor enforces better type safety and consistency, ensuring that a `User` object is always created with an email address.