### PR TITLE
✨ Auto-update updatedTime via Doctrine listener and UpdatedTimeInterface

### DIFF
--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -267,8 +267,6 @@ final class UserAdmin extends Admin
                 $this->passwordUpdater->updatePassword($object, $plainPassword);
             }
             $object->setPasswordChangeRequired(true);
-        } else {
-            $object->updateUpdatedTime();
         }
 
         if (false === $object->getTotpConfirmed()) {

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -21,12 +21,11 @@ use Stringable;
 
 #[ORM\Entity(repositoryClass: AliasRepository::class)]
 #[ORM\AssociationOverrides([new AssociationOverride(name: 'domain', joinColumns: new ORM\JoinColumn(nullable: true))])]
-#[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'virtual_aliases')]
 #[Index(columns: ['source', 'deleted'], name: 'source_deleted_idx')]
 #[Index(columns: ['destination', 'deleted'], name: 'destination_deleted_idx')]
 #[Index(columns: ['user_id', 'deleted'], name: 'user_deleted_idx')]
-class Alias implements SoftDeletableInterface, Stringable
+class Alias implements SoftDeletableInterface, UpdatedTimeInterface, Stringable
 {
     use CreationTimeTrait;
     use DeleteTrait;

--- a/src/Entity/Domain.php
+++ b/src/Entity/Domain.php
@@ -15,9 +15,8 @@ use Override;
 use Stringable;
 
 #[ORM\Entity(repositoryClass: DomainRepository::class)]
-#[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'virtual_domains')]
-class Domain implements Stringable
+class Domain implements UpdatedTimeInterface, Stringable
 {
     use CreationTimeTrait;
     use IdTrait;

--- a/src/Entity/ReservedName.php
+++ b/src/Entity/ReservedName.php
@@ -16,7 +16,7 @@ use Stringable;
 
 #[ORM\Entity(repositoryClass: ReservedNameRepository::class)]
 #[ORM\Table(name: 'virtual_reserved_names')]
-class ReservedName implements Stringable
+class ReservedName implements UpdatedTimeInterface, Stringable
 {
     use CreationTimeTrait;
     use IdTrait;

--- a/src/Entity/UpdatedTimeInterface.php
+++ b/src/Entity/UpdatedTimeInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use DateTime;
+
+interface UpdatedTimeInterface
+{
+    public function getUpdatedTime(): ?DateTime;
+
+    public function setUpdatedTime(DateTime $updatedTime): void;
+
+    public function updateUpdatedTime(): void;
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -48,7 +48,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[Index(columns: ['email', 'deleted'], name: 'email_deleted_idx')]
 #[Index(columns: ['domain_id', 'deleted'], name: 'domain_deleted_idx')]
 #[Index(columns: ['email', 'domain_id'], name: 'email_domain_idx')]
-class User implements UserInterface, PasswordAuthenticatedUserInterface, PasswordHasherAwareInterface, TwoFactorInterface, BackupCodeInterface, Stringable
+class User implements UserInterface, PasswordAuthenticatedUserInterface, PasswordHasherAwareInterface, TwoFactorInterface, BackupCodeInterface, UpdatedTimeInterface, Stringable
 {
     use CreationTimeTrait;
     use DeleteTrait;

--- a/src/EntityListener/UpdatedTimeListener.php
+++ b/src/EntityListener/UpdatedTimeListener.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EntityListener;
+
+use App\Entity\UpdatedTimeInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Events;
+
+#[AsDoctrineListener(event: Events::prePersist)]
+#[AsDoctrineListener(event: Events::preUpdate)]
+final class UpdatedTimeListener
+{
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        $entity = $args->getObject();
+        if ($entity instanceof UpdatedTimeInterface) {
+            $entity->updateUpdatedTime();
+        }
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $entity = $args->getObject();
+        if ($entity instanceof UpdatedTimeInterface) {
+            $entity->updateUpdatedTime();
+        }
+    }
+}

--- a/src/Helper/PasswordUpdater.php
+++ b/src/Helper/PasswordUpdater.php
@@ -16,6 +16,5 @@ final readonly class PasswordUpdater
     public function updatePassword(User $user, string $plainPassword): void
     {
         $user->setPassword($this->passwordHasherFactory->getPasswordHasher($user)->hash($plainPassword));
-        $user->updateUpdatedTime();
     }
 }

--- a/src/Traits/UpdatedTimeTrait.php
+++ b/src/Traits/UpdatedTimeTrait.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
+use App\Entity\UpdatedTimeInterface;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @see UpdatedTimeInterface
+ */
 trait UpdatedTimeTrait
 {
     #[ORM\Column]
@@ -22,7 +26,6 @@ trait UpdatedTimeTrait
         $this->updatedTime = $updatedTime;
     }
 
-    #[ORM\PrePersist]
     public function updateUpdatedTime(): void
     {
         $this->setUpdatedTime(new DateTime());

--- a/tests/EntityListener/UpdatedTimeListenerTest.php
+++ b/tests/EntityListener/UpdatedTimeListenerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EntityListener;
+
+use App\Entity\Alias;
+use App\Entity\Domain;
+use App\Entity\ReservedName;
+use App\Entity\User;
+use App\EntityListener\UpdatedTimeListener;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class UpdatedTimeListenerTest extends TestCase
+{
+    private UpdatedTimeListener $listener;
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->listener = new UpdatedTimeListener();
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+    }
+
+    public function testPrePersistUpdatesUpdatedTimeForUser(): void
+    {
+        $user = new User('test@example.org');
+        $oldDate = new DateTime('2020-01-01');
+        $user->setUpdatedTime($oldDate);
+
+        self::assertEquals('2020-01-01', $user->getUpdatedTime()->format('Y-m-d'));
+
+        $args = new PrePersistEventArgs($user, $this->entityManager);
+        $this->listener->prePersist($args);
+
+        self::assertNotEquals('2020-01-01', $user->getUpdatedTime()->format('Y-m-d'));
+        self::assertEquals((new DateTime())->format('Y-m-d'), $user->getUpdatedTime()->format('Y-m-d'));
+    }
+
+    public function testPreUpdateUpdatesUpdatedTimeForUser(): void
+    {
+        $user = new User('test@example.org');
+        $oldDate = new DateTime('2020-01-01');
+        $user->setUpdatedTime($oldDate);
+
+        self::assertEquals('2020-01-01', $user->getUpdatedTime()->format('Y-m-d'));
+
+        $args = $this->createMock(PreUpdateEventArgs::class);
+        $args->method('getObject')->willReturn($user);
+        $this->listener->preUpdate($args);
+
+        self::assertNotEquals('2020-01-01', $user->getUpdatedTime()->format('Y-m-d'));
+        self::assertEquals((new DateTime())->format('Y-m-d'), $user->getUpdatedTime()->format('Y-m-d'));
+    }
+
+    public function testPrePersistUpdatesUpdatedTimeForAlias(): void
+    {
+        $alias = new Alias();
+        $oldDate = new DateTime('2020-01-01');
+        $alias->setUpdatedTime($oldDate);
+
+        $args = new PrePersistEventArgs($alias, $this->entityManager);
+        $this->listener->prePersist($args);
+
+        self::assertEquals((new DateTime())->format('Y-m-d'), $alias->getUpdatedTime()->format('Y-m-d'));
+    }
+
+    public function testPrePersistUpdatesUpdatedTimeForDomain(): void
+    {
+        $domain = new Domain();
+        $oldDate = new DateTime('2020-01-01');
+        $domain->setUpdatedTime($oldDate);
+
+        $args = new PrePersistEventArgs($domain, $this->entityManager);
+        $this->listener->prePersist($args);
+
+        self::assertEquals((new DateTime())->format('Y-m-d'), $domain->getUpdatedTime()->format('Y-m-d'));
+    }
+
+    public function testPrePersistUpdatesUpdatedTimeForReservedName(): void
+    {
+        $reservedName = new ReservedName();
+        $oldDate = new DateTime('2020-01-01');
+        $reservedName->setUpdatedTime($oldDate);
+
+        $args = new PrePersistEventArgs($reservedName, $this->entityManager);
+        $this->listener->prePersist($args);
+
+        self::assertEquals((new DateTime())->format('Y-m-d'), $reservedName->getUpdatedTime()->format('Y-m-d'));
+    }
+
+    public function testPrePersistIgnoresNonUpdatedTimeEntities(): void
+    {
+        $entity = new stdClass();
+
+        $args = new PrePersistEventArgs($entity, $this->entityManager);
+        $this->listener->prePersist($args);
+
+        // No exception thrown, entity is simply ignored
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `UpdatedTimeInterface` and a generic `UpdatedTimeListener` (Doctrine event listener) that automatically sets `updatedTime` on `prePersist` and `preUpdate` for all entities implementing the interface
- All entities using `UpdatedTimeTrait` now implement `UpdatedTimeInterface`: `User`, `Alias`, `Domain`, `ReservedName`
- Remove redundant manual `updateUpdatedTime()` calls from `PasswordUpdater` and `UserAdmin`
- Remove `#[ORM\HasLifecycleCallbacks]` from `Alias` and `Domain` and `#[ORM\PrePersist]` from `UpdatedTimeTrait` (no longer needed)

## Motivation

Previously, `updatedTime` was only updated manually in specific places (`PasswordUpdater`, `UserAdmin`). If a `User` was persisted elsewhere, `updatedTime` would not be updated. This change centralizes the mechanism so that `updatedTime` is automatically set whenever any entity implementing `UpdatedTimeInterface` is persisted or updated via Doctrine — regardless of where in the codebase the save happens.

## Changes

| File | Change |
|------|--------|
| `src/Entity/UpdatedTimeInterface.php` | New interface defining the `updatedTime` contract |
| `src/EntityListener/UpdatedTimeListener.php` | New generic Doctrine listener for `prePersist`/`preUpdate` |
| `src/Traits/UpdatedTimeTrait.php` | Removed `#[ORM\PrePersist]`, added `@see UpdatedTimeInterface` |
| `src/Entity/User.php` | Implements `UpdatedTimeInterface` |
| `src/Entity/Alias.php` | Implements `UpdatedTimeInterface`, removed `#[ORM\HasLifecycleCallbacks]` |
| `src/Entity/Domain.php` | Implements `UpdatedTimeInterface`, removed `#[ORM\HasLifecycleCallbacks]` |
| `src/Entity/ReservedName.php` | Implements `UpdatedTimeInterface` |
| `src/Helper/PasswordUpdater.php` | Removed redundant `updateUpdatedTime()` call |
| `src/Admin/UserAdmin.php` | Removed redundant `updateUpdatedTime()` call |
| `tests/EntityListener/UpdatedTimeListenerTest.php` | New tests (6 test cases) |

Created with OpenCode (Claude Opus 4.6)