### PR TITLE
✨ Add Pagination for Webhook Deliveries

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -549,6 +549,11 @@ settings:
         status: Status
         dispatched: Gesendet
         actions: Aktionen
+      pagination:
+        total: "%count% Zustellungen insgesamt"
+        newer: Neuere
+        older: Ältere
+        page: "Seite %page% von %totalPages%"
       status:
         delivered: Zugestellt
         failed: Fehlgeschlagen

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -551,6 +551,11 @@ settings:
         status: Status
         dispatched: Dispatched
         actions: Actions
+      pagination:
+        total: "%count% deliveries total"
+        newer: Newer
+        older: Older
+        page: "Page %page% of %totalPages%"
       status:
         delivered: Delivered
         failed: Failed

--- a/src/Controller/WebhookDeliveryController.php
+++ b/src/Controller/WebhookDeliveryController.php
@@ -23,12 +23,17 @@ final class WebhookDeliveryController extends AbstractController
     #[Route('/settings/webhooks/{id}/deliveries', name: 'settings_webhook_delivery_index', methods: ['GET'])]
     public function index(
         #[MapEntity] WebhookEndpoint $endpoint,
+        Request $request,
     ): Response {
-        $deliveries = $this->manager->findAllByEndpoint($endpoint);
+        $page = $request->query->getInt('page', 1);
+        $pagination = $this->manager->findPaginatedByEndpoint($endpoint, $page);
 
         return $this->render('Settings/Webhook/Delivery/index.html.twig', [
-            'deliveries' => $deliveries,
+            'deliveries' => $pagination['items'],
             'endpoint' => $endpoint,
+            'page' => $pagination['page'],
+            'totalPages' => $pagination['totalPages'],
+            'total' => $pagination['total'],
         ]);
     }
 

--- a/src/DataFixtures/LoadWebhookData.php
+++ b/src/DataFixtures/LoadWebhookData.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Entity\WebhookDelivery;
+use App\Entity\WebhookEndpoint;
+use App\Enum\WebhookEvent;
+use DateTimeImmutable;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+
+final class LoadWebhookData extends Fixture implements FixtureGroupInterface
+{
+    private const DELIVERY_COUNT = 75;
+
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        $endpoint = new WebhookEndpoint(
+            'https://webhook.example.com/events',
+            bin2hex(random_bytes(16))
+        );
+        $endpoint->setEvents([WebhookEvent::USER_CREATED->value, WebhookEvent::USER_DELETED->value]);
+        $endpoint->setEnabled(true);
+        $manager->persist($endpoint);
+
+        $events = WebhookEvent::cases();
+        $statuses = ['success', 'failed', 'pending'];
+
+        for ($i = 0; $i < self::DELIVERY_COUNT; ++$i) {
+            $event = $events[array_rand($events)];
+
+            $requestBody = [
+                'event' => $event->value,
+                'timestamp' => time() - random_int(0, 86400 * 7),
+                'data' => [
+                    'user_id' => random_int(1, 1000),
+                    'email' => sprintf('user%d@example.org', random_int(1, 1000)),
+                ],
+            ];
+
+            $requestHeaders = [
+                'Content-Type' => 'application/json',
+                'X-Webhook-Signature' => hash('sha256', json_encode($requestBody).$endpoint->getSecret()),
+                'X-Webhook-Attempt' => '1',
+            ];
+
+            $delivery = new WebhookDelivery($endpoint, $event, $requestBody, $requestHeaders);
+            $this->applyRandomStatus($delivery, $statuses[array_rand($statuses)]);
+            $manager->persist($delivery);
+
+            if (($i % 50) === 0) {
+                $manager->flush();
+            }
+        }
+
+        $manager->flush();
+        $manager->clear();
+    }
+
+    private function applyRandomStatus(WebhookDelivery $delivery, string $status): void
+    {
+        $delivery->setAttempts(random_int(1, 3));
+
+        match ($status) {
+            'success' => $this->applySuccess($delivery),
+            'failed' => $this->applyFailed($delivery),
+            default => null,
+        };
+    }
+
+    private function applySuccess(WebhookDelivery $delivery): void
+    {
+        $delivery->setSuccess(true);
+        $delivery->setResponseCode(200);
+        $delivery->setResponseBody('{"status":"ok"}');
+        $delivery->setDeliveredTime(new DateTimeImmutable(sprintf('-%d minutes', random_int(1, 1440))));
+    }
+
+    private function applyFailed(WebhookDelivery $delivery): void
+    {
+        $errorCodes = [400, 401, 403, 404, 500, 502, 503, 504];
+        $errorResponses = ['{"error":"Bad Request"}', '{"error":"Internal Server Error"}', '502 Bad Gateway', ''];
+        $errors = ['Connection timed out', 'Could not resolve host', 'Connection refused', 'HTTP error 500'];
+
+        $delivery->setSuccess(false);
+        $delivery->setResponseCode($errorCodes[array_rand($errorCodes)]);
+        $delivery->setResponseBody($errorResponses[array_rand($errorResponses)]);
+        $delivery->setError($errors[array_rand($errors)]);
+        $delivery->setDeliveredTime(new DateTimeImmutable(sprintf('-%d minutes', random_int(1, 1440))));
+    }
+
+    #[Override]
+    public static function getGroups(): array
+    {
+        return ['basic', 'advanced'];
+    }
+}

