### PR TITLE
✨ Introduce configurable sending quotas

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -34,3 +34,15 @@ settings:
   weekly_report_enabled:
     type: boolean
     default: true
+
+  smtp_quota_limit_per_hour:
+    type: integer
+    default: 0
+    validation:
+      min: 0
+
+  smtp_quota_limit_per_day:
+    type: integer
+    default: 0
+    validation:
+      min: 0

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -415,6 +415,7 @@ settings:
       project: Projekteinstellungen
       email: E-Mail Einstellungen
       reports: Berichte
+      smtp_quota: SMTP-Quota Limits
     app_name:
       label: Anwendungsname
       help: Der im Anwendungsheader und Browsertitel angezeigte Name
@@ -439,6 +440,12 @@ settings:
     weekly_report_enabled:
       label: Wöchentlicher Bericht
       help: Einen wöchentlichen Bericht über neue Registrierungen an die Benachrichtigungs-E-Mail-Adresse senden
+    smtp_quota_limit_per_hour:
+      label: Limit pro Stunde
+      help: Maximale Anzahl an E-Mails, die ein:e Benutzer:in pro Stunde senden kann (0 = unbegrenzt)
+    smtp_quota_limit_per_day:
+      label: Limit pro Tag
+      help: Maximale Anzahl an E-Mails, die ein:e Benutzer:in pro Tag senden kann (0 = unbegrenzt)
   navigation:
     aria-label: Einstellungen Navigation
     api: API Tokens

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -435,6 +435,7 @@ settings:
       project: Project Settings
       email: Email Configuration
       reports: Reports
+      smtp_quota: SMTP Quota Limits
     app_name:
       label: Application Name
       help: The name displayed in the application header and browser title
@@ -459,6 +460,12 @@ settings:
     weekly_report_enabled:
       label: Weekly Report
       help: Send a weekly report with new registrations to the notification email address
+    smtp_quota_limit_per_hour:
+      label: Limit per Hour
+      help: Default maximum number of emails a user can send per hour (0 = unlimited)
+    smtp_quota_limit_per_day:
+      label: Limit per Day
+      help: Default maximum number of emails a user can send per day (0 = unlimited)
   navigation:
     aria-label: Settings navigation
     api: API Tokens

--- a/features/api_postfix.feature
+++ b/features/api_postfix.feature
@@ -103,3 +103,31 @@ Feature: Postfix API
             """
             ["user2@example.org"]
             """
+
+    @quota
+    Scenario: Get SMTP quota with wrong API token
+        Given I have an invalid API token
+        When I send a GET request to "/api/postfix/smtp_quota/user@example.org"
+        Then the response status code should equal 401
+
+    @quota
+    Scenario: Get SMTP quota for non-existent address
+        Given I have a valid API token "postfix-test-123"
+        When I send a GET request to "/api/postfix/smtp_quota/nonexistent@example.org"
+        Then the response status code should equal 404
+
+    @quota
+    Scenario: Get SMTP quota for existing user
+        Given I have a valid API token "postfix-test-123"
+        When I send a GET request to "/api/postfix/smtp_quota/user@example.org"
+        Then the response status code should equal 200
+        And the JSON path "per_hour" should equal "0"
+        And the JSON path "per_day" should equal "0"
+
+    @quota
+    Scenario: Get SMTP quota for existing alias
+        Given I have a valid API token "postfix-test-123"
+        When I send a GET request to "/api/postfix/smtp_quota/alias@example.org"
+        Then the response status code should equal 200
+        And the JSON path "per_hour" should equal "0"
+        And the JSON path "per_day" should equal "0"

--- a/migrations/Version20260215115726.php
+++ b/migrations/Version20260215115726.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260215115726 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add smtp_quota_limits column to virtual_users and virtual_aliases tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE virtual_aliases ADD smtp_quota_limits JSON DEFAULT NULL');
+        $this->addSql('ALTER TABLE virtual_users ADD smtp_quota_limits JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE virtual_aliases DROP smtp_quota_limits');
+        $this->addSql('ALTER TABLE virtual_users DROP smtp_quota_limits');
+    }
+}

