### PR TITLE
🧑‍💻 Add Container for receiving Webhooks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,15 @@ services:
     networks:
       - userli
 
+  webhook:
+    image: ghcr.io/tarampampam/webhook-tester:2
+    command: server --auto-create-sessions
+    ports:
+      - 9000:8080
+    restart: always
+    networks:
+      - userli
+
 networks:
   userli:
 

--- a/src/DataFixtures/LoadWebhookData.php
+++ b/src/DataFixtures/LoadWebhookData.php
@@ -21,7 +21,7 @@ final class LoadWebhookData extends Fixture implements FixtureGroupInterface
     public function load(ObjectManager $manager): void
     {
         $endpoint = new WebhookEndpoint(
-            'https://webhook.example.com/events',
+            'http://webhook:8080/e6fd49c8-7ecc-4b0a-8af1-a16f508e0f68',
             bin2hex(random_bytes(16))
         );
         $endpoint->setEvents([WebhookEvent::USER_CREATED->value, WebhookEvent::USER_DELETED->value]);


### PR DESCRIPTION
This pull request introduces a new local webhook testing service and updates the webhook endpoint configuration to use this service for development and testing purposes. The main changes are grouped into infrastructure and data fixture updates:

**Infrastructure:**

* Added a new `webhook` service to `docker-compose.yml` using the `ghcr.io/tarampampam/webhook-tester` image, exposing port 9000 for local webhook event testing.

**Data Fixtures:**

* Updated the webhook endpoint URL in `LoadWebhookData.php` to point to the local `webhook` service instead of the external example URL, enabling integration with the new testing service.