### PR TITLE
♻️ Centralize validation in form models and admin classes

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.4"
           extensions: pdo_mysql, openssl, sodium
           tools: composer
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -92,7 +92,6 @@ services:
                   model_class: App\Entity\Domain,
               }
         calls:
-            - [setDomainCreator, ['@App\Creator\DomainCreator']]
             - [
                   setEventDispatcher,
                   [

--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -7,6 +7,8 @@ namespace App\Admin;
 use App\Entity\Alias;
 use App\Enum\Roles;
 use App\Traits\DomainGuesserAwareTrait;
+use App\Validator\EmailAddress;
+use App\Validator\Lowercase;
 use DateTime;
 use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
@@ -16,6 +18,7 @@ use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @extends Admin<Alias>
@@ -39,7 +42,14 @@ final class AliasAdmin extends Admin
     protected function configureFormFields(FormMapper $form): void
     {
         $form
-            ->add('source', EmailType::class)
+            ->add('source', EmailType::class, [
+                'constraints' => $this->isNewObject() ? [
+                    new Assert\NotNull(),
+                    new Assert\Email(mode: 'strict'),
+                    new Lowercase(),
+                    new EmailAddress(),
+                ] : [],
+            ])
             ->add('user', ModelAutocompleteType::class, ['property' => 'email', 'required' => false])
             ->add('deleted', CheckboxType::class, ['disabled' => true]);
 

--- a/src/Admin/ReservedNameAdmin.php
+++ b/src/Admin/ReservedNameAdmin.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Admin;
 
 use App\Entity\ReservedName;
+use App\Validator\Lowercase;
+use App\Validator\UniqueField;
 use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @extends Admin<ReservedName>
@@ -26,7 +29,15 @@ final class ReservedNameAdmin extends Admin
     protected function configureFormFields(FormMapper $form): void
     {
         $form
-            ->add('name', TextType::class, ['disabled' => !$this->isNewObject()]);
+            ->add('name', TextType::class, [
+                'disabled' => !$this->isNewObject(),
+                'constraints' => $this->isNewObject() ? [
+                    new Assert\NotNull(),
+                    new Assert\NotBlank(),
+                    new Lowercase(),
+                    new UniqueField(entityClass: ReservedName::class, field: 'name', message: 'form.unique-field'),
+                ] : [],
+            ]);
     }
 
     #[Override]

--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -10,7 +10,9 @@ use App\Enum\Roles;
 use App\Handler\MailCryptKeyHandler;
 use App\Helper\PasswordUpdater;
 use App\Traits\DomainGuesserAwareTrait;
+use App\Validator\Lowercase;
 use App\Validator\PasswordPolicy;
+use App\Validator\UniqueField;
 use Exception;
 use Override;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
@@ -73,7 +75,15 @@ final class UserAdmin extends Admin
         $availableRoleChoices = array_combine($availableRoles, $availableRoles) ?: [];
 
         $form
-            ->add('email', EmailType::class, ['disabled' => !$this->isNewObject()])
+            ->add('email', EmailType::class, [
+                'disabled' => !$this->isNewObject(),
+                'constraints' => $this->isNewObject() ? [
+                    new Assert\NotNull(),
+                    new Assert\Email(mode: 'strict'),
+                    new Lowercase(),
+                    new UniqueField(entityClass: User::class, field: 'email', message: 'registration.email-already-taken'),
+                ] : [],
+            ])
             ->add('plainPassword', PasswordType::class, [
                 'label' => 'form.password',
                 'required' => $this->isNewObject(),

--- a/src/Controller/AliasController.php
+++ b/src/Controller/AliasController.php
@@ -92,8 +92,16 @@ final class AliasController extends AbstractController
             /** @var AliasCreate $randomData */
             $randomData = $randomAliasCreateForm->getData();
             $this->processRandomAliasCreation($user, $randomData->getNote());
-        } elseif ($customAliasCreateForm->isSubmitted() && $customAliasCreateForm->isValid()) {
-            $this->processCustomAliasCreation($user, $aliasCreate->alias, $aliasCreate->getNote());
+        } elseif ($customAliasCreateForm->isSubmitted()) {
+            if ($customAliasCreateForm->isValid()) {
+                // Extract local part from full email (alias contains "localpart@domain")
+                $localPart = explode('@', $aliasCreate->getAlias())[0];
+                $this->processCustomAliasCreation($user, $localPart, $aliasCreate->getNote());
+            } else {
+                foreach ($customAliasCreateForm->getErrors(true) as $error) {
+                    $this->addFlash('error', $error->getMessage());
+                }
+            }
         }
 
         return $this->redirectToRoute('aliases');

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -12,7 +12,6 @@ use App\Traits\IdTrait;
 use App\Traits\RandomTrait;
 use App\Traits\UpdatedTimeTrait;
 use App\Traits\UserAwareTrait;
-use App\Validator\EmailAddress;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\AssociationOverride;
@@ -38,7 +37,6 @@ class Alias implements SoftDeletableInterface, Stringable
     use UserAwareTrait;
 
     #[ORM\Column]
-    #[EmailAddress(groups: ['unique'])]
     protected ?string $source = null;
 
     #[ORM\Column(nullable: true)]

--- a/src/Entity/Domain.php
+++ b/src/Entity/Domain.php
@@ -13,12 +13,10 @@ use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Stringable;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 #[ORM\Entity(repositoryClass: DomainRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'virtual_domains')]
-#[UniqueEntity('name')]
 class Domain implements Stringable
 {
     use CreationTimeTrait;

--- a/src/Entity/ReservedName.php
+++ b/src/Entity/ReservedName.php
@@ -13,11 +13,9 @@ use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Stringable;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 #[ORM\Entity(repositoryClass: ReservedNameRepository::class)]
 #[ORM\Table(name: 'virtual_reserved_names')]
-#[UniqueEntity('name')]
 class ReservedName implements Stringable
 {
     use CreationTimeTrait;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -28,7 +28,6 @@ use App\Traits\SaltTrait;
 use App\Traits\TwofactorBackupCodeTrait;
 use App\Traits\TwofactorTrait;
 use App\Traits\UpdatedTimeTrait;
-use App\Validator\EmailDomain;
 use DateTime;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -49,7 +48,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[Index(columns: ['email', 'deleted'], name: 'email_deleted_idx')]
 #[Index(columns: ['domain_id', 'deleted'], name: 'domain_deleted_idx')]
 #[Index(columns: ['email', 'domain_id'], name: 'email_domain_idx')]
-#[EmailDomain]
 class User implements UserInterface, PasswordAuthenticatedUserInterface, PasswordHasherAwareInterface, TwoFactorInterface, BackupCodeInterface, Stringable
 {
     use CreationTimeTrait;

--- a/src/Entity/Voucher.php
+++ b/src/Entity/Voucher.php
@@ -8,7 +8,6 @@ use App\Repository\VoucherRepository;
 use App\Traits\CreationTimeTrait;
 use App\Traits\IdTrait;
 use App\Traits\UserAwareTrait;
-use App\Validator\VoucherUser;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Index;
@@ -18,7 +17,6 @@ use Stringable;
 #[ORM\Entity(repositoryClass: VoucherRepository::class)]
 #[ORM\Table(name: 'virtual_vouchers')]
 #[Index(columns: ['code'], name: 'code_idx')]
-#[VoucherUser]
 class Voucher implements Stringable
 {
     use CreationTimeTrait;

--- a/src/Form/CustomAliasCreateType.php
+++ b/src/Form/CustomAliasCreateType.php
@@ -7,9 +7,12 @@ namespace App\Form;
 use App\Form\Model\AliasCreate;
 use Override;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -24,13 +27,28 @@ final class CustomAliasCreateType extends AbstractType
     {
         $builder
             ->add('alias', TextType::class, ['label' => 'form.new-custom-alias'])
+            ->add('domain', HiddenType::class, ['mapped' => false])
             ->add('submit', SubmitType::class, ['label' => 'form.create-custom-alias']);
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event): void {
+            $data = $event->getData();
+
+            if (!is_array($data) || empty($data['alias']) || empty($data['domain'])) {
+                return;
+            }
+
+            // Combine local part + domain into full email address
+            $data['alias'] = strtolower($data['alias']).'@'.$data['domain'];
+            $event->setData($data);
+        });
     }
 
     #[Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults(['data_class' => AliasCreate::class]);
+        $resolver->setDefaults([
+            'data_class' => AliasCreate::class,
+        ]);
     }
 
     #[Override]

--- a/src/Form/Model/AliasCreate.php
+++ b/src/Form/Model/AliasCreate.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace App\Form\Model;
 
+use App\Validator\EmailAddress;
 use Symfony\Component\Validator\Constraints as Assert;
 
 final class AliasCreate
 {
+    /**
+     * Full email address (alias@domain).
+     * The form combines the local part with the domain before submission.
+     */
     #[Assert\NotNull]
-    #[Assert\Length(min: 3, max: 24)]
-    public string $alias;
+    #[EmailAddress]
+    private string $alias;
 
     #[Assert\Length(max: 40)]
     private ?string $note = null;
@@ -23,5 +28,15 @@ final class AliasCreate
     public function setNote(?string $note): void
     {
         $this->note = $note !== null ? trim($note) : null;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    public function setAlias(string $alias): void
+    {
+        $this->alias = $alias;
     }
 }

--- a/src/Form/Model/DomainCreate.php
+++ b/src/Form/Model/DomainCreate.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 namespace App\Form\Model;
 
+use App\Entity\Domain;
+use App\Validator\Lowercase;
+use App\Validator\UniqueField;
+use Symfony\Component\Validator\Constraints as Assert;
+
 final class DomainCreate
 {
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
+    #[Lowercase]
+    #[UniqueField(entityClass: Domain::class, field: 'name', message: 'form.unique-field')]
     public string $domain;
 }

--- a/src/Traits/DomainAwareTrait.php
+++ b/src/Traits/DomainAwareTrait.php
@@ -6,13 +6,11 @@ namespace App\Traits;
 
 use App\Entity\Domain;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 trait DomainAwareTrait
 {
     #[ORM\ManyToOne(targetEntity: Domain::class)]
     #[ORM\JoinColumn(nullable: false)]
-    #[Assert\Valid]
     private ?Domain $domain = null;
 
     public function getDomain(): ?Domain

--- a/src/Traits/EmailTrait.php
+++ b/src/Traits/EmailTrait.php
@@ -4,16 +4,11 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
-use App\Validator\Lowercase;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 trait EmailTrait
 {
     #[ORM\Column(unique: true)]
-    #[Assert\NotNull]
-    #[Lowercase]
-    #[Assert\Email]
     private string $email;
 
     public function getEmail(): string

--- a/src/Traits/NameTrait.php
+++ b/src/Traits/NameTrait.php
@@ -4,16 +4,11 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
-use App\Validator\Lowercase;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 trait NameTrait
 {
     #[ORM\Column(unique: true)]
-    #[Assert\NotNull]
-    #[Assert\NotBlank]
-    #[Lowercase]
     private ?string $name = null;
 
     public function getName(): ?string

--- a/src/Validator/UniqueField.php
+++ b/src/Validator/UniqueField.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+#[Attribute]
+final class UniqueField extends Constraint
+{
+    public string $message = 'form.unique-field';
+
+    /**
+     * @param class-string $entityClass
+     */
+    public function __construct(
+        public readonly string $entityClass,
+        public readonly string $field,
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        if (null !== $message) {
+            $this->message = $message;
+        }
+
+        parent::__construct(groups: $groups, payload: $payload);
+    }
+}

--- a/src/Validator/UniqueFieldValidator.php
+++ b/src/Validator/UniqueFieldValidator.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Override;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class UniqueFieldValidator extends ConstraintValidator
+{
+    public function __construct(private readonly EntityManagerInterface $manager)
+    {
+    }
+
+    #[Override]
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof UniqueField) {
+            throw new UnexpectedTypeException($constraint, UniqueField::class);
+        }
+
+        // custom constraints should ignore null and empty values to allow
+        // other constraints (NotBlank, NotNull, etc.) to take care of that
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        $repository = $this->manager->getRepository($constraint->entityClass);
+        $existingEntity = $repository->findOneBy([$constraint->field => $value]);
+
+        if (null !== $existingEntity) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ field }}', $constraint->field)
+                ->addViolation();
+        }
+    }
+}

--- a/templates/Alias/show.html.twig
+++ b/templates/Alias/show.html.twig
@@ -68,6 +68,7 @@
                             <div class="mb-6 flex items-center">
                                 {%  if alias_creation_custom %}
                                 {{ form_start(custom_alias_form, {'attr': {'class': 'w-full'}}) }}
+                                {{ form_widget(custom_alias_form.domain, {'value': user_domain}) }}
                                 <div class="mb-6">
                                     {{ form_label(custom_alias_form.alias, "index.alias-custom-create"|trans, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
 

--- a/tests/Form/CustomAliasCreateTypeTest.php
+++ b/tests/Form/CustomAliasCreateTypeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form;
+
+use App\Form\CustomAliasCreateType;
+use App\Form\Model\AliasCreate;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class CustomAliasCreateTypeTest extends TypeTestCase
+{
+    public function testSubmitValidData(): void
+    {
+        $localPart = 'testalias';
+        $domain = 'example.org';
+        $formData = ['alias' => $localPart, 'domain' => $domain];
+
+        $form = $this->factory->create(CustomAliasCreateType::class);
+
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+
+        /** @var AliasCreate $data */
+        $data = $form->getData();
+        // alias now contains the full email
+        $this->assertEquals($localPart.'@'.$domain, $data->getAlias());
+    }
+
+    public function testSubmitWithoutDomainKeepsLocalPart(): void
+    {
+        $localPart = 'testalias';
+        $formData = ['alias' => $localPart];
+
+        $form = $this->factory->create(CustomAliasCreateType::class);
+
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+
+        /** @var AliasCreate $data */
+        $data = $form->getData();
+        // Without domain, alias stays as local part only
+        $this->assertEquals($localPart, $data->getAlias());
+    }
+
+    public function testAliasIsLowercased(): void
+    {
+        $localPart = 'TestAlias';
+        $domain = 'example.org';
+        $formData = ['alias' => $localPart, 'domain' => $domain];
+
+        $form = $this->factory->create(CustomAliasCreateType::class);
+
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+
+        /** @var AliasCreate $data */
+        $data = $form->getData();
+        $this->assertEquals('testalias@'.$domain, $data->getAlias());
+    }
+
+    public function testDomainFieldIsUnmapped(): void
+    {
+        $form = $this->factory->create(CustomAliasCreateType::class);
+
+        $domainField = $form->get('domain');
+        $this->assertFalse($domainField->getConfig()->getMapped());
+    }
+}

--- a/tests/Validator/UniqueFieldValidatorTest.php
+++ b/tests/Validator/UniqueFieldValidatorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Validator;
+
+use App\Entity\Domain;
+use App\Validator\UniqueField;
+use App\Validator\UniqueFieldValidator;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use stdClass;
+use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class UniqueFieldValidatorTest extends ConstraintValidatorTestCase
+{
+    private EntityManagerInterface $manager;
+    private EntityRepository $repository;
+
+    protected function createValidator(): UniqueFieldValidator
+    {
+        $this->repository = $this->createMock(EntityRepository::class);
+
+        $this->manager = $this->createMock(EntityManagerInterface::class);
+        $this->manager->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($this->repository);
+
+        return new UniqueFieldValidator($this->manager);
+    }
+
+    public function testExpectsUniqueFieldConstraint(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validate('value', new Valid());
+    }
+
+    public function testNullIsValid(): void
+    {
+        $constraint = new UniqueField(entityClass: Domain::class, field: 'name');
+        $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid(): void
+    {
+        $constraint = new UniqueField(entityClass: Domain::class, field: 'name');
+        $this->validator->validate('', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testExpectsStringValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $constraint = new UniqueField(entityClass: Domain::class, field: 'name');
+        $this->validator->validate(new stdClass(), $constraint);
+    }
+
+    public function testUniqueValueIsValid(): void
+    {
+        $this->repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['name' => 'unique-domain'])
+            ->willReturn(null);
+
+        $constraint = new UniqueField(entityClass: Domain::class, field: 'name');
+        $this->validator->validate('unique-domain', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testDuplicateValueRaisesViolation(): void
+    {
+        $existingDomain = new Domain();
+
+        $this->repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['name' => 'existing-domain'])
+            ->willReturn($existingDomain);
+
+        $constraint = new UniqueField(entityClass: Domain::class, field: 'name');
+        $this->validator->validate('existing-domain', $constraint);
+
+        $this->buildViolation('form.unique-field')
+            ->setParameter('{{ value }}', 'existing-domain')
+            ->setParameter('{{ field }}', 'name')
+            ->assertRaised();
+    }
+
+    public function testCustomMessageIsUsed(): void
+    {
+        $existingDomain = new Domain();
+
+        $this->repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['name' => 'duplicate'])
+            ->willReturn($existingDomain);
+
+        $constraint = new UniqueField(
+            entityClass: Domain::class,
+            field: 'name',
+            message: 'custom.error-message'
+        );
+        $this->validator->validate('duplicate', $constraint);
+
+        $this->buildViolation('custom.error-message')
+            ->setParameter('{{ value }}', 'duplicate')
+            ->setParameter('{{ field }}', 'name')
+            ->assertRaised();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new custom `UniqueField` validator to enforce uniqueness constraints at the form validation level, replacing previous Doctrine-level and trait-based uniqueness checks. The changes also standardize and improve validation logic for several admin forms, ensuring stricter and more consistent input validation for new entities. Additionally, some legacy validation logic and service wiring are cleaned up.

- Remove validation constraints from entities and traits
- Add UniqueField validator as replacement for UniqueEntity
- Add form-level validation to all SonataAdmin classes
- Update DomainCreate form model with validation