--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -6,6 +6,7 @@ namespace App\Admin;
 
 use App\Entity\Alias;
 use App\Enum\Roles;
+use App\Form\SmtpQuotaLimitsType;
 use App\Traits\DomainGuesserAwareTrait;
 use App\Validator\EmailAddress;
 use App\Validator\Lowercase;
@@ -54,7 +55,12 @@ final class AliasAdmin extends Admin
 
         if ($this->security->isGranted(Roles::ADMIN)) {
             $form
-                ->add('destination', EmailType::class, ['required' => false]);
+                ->add('destination', EmailType::class, ['required' => false])
+                ->add('smtpQuotaLimits', SmtpQuotaLimitsType::class, [
+                    'label' => 'SMTP Quota Limits',
+                    'required' => false,
+                    'help' => 'Set custom SMTP quota limits for this alias.',
+                ]);
         }
     }
 

--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -7,6 +7,7 @@ namespace App\Admin;
 use App\Entity\User;
 use App\Enum\MailCrypt;
 use App\Enum\Roles;
+use App\Form\SmtpQuotaLimitsType;
 use App\Handler\MailCryptKeyHandler;
 use App\Helper\PasswordUpdater;
 use App\Service\UserResetService;
@@ -131,11 +132,20 @@ final class UserAdmin extends Admin
             ])
             ->add('quota', null, [
                 'help' => 'Custom mailbox quota in MB',
-            ])
-            ->add('passwordChangeRequired', CheckboxType::class, [
+            ]);
+
+        if ($this->security->isGranted(Roles::ADMIN)) {
+            $form->add('smtpQuotaLimits', SmtpQuotaLimitsType::class, [
+                'label' => 'SMTP Quota Limits',
                 'required' => false,
-                'help' => 'User must change password on next login',
-            ])
+                'help' => 'Set custom SMTP quota limits for this user',
+            ]);
+        }
+
+        $form->add('passwordChangeRequired', CheckboxType::class, [
+            'required' => false,
+            'help' => 'User must change password on next login',
+        ])
             ->add('deleted', CheckboxType::class, ['disabled' => true]);
     }
 

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -13,6 +13,7 @@ use App\Traits\RandomTrait;
 use App\Traits\UpdatedTimeTrait;
 use App\Traits\UserAwareTrait;
 use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\AssociationOverride;
 use Doctrine\ORM\Mapping\Index;
@@ -43,6 +44,9 @@ class Alias implements SoftDeletableInterface, UpdatedTimeInterface, Stringable
 
     #[ORM\Column(nullable: true)]
     protected ?string $note = null;
+
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $smtpQuotaLimits = null;
 
     /**
      * Alias constructor.
@@ -86,6 +90,16 @@ class Alias implements SoftDeletableInterface, UpdatedTimeInterface, Stringable
     {
         $this->user = null;
         $this->destination = null;
+    }
+
+    public function getSmtpQuotaLimits(): ?array
+    {
+        return $this->smtpQuotaLimits;
+    }
+
+    public function setSmtpQuotaLimits(?array $smtpQuotaLimits): void
+    {
+        $this->smtpQuotaLimits = $smtpQuotaLimits;
     }
 
     #[Override]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -82,6 +82,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
     #[ORM\Column(type: 'boolean', options: ['default' => false])]
     private bool $passwordChangeRequired;
 
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $smtpQuotaLimits = null;
+
     /**
      * User constructor.
      */
@@ -157,5 +160,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
     public function setPasswordChangeRequired(bool $passwordChangeRequired): void
     {
         $this->passwordChangeRequired = $passwordChangeRequired;
+    }
+
+    public function getSmtpQuotaLimits(): ?array
+    {
+        return $this->smtpQuotaLimits;
+    }
+
+    public function setSmtpQuotaLimits(?array $smtpQuotaLimits): void
+    {
+        $this->smtpQuotaLimits = $smtpQuotaLimits;
     }
 }

--- a/src/Enum/UserCacheKey.php
+++ b/src/Enum/UserCacheKey.php
@@ -10,6 +10,7 @@ enum UserCacheKey: string
 
     case DOVECOT_LOOKUP = 'dovecot_lookup_';
     case POSTFIX_MAILBOX = 'postfix_mailbox_';