--- a/src/Entity/WebhookDelivery.php
+++ b/src/Entity/WebhookDelivery.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Enum\WebhookEvent;
+use App\Repository\WebhookDeliveryRepository;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Ulid;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: WebhookDeliveryRepository::class)]
 #[ORM\Table(name: 'webhook_deliveries')]
 #[ORM\Index(columns: ['dispatched_time'])]
 #[ORM\Index(columns: ['success'])]

--- a/src/Repository/WebhookDeliveryRepository.php
+++ b/src/Repository/WebhookDeliveryRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\WebhookDelivery;
+use App\Entity\WebhookEndpoint;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<WebhookDelivery>
+ */
+final class WebhookDeliveryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, WebhookDelivery::class);
+    }
+
+    public function countByEndpoint(WebhookEndpoint $endpoint): int
+    {
+        return (int) $this->createQueryBuilder('d')
+            ->select('COUNT(d.id)')
+            ->where('d.endpoint = :endpoint')
+            ->setParameter('endpoint', $endpoint)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/templates/Settings/Webhook/Delivery/index.html.twig
+++ b/templates/Settings/Webhook/Delivery/index.html.twig
@@ -81,6 +81,30 @@
                         </table>
                     </div>
                 </div>
+                {% if totalPages > 1 %}
+                    <div class="mt-6 flex items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-4">
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                            {{ 'settings.webhook.deliveries.pagination.total'|trans({'%count%': total}) }}
+                        </div>
+                        <div class="flex gap-2">
+                            {% if page > 1 %}
+                                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page - 1}) }}"
+                                   class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                                    {{ ux_icon('heroicons:chevron-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.deliveries.pagination.newer'|trans }}
+                                </a>
+                            {% endif %}
+                            <span class="inline-flex items-center px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400">
+                                {{ 'settings.webhook.deliveries.pagination.page'|trans({'%page%': page, '%totalPages%': totalPages}) }}
+                            </span>
+                            {% if page < totalPages %}
+                                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page + 1}) }}"
+                                   class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                                    {{ 'settings.webhook.deliveries.pagination.older'|trans }} {{ ux_icon('heroicons:chevron-right', {class: 'w-4 h-4 ml-1'}) }}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/tests/Service/WebhookDeliveryManagerTest.php
+++ b/tests/Service/WebhookDeliveryManagerTest.php
@@ -8,38 +8,43 @@ use App\Entity\WebhookDelivery;
 use App\Entity\WebhookEndpoint;
 use App\Enum\WebhookEvent;
 use App\Message\SendWebhook;
