### PR TITLE
🗃️ Add missing migration for webhook_deliveries indexes

### DIFF
--- a/migrations/Version20260131181339.php
+++ b/migrations/Version20260131181339.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add indexes to webhook_deliveries for endpoint_id and type.
+ */
+final class Version20260131181339 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add indexes to webhook_deliveries for endpoint_id and type';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $indexes = $schemaManager->listTableIndexes('webhook_deliveries');
+
+        if (isset($indexes['idx_3681f32d21af7e368cde5729'])) {
+            $this->write('Index IDX_3681F32D21AF7E368CDE5729 already exists, skipping creation.');
+        } else {
+            $this->addSql('CREATE INDEX IDX_3681F32D21AF7E368CDE5729 ON webhook_deliveries (endpoint_id, type)');
+        }
+
+        if (isset($indexes['idx_3681f32d21af7e368cde57296f00dfb2'])) {
+            $this->write('Index IDX_3681F32D21AF7E368CDE57296F00DFB2 already exists, skipping creation.');
+        } else {
+            $this->addSql('CREATE INDEX IDX_3681F32D21AF7E368CDE57296F00DFB2 ON webhook_deliveries (endpoint_id, type, success)');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_3681F32D21AF7E368CDE5729 ON webhook_deliveries');
+        $this->addSql('DROP INDEX IDX_3681F32D21AF7E368CDE57296F00DFB2 ON webhook_deliveries');
+    }
+}


### PR DESCRIPTION
## What I did?

```
git checkout 5.4.1
podman compose exec userli bin/console doctrine:database:drop --force
podman compose exec userli bin/console doctrine:database:create
podman compose exec userli bin/console doctrine:schema:update --dump-sql --complete --force

git checkout main
podman compose exec userli bin/console doctrine:migrations:migrate --no-interaction
podman compose exec userli bin/console doctrine:schema:update --dump-sql --complete 
# Output
# CREATE INDEX IDX_3681F32D21AF7E368CDE5729 ON webhook_deliveries (endpoint_id, type);
# CREATE INDEX IDX_3681F32D21AF7E368CDE57296F00DFB2 ON webhook_deliveries (endpoint_id, type, success);
```

With this change, the upgrade path to Doctrine migrations from the latest (5.4.1) version should be safe now.