### PR TITLE
✨ Add Filter for Webhook Deliveries

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -543,6 +543,9 @@ settings:
       title: Zustellungen
       heading: Zustellungen
       subtitle: Kürzliche Webhook-Zustellungen
+      filter:
+        label: Status
+        all: Alle
       table:
         id: ID
         event: Ereignis

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -545,6 +545,9 @@ settings:
       title: Deliveries
       heading: Deliveries
       subtitle: Recent webhook deliveries
+      filter:
+        label: Status
+        all: All
       table:
         id: ID
         event: Event

--- a/features/settings_webhook.feature
+++ b/features/settings_webhook.feature
@@ -84,6 +84,14 @@ Feature: Settings
     And I should see "Delivered"
     And I should see "Failed"
 
+    When I am on "/settings/webhooks/1/deliveries?status=success"
+    Then the response status code should be 200
+    And I should not see "Retry"
+
+    When I am on "/settings/webhooks/1/deliveries?status=failed"
+    Then the response status code should be 200
+    And I should see "Retry"
+
   @webhooks
   Scenario: Admin can view a delivery for a webhook
     Given the following WebhookEndpoint exists:

--- a/src/Controller/WebhookDeliveryController.php
+++ b/src/Controller/WebhookDeliveryController.php
@@ -26,7 +26,8 @@ final class WebhookDeliveryController extends AbstractController
         Request $request,
     ): Response {
         $page = $request->query->getInt('page', 1);
-        $pagination = $this->manager->findPaginatedByEndpoint($endpoint, $page);
+        $status = $request->query->getString('status', '');
+        $pagination = $this->manager->findPaginatedByEndpoint($endpoint, $page, $status);
 
         return $this->render('Settings/Webhook/Delivery/index.html.twig', [
             'deliveries' => $pagination['items'],
@@ -34,6 +35,7 @@ final class WebhookDeliveryController extends AbstractController
             'page' => $pagination['page'],
             'totalPages' => $pagination['totalPages'],
             'total' => $pagination['total'],
+            'status' => $status,
         ]);
     }
 

--- a/src/Service/WebhookDeliveryManager.php
+++ b/src/Service/WebhookDeliveryManager.php
@@ -30,14 +30,15 @@ final readonly class WebhookDeliveryManager
     public function findPaginatedByEndpoint(
         WebhookEndpoint $endpoint,
         int $page = 1,
+        string $status = '',
     ): array {
         $page = max(1, $page);
         $offset = ($page - 1) * self::PAGE_SIZE;
-        $total = $this->repository->countByEndpoint($endpoint);
-        $totalPages = (int) ceil($total / self::PAGE_SIZE);
-        $items = $this->repository->findBy(
-            ['endpoint' => $endpoint],
-            ['id' => 'DESC'],
+        $total = $this->repository->countByEndpointAndStatus($endpoint, $status);
+        $totalPages = max(1, (int) ceil($total / self::PAGE_SIZE));
+        $items = $this->repository->findByEndpointAndStatus(
+            $endpoint,
+            $status,
             self::PAGE_SIZE,
             $offset,
         );

--- a/templates/Settings/Webhook/Delivery/index.html.twig
+++ b/templates/Settings/Webhook/Delivery/index.html.twig
@@ -16,11 +16,22 @@
                         <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.webhook.deliveries.subtitle'|trans }}</p>
                     </div>
                 </div>
-                <div class="mb-4">
+                <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                     <a href="{{ path('settings_webhook_endpoint_index') }}"
                        class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
                         {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.actions.back'|trans }}
                     </a>
+                    <div class="flex items-center gap-2">
+                        <label for="status-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.webhook.deliveries.filter.label'|trans }}:</label>
+                        <select id="status-filter"
+                                onchange="window.location.href = this.value"
+                                class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id}) }}"{% if status == '' %} selected{% endif %}>{{ 'settings.webhook.deliveries.filter.all'|trans }}</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'success'}) }}"{% if status == 'success' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.delivered'|trans }}</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'failed'}) }}"{% if status == 'failed' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.failed'|trans }}</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'pending'}) }}"{% if status == 'pending' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.pending'|trans }}</option>
+                        </select>
+                    </div>
                 </div>
                 <div class="overflow-hidden">
                     <div class="overflow-x-auto">
@@ -88,7 +99,7 @@
                         </div>
                         <div class="flex gap-2">
                             {% if page > 1 %}
-                                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page - 1}) }}"
+                                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page - 1, status: status}|filter(v => v)) }}"
                                    class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
                                     {{ ux_icon('heroicons:chevron-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.deliveries.pagination.newer'|trans }}
                                 </a>
@@ -97,7 +108,7 @@
                                 {{ 'settings.webhook.deliveries.pagination.page'|trans({'%page%': page, '%totalPages%': totalPages}) }}
                             </span>
                             {% if page < totalPages %}
-                                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page + 1}) }}"
+                                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page + 1, status: status}|filter(v => v)) }}"
                                    class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
                                     {{ 'settings.webhook.deliveries.pagination.older'|trans }} {{ ux_icon('heroicons:chevron-right', {class: 'w-4 h-4 ml-1'}) }}
                                 </a>

--- a/tests/Service/WebhookDeliveryManagerTest.php
+++ b/tests/Service/WebhookDeliveryManagerTest.php
@@ -27,12 +27,12 @@ class WebhookDeliveryManagerTest extends TestCase
 
         $repo = $this->createMock(WebhookDeliveryRepository::class);
         $repo->expects($this->once())
-            ->method('countByEndpoint')
-            ->with($endpoint)
+            ->method('countByEndpointAndStatus')
+            ->with($endpoint, '')
             ->willReturn(2);
         $repo->expects($this->once())
-            ->method('findBy')
-            ->with(['endpoint' => $endpoint], ['id' => 'DESC'], 20, 0)
+            ->method('findByEndpointAndStatus')
+            ->with($endpoint, '', 20, 0)
             ->willReturn([$d2, $d1]);
 
         $em = $this->createMock(EntityManagerInterface::class);


### PR DESCRIPTION
This pull request adds the ability to filter webhook deliveries by status (all, delivered, failed, pending) in the settings UI. It introduces backend support for filtering and paginating deliveries by status, updates the frontend to include a status filter dropdown, and ensures pagination works correctly with filters. Translations and tests are also updated accordingly.

<img width="1280" height="800" alt="Bildschirmfoto am 2026-01-10 um 16 29 16" src="https://github.com/user-attachments/assets/e8d64cfe-a5ff-42c0-9ce8-815d9ada4c1c" />
<img width="1280" height="800" alt="Bildschirmfoto am 2026-01-10 um 16 28 27" src="https://github.com/user-attachments/assets/9fa12203-04c3-45fd-9fa4-22a855310015" />