+use App\Repository\WebhookDeliveryRepository;
 use App\Service\WebhookDeliveryManager;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 class WebhookDeliveryManagerTest extends TestCase
 {
-    public function testFindAllByEndpointReturnsDeliveries(): void
+    public function testFindPaginatedByEndpointReturnsDeliveries(): void
     {
         $endpoint = new WebhookEndpoint('https://example.test/a', 'secret');
 
         $d1 = new WebhookDelivery($endpoint, WebhookEvent::USER_CREATED, ['a' => 1], ['Content-Type' => 'application/json']);
         $d2 = new WebhookDelivery($endpoint, WebhookEvent::USER_DELETED, ['b' => 2], ['Content-Type' => 'application/json']);
 
-        $repo = $this->createMock(ObjectRepository::class);
-        $repo->method('getClassName')->willReturn(WebhookDelivery::class);
+        $repo = $this->createMock(WebhookDeliveryRepository::class);
+        $repo->expects($this->once())
+            ->method('countByEndpoint')
+            ->with($endpoint)
+            ->willReturn(2);
         $repo->expects($this->once())
             ->method('findBy')
-            ->with(['endpoint' => $endpoint], ['id' => 'DESC'])
+            ->with(['endpoint' => $endpoint], ['id' => 'DESC'], 20, 0)
             ->willReturn([$d2, $d1]);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->method('getRepository')->with(WebhookDelivery::class)->willReturn($repo);
         $bus = $this->createMock(MessageBusInterface::class);
 
-        $manager = new WebhookDeliveryManager($em, $bus);
-        $result = $manager->findAllByEndpoint($endpoint);
+        $manager = new WebhookDeliveryManager($em, $bus, $repo);
+        $result = $manager->findPaginatedByEndpoint($endpoint);
 
-        $this->assertSame([$d2, $d1], $result);
+        $this->assertSame([$d2, $d1], $result['items']);
+        $this->assertSame(1, $result['page']);
+        $this->assertSame(1, $result['totalPages']);
+        $this->assertSame(2, $result['total']);
     }
 
     public function testRetryDoesNothingForSuccessfulDelivery(): void
@@ -52,8 +57,9 @@ class WebhookDeliveryManagerTest extends TestCase
         $em->expects($this->never())->method('flush');
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects($this->never())->method('dispatch');
+        $repo = $this->createMock(WebhookDeliveryRepository::class);
 
-        $manager = new WebhookDeliveryManager($em, $bus);
+        $manager = new WebhookDeliveryManager($em, $bus, $repo);
         $manager->retry($delivery);
     }
 
@@ -84,7 +90,9 @@ class WebhookDeliveryManagerTest extends TestCase
             return true;
         }))->willReturnCallback(fn ($m) => $m instanceof Envelope ? $m : new Envelope($m));
 
-        $manager = new WebhookDeliveryManager($em, $bus);
+        $repo = $this->createMock(WebhookDeliveryRepository::class);
+
+        $manager = new WebhookDeliveryManager($em, $bus, $repo);
         $manager->retry($delivery);
 
         $this->assertNull($delivery->getResponseCode());


### PR DESCRIPTION
This pull request introduces pagination support for viewing webhook deliveries in the settings area. It adds a repository for efficient counting and retrieval, updates the service and controller to support paginated access, and enhances the UI and translations to display pagination controls. Additionally, it includes new test coverage and data fixtures for webhook deliveries.

<img width="2360" height="1640" alt="Bildschirmfoto am 2026-01-10 um 12 06 10" src="https://github.com/user-attachments/assets/40c14d2b-bff7-4bad-955c-2624166655ad" />
<img width="2360" height="1640" alt="Bildschirmfoto am 2026-01-10 um 12 06 27" src="https://github.com/user-attachments/assets/bcb21204-6ae0-4fe4-bc1c-38dd1d500e1b" />

