### PR TITLE
♻️ Code is required in Voucher constructor

### DIFF
--- a/src/Admin/VoucherAdmin.php
+++ b/src/Admin/VoucherAdmin.php
@@ -32,10 +32,15 @@ final class VoucherAdmin extends Admin
     }
 
     #[Override]
+    protected function createNewInstance(): object
+    {
+        return new Voucher(RandomStringGenerator::generate(6, true));
+    }
+
+    #[Override]
     protected function alterNewInstance(object $object): void
     {
         $object->setUser($this->security->getUser());
-        $object->setCode(RandomStringGenerator::generate(6, true));
     }
 
     #[Override]

--- a/src/Entity/Voucher.php
+++ b/src/Entity/Voucher.php
@@ -29,13 +29,14 @@ class Voucher implements Stringable
     protected ?DateTime $redeemedTime = null;
 
     #[ORM\Column(unique: true)]
-    protected ?string $code = null;
+    protected string $code;
 
     #[ORM\OneToOne(targetEntity: User::class, mappedBy: 'invitationVoucher')]
     protected ?User $invitedUser = null;
 
-    public function __construct()
+    public function __construct(string $code)
     {
+        $this->code = $code;
         $currentDateTime = new DateTime();
         $this->creationTime = $currentDateTime;
     }
@@ -57,7 +58,7 @@ class Voucher implements Stringable
 
     public function getCode(): string
     {
-        return $this->code ?? '';
+        return $this->code;
     }
 
     public function setCode(string $code): void
@@ -78,6 +79,6 @@ class Voucher implements Stringable
     #[Override]
     public function __toString(): string
     {
-        return (string) $this->code;
+        return $this->code;
     }
 }

--- a/src/Factory/VoucherFactory.php
+++ b/src/Factory/VoucherFactory.php
@@ -19,9 +19,8 @@ final class VoucherFactory
      */
     public static function create(User $user): Voucher
     {
-        $voucher = new Voucher();
+        $voucher = new Voucher(RandomStringGenerator::generate(6, true));
         $voucher->setUser($user);
-        $voucher->setCode(RandomStringGenerator::generate(6, true));
 
         return $voucher;
     }