+    case POSTFIX_QUOTA = 'postfix_quota_';
     case POSTFIX_SENDERS = 'postfix_senders_';
 
     public function ttl(): int

--- a/src/Form/SmtpQuotaLimitsType.php
+++ b/src/Form/SmtpQuotaLimitsType.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use Override;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @extends AbstractType<array<string, int>>
+ */
+final class SmtpQuotaLimitsType extends AbstractType
+{
+    #[Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('per_hour', IntegerType::class, [
+                'label' => 'Per Hour',
+                'required' => false,
+                'attr' => ['min' => 0],
+            ])
+            ->add('per_day', IntegerType::class, [
+                'label' => 'Per Day',
+                'required' => false,
+                'attr' => ['min' => 0],
+            ]);
+    }
+
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'required' => false,
+        ]);
+    }
+}

--- a/src/MessageHandler/InvalidateAliasCacheHandler.php
+++ b/src/MessageHandler/InvalidateAliasCacheHandler.php
@@ -24,6 +24,9 @@ final readonly class InvalidateAliasCacheHandler
             $this->cache->delete($key);
         }
 
+        // Invalidate quota cache for the alias source address
+        $this->cache->delete(UserCacheKey::POSTFIX_QUOTA->key($message->source));
+
         // Invalidate sender cache for all destination emails of the alias
         $emails = $this->aliasRepository->findDestinationsBySource($message->source);
         foreach ($emails as $email) {

--- a/src/Repository/AliasRepository.php
+++ b/src/Repository/AliasRepository.php
@@ -48,6 +48,33 @@ final class AliasRepository extends ServiceEntityRepository
     }
 
     /**
+     * Returns the smtp_quota_limits for an alias, or null if the alias does not exist.
+     *
+     * Uses a scalar query to avoid hydrating the full Alias entity.
+     * An existing alias with no custom limits returns an empty array.
+     *
+     * @return array<string, int>|null
+     */
+    public function findSmtpQuotaLimitsBySource(string $source): ?array
+    {
+        $result = $this->createQueryBuilder('a')
+            ->select('a.smtpQuotaLimits')
+            ->where('a.source = :source')
+            ->andWhere('a.deleted = :deleted')
+            ->setParameter('source', $source)
+            ->setParameter('deleted', false)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($result === null) {
+            return null;
+        }
+
+        return $result['smtpQuotaLimits'] ?? [];
+    }
+
+    /**
      * @return array|Alias[]
      */
     public function findByUser(User $user, ?bool $random = null, ?bool $disableDomainFilter = false): array

--- a/templates/Settings/show.html.twig
+++ b/templates/Settings/show.html.twig
@@ -33,6 +33,7 @@
                         'project': ['project_name', 'project_url'],
                         'email': ['email_sender_address', 'email_notification_address'],
                         'reports': ['weekly_report_enabled'],
+                        'smtp_quota': ['smtp_quota_limit_per_hour', 'smtp_quota_limit_per_day'],
                     } %}
 
                     {% for category, fields in categories %}
@@ -43,6 +44,7 @@
                                     'project': 'heroicons:building-office',
                                     'email': 'heroicons:envelope',
                                     'reports': 'heroicons:document-chart-bar',
+                                    'smtp_quota': 'heroicons:arrow-up-tray',
                                 }[category] %}
 
                                 <div class="w-8 h-8 bg-gray-100 dark:bg-gray-700 rounded-lg flex items-center justify-center mr-3">

--- a/tests/Enum/UserCacheKeyTest.php
+++ b/tests/Enum/UserCacheKeyTest.php
@@ -15,6 +15,7 @@ class UserCacheKeyTest extends TestCase
 
         self::assertSame('dovecot_lookup_'.sha1($email), UserCacheKey::DOVECOT_LOOKUP->key($email));
         self::assertSame('postfix_mailbox_'.sha1($email), UserCacheKey::POSTFIX_MAILBOX->key($email));
+        self::assertSame('postfix_quota_'.sha1($email), UserCacheKey::POSTFIX_QUOTA->key($email));
         self::assertSame('postfix_senders_'.sha1($email), UserCacheKey::POSTFIX_SENDERS->key($email));
     }
 
