### PR TITLE
🐛 Remove novalidate attribute from login template

### DIFF
--- a/templates/Security/login.html.twig
+++ b/templates/Security/login.html.twig
@@ -30,7 +30,7 @@
         </div>
     {% endif %}
 
-    {{ form_start(form, {'attr': {'class': 'space-y-6', 'novalidate': 'novalidate'}}) }}
+    {{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
         {{ form_row(form._username) }}
         {{ form_row(form._password) }}
 


### PR DESCRIPTION
This pull request makes a minor change to the login form template by removing the `novalidate` attribute from the form element. This means that browser-based form validation will now be enabled for the login form.