### PR TITLE
✨ Allow admins to reset user passwords in UserAdmin

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -65,6 +65,7 @@ services:
             - [setMailCryptKeyHandler, ['@App\Handler\MailCryptKeyHandler']]
             - [setMailCryptVar, ["%env(MAIL_CRYPT)%"]]
             - [setSecurity, ['@Symfony\Bundle\SecurityBundle\Security']]
+            - [setUserResetService, ['@App\Service\UserResetService']]
 
     userli.admin.user_notification:
         class: App\Admin\UserNotificationAdmin

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -181,6 +181,9 @@ class FeatureContext extends MinkContext
                     case 'totpSecret':
                         $user->setTotpSecret($value);
                         break;
+                    case 'passwordChangeRequired':
+                        $user->setPasswordChangeRequired((bool) $value);
+                        break;
                     case 'totp_backup_codes':
                         $codes = $this->totpBackupCodeGenerator->generate();
                         $user->setTotpBackupCodes($codes);
@@ -587,6 +590,60 @@ class FeatureContext extends MinkContext
 
         if (null === $user) {
             throw new RuntimeException(sprintf('User "%s" does not exist', $email));
+        }
+    }
+
+    /**
+     * @Then /^the user "([^"]*)" should have passwordChangeRequired$/
+     */
+    public function theUserShouldHavePasswordChangeRequired(string $email): void
+    {
+        $this->manager->clear();
+
+        $user = $this->getUserRepository()->findByEmail($email);
+
+        if (null === $user) {
+            throw new RuntimeException(sprintf('User "%s" does not exist', $email));
+        }
+
+        if (!$user->isPasswordChangeRequired()) {
+            throw new RuntimeException(sprintf('User "%s" does not have passwordChangeRequired set', $email));
+        }
+    }
+
+    /**
+     * @Then /^the user "([^"]*)" should have a mailCryptSecretBox$/
+     */
+    public function theUserShouldHaveAMailCryptSecretBox(string $email): void
+    {
+        $this->manager->clear();
+
+        $user = $this->getUserRepository()->findByEmail($email);
+
+        if (null === $user) {
+            throw new RuntimeException(sprintf('User "%s" does not exist', $email));
+        }
+
+        if (!$user->hasMailCryptSecretBox()) {
+            throw new RuntimeException(sprintf('User "%s" does not have a mailCryptSecretBox', $email));
+        }
+    }
+
+    /**
+     * @Then /^the user "([^"]*)" should not have totpConfirmed$/
+     */
+    public function theUserShouldNotHaveTotpConfirmed(string $email): void
+    {
+        $this->manager->clear();
+
+        $user = $this->getUserRepository()->findByEmail($email);
+
+        if (null === $user) {
+            throw new RuntimeException(sprintf('User "%s" does not exist', $email));
+        }
+
+        if ($user->getTotpConfirmed()) {
+            throw new RuntimeException(sprintf('User "%s" still has totpConfirmed set', $email));
         }
     }
 


### PR DESCRIPTION
## Summary

- Allow admins to reset passwords for all users in the Sonata Admin UserAdmin, including users with MailCrypt keys enabled
- Replace single password field with `RepeatedType` (password + confirmation) for both create and edit forms
- When resetting a MailCrypt user's password: regenerate MailCrypt keys, reset 2FA (TOTP), generate a new recovery token, and display it as a flash message
- Always set `passwordChangeRequired = true` on password reset so the user must change their password on next login
- Add Behat test scenarios for both MailCrypt and non-MailCrypt password resets

<img width="1280" height="800" alt="Bildschirmfoto am 2026-02-06 um 15 17 27" src="https://github.com/user-attachments/assets/78619715-e5ec-4b0c-b3ae-0523771b4f39" />

<img width="1280" height="800" alt="Bildschirmfoto am 2026-02-06 um 15 17 16" src="https://github.com/user-attachments/assets/f7a80c21-3cde-46a7-9b59-3e29853e76a7" />

## Changes

### `src/Admin/UserAdmin.php`
- Changed `plainPassword` field from `PasswordType` to `RepeatedType` with password confirmation
- Removed `disabled` restriction on password field for MailCrypt users; replaced with a warning message
- Modified `preUpdate()` to use `UserResetService::resetUser()` for MailCrypt users (new keys, recovery token, 2FA reset) and `PasswordUpdater` for non-MailCrypt users
- Added `postUpdate()` to display the generated recovery token as a flash message
- Added `UserResetService` dependency

### `config/services.yaml`
- Injected `UserResetService` into the `userli.admin.user` service

### `features/admin.feature`
- Updated "Create a new User" scenario for the new confirmation field
- Added scenario: Admin resets password of user without MailCrypt
- Added scenario: Admin resets password of user with MailCrypt (verifies warning, passwordChangeRequired, key regeneration, 2FA reset, recovery token display)

### `tests/Behat/FeatureContext.php`
- Added `passwordChangeRequired` support in user fixture setup
- Added step definitions: `should have passwordChangeRequired`, `should have a mailCryptSecretBox`, `should not have totpConfirmed`

## Test Results
- 174 Behat scenarios passing (was 172)
- 1711 steps passing (was 1652)

Created with OpenCode (Claude Opus 4.6)