@@ -23,9 +24,10 @@ class UserCacheKeyTest extends TestCase
         $email = 'user@example.org';
         $keys = UserCacheKey::allKeysForEmail($email);
 
-        self::assertCount(3, $keys);
+        self::assertCount(4, $keys);
         self::assertContains('dovecot_lookup_'.sha1($email), $keys);
         self::assertContains('postfix_mailbox_'.sha1($email), $keys);
+        self::assertContains('postfix_quota_'.sha1($email), $keys);
         self::assertContains('postfix_senders_'.sha1($email), $keys);
     }
 
@@ -34,6 +36,7 @@ class UserCacheKeyTest extends TestCase
         self::assertSame(86400, UserCacheKey::TTL);
         self::assertSame(UserCacheKey::TTL, UserCacheKey::DOVECOT_LOOKUP->ttl());
         self::assertSame(UserCacheKey::TTL, UserCacheKey::POSTFIX_MAILBOX->ttl());
+        self::assertSame(UserCacheKey::TTL, UserCacheKey::POSTFIX_QUOTA->ttl());
         self::assertSame(UserCacheKey::TTL, UserCacheKey::POSTFIX_SENDERS->ttl());
     }
 }

--- a/tests/Form/SmtpQuotaLimitsTypeTest.php
+++ b/tests/Form/SmtpQuotaLimitsTypeTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form;
+
+use App\Form\SmtpQuotaLimitsType;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class SmtpQuotaLimitsTypeTest extends TypeTestCase
+{
+    protected function setUp(): void
+    {
+        $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
+        parent::setUp();
+    }
+
+    public function testSubmitValidData(): void
+    {
+        $formData = [
+            'per_hour' => 100,
+            'per_day' => 1000,
+        ];
+
+        $form = $this->factory->create(SmtpQuotaLimitsType::class);
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertTrue($form->isValid());
+
+        $expected = [
+            'per_hour' => 100,
+            'per_day' => 1000,
+        ];
+
+        $this->assertEquals($expected, $form->getData());
+    }
+
+    public function testSubmitPartialData(): void
+    {
+        $formData = [
+            'per_hour' => 5,
+        ];
+
+        $form = $this->factory->create(SmtpQuotaLimitsType::class);
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertTrue($form->isValid());
+
+        $expected = [
+            'per_hour' => 5,
+            'per_day' => null,
+        ];
+
+        $this->assertEquals($expected, $form->getData());
+    }
+
+    public function testSubmitEmptyData(): void
+    {
+        $formData = [];
+
+        $form = $this->factory->create(SmtpQuotaLimitsType::class);
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertTrue($form->isValid());
+
+        $expected = [
+            'per_hour' => null,
+            'per_day' => null,
+        ];
+
+        $this->assertEquals($expected, $form->getData());
+    }
+
+    public function testFormHasExpectedFields(): void
+    {
+        $form = $this->factory->create(SmtpQuotaLimitsType::class);
+
+        $this->assertTrue($form->has('per_hour'));
+        $this->assertTrue($form->has('per_day'));
+    }
+
+    public function testSubmitWithExistingData(): void
+    {
+        $existingData = [
+            'per_hour' => 200,
+            'per_day' => 2000,
+        ];
+
+        $form = $this->factory->create(SmtpQuotaLimitsType::class, $existingData);
+
+        $this->assertEquals(200, $form->get('per_hour')->getData());
+        $this->assertEquals(2000, $form->get('per_day')->getData());
+
+        $formData = [
+            'per_hour' => 300,
+            'per_day' => 3000,
+        ];
+
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+
+        $expected = [
+            'per_hour' => 300,
+            'per_day' => 3000,
+        ];
+
+        $this->assertEquals($expected, $form->getData());
+    }
+}

--- a/tests/MessageHandler/InvalidateUserCacheHandlerTest.php
+++ b/tests/MessageHandler/InvalidateUserCacheHandlerTest.php
@@ -18,7 +18,7 @@ class InvalidateUserCacheHandlerTest extends TestCase
         $expectedKeys = UserCacheKey::allKeysForEmail($email);
 
         $cache = $this->createMock(CacheInterface::class);