--- a/src/Repository/VoucherRepository.php
+++ b/src/Repository/VoucherRepository.php
@@ -15,10 +15,9 @@ use Doctrine\ORM\EntityRepository;
 final class VoucherRepository extends EntityRepository
 {
     /**
-     * @TODO: Remove nullable
      * Finds a voucher by its code.
      */
-    public function findByCode(?string $code): ?Voucher
+    public function findByCode(string $code): ?Voucher
     {
         return $this->findOneBy(['code' => $code]);
     }

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -195,7 +195,8 @@ class FeatureContext extends MinkContext
     public function theFollowingVoucherExists(TableNode $table): void
     {
         foreach ($table->getColumnsHash() as $data) {
-            $voucher = new Voucher();
+            $code = $data['code'] ?? 'default';
+            $voucher = new Voucher($code);
 
             foreach ($data as $key => $value) {
                 if (empty($value)) {
@@ -203,9 +204,6 @@ class FeatureContext extends MinkContext
                 }
 
                 switch ($key) {
-                    case 'code':
-                        $voucher->setCode($value);
-                        break;
                     case 'user':
                         $user = $this->getUserRepository()->findByEmail($value);
 

--- a/tests/Command/VoucherCreateCommandTest.php
+++ b/tests/Command/VoucherCreateCommandTest.php
@@ -103,8 +103,7 @@ class VoucherCreateCommandTest extends TestCase
         $this->router->method('generate')
             ->willReturn($baseUrl.'/register/'.$voucherCode);
 
-        $voucher = new Voucher();
-        $voucher->setCode($voucherCode);
+        $voucher = new Voucher($voucherCode);
         $this->creator->method('create')
             ->willReturn($voucher);
 
@@ -160,8 +159,7 @@ class VoucherCreateCommandTest extends TestCase
             ->method('setBaseUrl')
             ->with($baseUrl);
 
-        $voucher = new Voucher();
-        $voucher->setCode($voucherCode);
+        $voucher = new Voucher($voucherCode);
         $exception = $this->createMock(ValidationException::class);
         $this->creator->method('create')
             ->willThrowException($exception);
@@ -201,8 +199,7 @@ class VoucherCreateCommandTest extends TestCase
             ->method('setBaseUrl')
             ->with($baseUrl);
 
-        $voucher = new Voucher();
-        $voucher->setCode($voucherCode);
+        $voucher = new Voucher($voucherCode);
 
         $this->creator->expects(self::once())
             ->method('create')
@@ -250,8 +247,7 @@ class VoucherCreateCommandTest extends TestCase
             ->method('setBaseUrl')
             ->with($baseUrl);
 
-        $voucher = new Voucher();
-        $voucher->setCode($voucherCode);
+        $voucher = new Voucher($voucherCode);
 
         $this->creator->expects(self::once())
             ->method('create')

--- a/tests/EntityListener/UserChangedListenerTest.php
+++ b/tests/EntityListener/UserChangedListenerTest.php
@@ -93,10 +93,10 @@ class UserChangedListenerTest extends TestCase
             ->willReturn(['roles' => [[Roles::USER], [Roles::USER, Roles::SUSPICIOUS]]]);
 
         $invitedUser1 = new User('invited1@example.org');
-        $voucher1 = new Voucher();
+        $voucher1 = new Voucher('code1');
         $voucher1->setInvitedUser($invitedUser1);
         $invitedUser2 = new User('invited2@example.org');
-        $voucher2 = new Voucher();
+        $voucher2 = new Voucher('code2');
         $voucher2->setInvitedUser($invitedUser2);
         $this->voucherRepository->method('getRedeemedVouchersByUser')
             ->willReturn([$voucher1, $voucher2]);

--- a/tests/Factory/VoucherFactoryTest.php
+++ b/tests/Factory/VoucherFactoryTest.php
@@ -18,6 +18,6 @@ class VoucherFactoryTest extends TestCase
 
         self::assertNotNull($voucher->getCreationTime());
         self::assertNotNull($voucher->getUser());
-        self::assertNotNull($voucher->getCode());
+        self::assertSame(6, strlen($voucher->getCode()));
     }
 }

--- a/tests/Handler/RegistrationHandlerTest.php
+++ b/tests/Handler/RegistrationHandlerTest.php
@@ -45,7 +45,7 @@ class RegistrationHandlerTest extends KernelTestCase
         $domainGuesser = $this->createMock(DomainGuesser::class);
         $domainGuesser->method('guess')->willReturn($domain);
 
-        $voucher = new Voucher();
+        $voucher = new Voucher('code');
         $voucherRepository = $this->createMock(VoucherRepository::class);
         $voucherRepository->method('findByCode')->willReturn($voucher);
 

--- a/tests/Handler/VoucherHandlerTest.php
+++ b/tests/Handler/VoucherHandlerTest.php
@@ -61,7 +61,7 @@ class VoucherHandlerTest extends TestCase
     public function testFindEnoughVouchers(): void
     {
         $repository = $this->getMockBuilder(VoucherRepository::class)->disableOriginalConstructor()->getMock();
-        $repository->method('findByUser')->willReturn([new Voucher(), new Voucher(), new Voucher()]);
+        $repository->method('findByUser')->willReturn([new Voucher('code1'), new Voucher('code2'), new Voucher('code3')]);
 
         $manager = $this->getMockBuilder(EntityManagerInterface::class)->disableOriginalConstructor()->getMock();
         $manager->method('getRepository')->willReturn($repository);
@@ -87,13 +87,13 @@ class VoucherHandlerTest extends TestCase
     public function testNeedToCreateVouchers(): void
     {
         $repository = $this->getMockBuilder(VoucherRepository::class)->disableOriginalConstructor()->getMock();
-        $repository->method('findByUser')->willReturn([new Voucher(), new Voucher()]);
+        $repository->method('findByUser')->willReturn([new Voucher('code1'), new Voucher('code2')]);
 
         $manager = $this->getMockBuilder(EntityManagerInterface::class)->disableOriginalConstructor()->getMock();
         $manager->method('getRepository')->willReturn($repository);
 
         $creator = $this->getMockBuilder(VoucherCreator::class)->disableOriginalConstructor()->getMock();
-        $creator->method('create')->willReturn(new Voucher());
+        $creator->method('create')->willReturn(new Voucher('code3'));
 
         $handler = new VoucherHandler($manager, $creator);
 

--- a/tests/MessageHandler/UnlinkRedeemedVouchersHandlerTest.php
+++ b/tests/MessageHandler/UnlinkRedeemedVouchersHandlerTest.php
@@ -18,22 +18,19 @@ class UnlinkRedeemedVouchersHandlerTest extends TestCase
 {
     public function testUnlinksRedeemedVouchersOlderThanThreeMonths(): void
     {
-        $voucher1 = new Voucher();
-        $voucher1->setCode('A');
+        $voucher1 = new Voucher('A');
         $voucher1->setRedeemedTime(new DateTime('-4 months')); // old
         $user1 = new User('user1@example.org');
         $user1->setInvitationVoucher($voucher1);
         $voucher1->setInvitedUser($user1);
 
-        $voucher2 = new Voucher();
-        $voucher2->setCode('B');
+        $voucher2 = new Voucher('B');
         $voucher2->setRedeemedTime(new DateTime('-5 months')); // old
         $user2 = new User('user2@example.org');
         $user2->setInvitationVoucher($voucher2);
         $voucher2->setInvitedUser($user2);
 
-        $voucherRecent = new Voucher();
-        $voucherRecent->setCode('C');
+        $voucherRecent = new Voucher('C');
         $voucherRecent->setRedeemedTime(new DateTime('-1 month')); // recent (should not appear in result set)
         $recentUser = new User('recent@example.org');
         $recentUser->setInvitationVoucher($voucherRecent);

--- a/tests/Validator/VoucherExistsValidatorTest.php
+++ b/tests/Validator/VoucherExistsValidatorTest.php
@@ -25,8 +25,7 @@ class VoucherExistsValidatorTest extends ConstraintValidatorTestCase
     protected function createValidator(): VoucherExistsValidator
     {
         $this->user = new User('test@example.org');
-        $this->voucher = new Voucher();
-        $this->voucher->setCode('code');
+        $this->voucher = new Voucher('code');
         $this->voucher->setUser($this->user);
         $repository = $this->getMockBuilder(VoucherRepository::class)
             ->disableOriginalConstructor()

--- a/tests/Validator/VoucherUserValidatorTest.php
+++ b/tests/Validator/VoucherUserValidatorTest.php
@@ -19,8 +19,7 @@ class VoucherUserValidatorTest extends ConstraintValidatorTestCase
 
     protected function createValidator(): VoucherUserValidator
     {
-        $this->voucher = new Voucher();
-        $this->voucher->setCode('code');
+        $this->voucher = new Voucher('code');
 
         return new VoucherUserValidator();
     }


### PR DESCRIPTION
This pull request refactors the handling of voucher codes throughout the codebase to ensure that every `Voucher` instance is always created with a code. The main change is making the `code` property required at construction, removing the need to set it separately after instantiation. This results in a cleaner, safer, and more consistent API for working with vouchers. The change is reflected across the main application logic, factories, repositories, and all relevant tests.