-        $cache->expects(self::exactly(3))
+        $cache->expects(self::exactly(4))
             ->method('delete')
             ->with($this->callback(static function (string $key) use (&$expectedKeys): bool {
                 $index = array_search($key, $expectedKeys, true);


### PR DESCRIPTION
This pull request introduces configurable SMTP quota limits at both the global (settings), user, and alias levels, allowing administrators to restrict the number of emails sent per hour and per day. It adds support for these limits in the backend, exposes them via a new API endpoint, and updates the admin UI and translations accordingly. Comprehensive tests are included to ensure correct behavior.

**SMTP Quota Limit Functionality**

- Added global settings for `smtp_quota_limit_per_hour` and `smtp_quota_limit_per_day`, including validation and display in the settings UI. [[1]](diffhunk://#diff-7cbc4a96df70c69babc1d86c426f1656c40c09230abb4ec275b97bc39a21e546R28-R40) [[2]](diffhunk://#diff-ae5f0525dcfd982ff1d01f2216170402495d51381d7bbd96a16410374c50627cR35) [[3]](diffhunk://#diff-ae5f0525dcfd982ff1d01f2216170402495d51381d7bbd96a16410374c50627cR45)
- Extended the `User` and `Alias` entities to support custom SMTP quota limits, with corresponding getter/setter methods and database mapping. [[1]](diffhunk://#diff-647507ae5a0ec79fc7b83372ecf7f49fc6a26d74cd86ab291b22be4d3ca4e259R53-R55) [[2]](diffhunk://#diff-647507ae5a0ec79fc7b83372ecf7f49fc6a26d74cd86ab291b22be4d3ca4e259R94-R103) [[3]](diffhunk://#diff-29168649467ab681a1c7891011f17d64e2cae8a6efd8f976111521bb308ea372R91-R93) [[4]](diffhunk://#diff-29168649467ab681a1c7891011f17d64e2cae8a6efd8f976111521bb308ea372R173-R182)
- Introduced the reusable form type `SmtpQuotaLimitsType` for editing quota limits, and integrated it into the admin forms for users and aliases. [[1]](diffhunk://#diff-24d90368658641548808932cd35792ce9a85db0c361cfc21bc82cb03b4896932R1-R41) [[2]](diffhunk://#diff-51689114e6dc042c61d7c82be1c5c44ff0f1cfe46dafd807ea1614c2426be89bR9) [[3]](diffhunk://#diff-51689114e6dc042c61d7c82be1c5c44ff0f1cfe46dafd807ea1614c2426be89bL48-R54) [[4]](diffhunk://#diff-c0545377919eb8da2db959c0d034e26f324d15486e3f4c9b01f7de7d99f72343R10) [[5]](diffhunk://#diff-c0545377919eb8da2db959c0d034e26f324d15486e3f4c9b01f7de7d99f72343L97-R108)

**API and Backend Enhancements**

- Added a new API endpoint `/api/postfix/quota/{email}` to retrieve the effective SMTP quota limits for a user or alias, defaulting to global settings if no custom limits are set. [[1]](diffhunk://#diff-b52e03d55bba46b85a5a51d4159e77a9582d3b02b3fc2d719c8c32a714326325R12) [[2]](diffhunk://#diff-b52e03d55bba46b85a5a51d4159e77a9582d3b02b3fc2d719c8c32a714326325L20-R24) [[3]](diffhunk://#diff-b52e03d55bba46b85a5a51d4159e77a9582d3b02b3fc2d719c8c32a714326325R76-R100)


<img width="2880" height="1800" alt="Bildschirmfoto am 2026-01-05 um 22 15 07" src="https://github.com/user-attachments/assets/a6c32789-236b-46f0-8aa1-01674dd92fee" />
<img width="2880" height="1800" alt="Bildschirmfoto am 2026-01-05 um 22 14 42" src="https://github.com/user-attachments/assets/bb1cdc20-bf73-40ad-9aee-f3eebe4508aa" />
<img width="2880" height="1800" alt="Bildschirmfoto am 2026-01-05 um 22 14 30" src="https://github.com/user-attachments/assets/3c9c0047-ab79-405b-b007-a7526717fa1d" />