### PR TITLE
✨ Add webhook event for user.reset

### DIFF
--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -14,6 +14,7 @@ The following events can trigger webhooks:
 
 - `user.created`: Triggered when a new user is created.
 - `user.deleted`: Triggered when a user is deleted.
+- `user.reset`: Triggered when a user is reset (password, MailCrypt keys, recovery token, and 2FA settings).
 
 ## Configuring Webhooks
 

--- a/features/settings_webhook.feature
+++ b/features/settings_webhook.feature
@@ -36,6 +36,7 @@ Feature: Settings
     And I fill in "webhook_endpoint_secret" with "secret"
     And I check "user.created"
     And I check "user.deleted"
+    And I check "user.reset"
     And I press "Create"
 
     Then I should see "Webhook created successfully"

--- a/src/DataFixtures/LoadWebhookData.php
+++ b/src/DataFixtures/LoadWebhookData.php
@@ -24,7 +24,7 @@ final class LoadWebhookData extends Fixture implements FixtureGroupInterface
             'http://webhook:8080/e6fd49c8-7ecc-4b0a-8af1-a16f508e0f68',
             bin2hex(random_bytes(16))
         );
-        $endpoint->setEvents([WebhookEvent::USER_CREATED->value, WebhookEvent::USER_DELETED->value]);
+        $endpoint->setEvents([WebhookEvent::USER_CREATED->value, WebhookEvent::USER_DELETED->value, WebhookEvent::USER_RESET->value]);
         $endpoint->setEnabled(true);
         $manager->persist($endpoint);
 

--- a/src/Enum/WebhookEvent.php
+++ b/src/Enum/WebhookEvent.php
@@ -8,6 +8,7 @@ enum WebhookEvent: string
 {
     case USER_CREATED = 'user.created';
     case USER_DELETED = 'user.deleted';
+    case USER_RESET = 'user.reset';
 
     public static function all(): array
     {

--- a/src/Event/UserEvent.php
+++ b/src/Event/UserEvent.php
@@ -5,25 +5,21 @@ declare(strict_types=1);
 namespace App\Event;
 
 use App\Entity\User;
-use App\Traits\UserAwareTrait;
 use Symfony\Contracts\EventDispatcher\Event;
 
 final class UserEvent extends Event
 {
-    use UserAwareTrait;
+    public const string USER_CREATED = 'user.created';
+    public const string USER_DELETED = 'user.deleted';
+    public const string USER_RESET = 'user.reset';
+    public const string PASSWORD_CHANGED = 'user.password_changed';
 
-    public const USER_CREATED = 'user.created';
-
-    public const USER_DELETED = 'user.deleted';
-    public const USER_RESTORED = 'user.restored';
-
-    public const PASSWORD_CHANGED = 'user.password_changed';
-
-    /**
-     * Constructor.
-     */
-    public function __construct(User $user)
+    public function __construct(private readonly User $user)
     {
-        $this->user = $user;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
     }
 }

--- a/src/EventListener/WebhookListener.php
+++ b/src/EventListener/WebhookListener.php
@@ -26,12 +26,18 @@ final readonly class WebhookListener implements EventSubscriberInterface
         $this->dispatcher->dispatchUserEvent($event->getUser(), WebhookEvent::USER_DELETED);
     }
 
+    public function onUserReset(UserEvent $event): void
+    {
+        $this->dispatcher->dispatchUserEvent($event->getUser(), WebhookEvent::USER_RESET);
+    }
+
     #[Override]
     public static function getSubscribedEvents(): array
     {
         return [
             UserEvent::USER_CREATED => 'onUserCreated',
             UserEvent::USER_DELETED => 'onUserDeleted',
+            UserEvent::USER_RESET => 'onUserReset',
         ];
     }
 }

--- a/src/Service/UserResetService.php
+++ b/src/Service/UserResetService.php
@@ -61,7 +61,7 @@ final readonly class UserResetService
         $this->manager->flush();
 
         if (!$user->isDeleted()) {
-            $this->eventDispatcher->dispatch(new UserEvent($user), UserEvent::USER_RESTORED);
+            $this->eventDispatcher->dispatch(new UserEvent($user), UserEvent::USER_RESET);
         }
 
         return $recoveryToken;

--- a/templates/Settings/Webhook/Delivery/index.html.twig
+++ b/templates/Settings/Webhook/Delivery/index.html.twig
@@ -30,6 +30,7 @@
                                 <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status}|filter(v => v)) }}"{% if eventType == '' %} selected{% endif %}>{{ 'settings.webhook.deliveries.filter.all'|trans }}</option>
                                 <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.created'}|filter(v => v)) }}"{% if eventType == 'user.created' %} selected{% endif %}>user.created</option>
                                 <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.deleted'}|filter(v => v)) }}"{% if eventType == 'user.deleted' %} selected{% endif %}>user.deleted</option>
+                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.reset'}|filter(v => v)) }}"{% if eventType == 'user.reset' %} selected{% endif %}>user.reset</option>
                             </select>
                         </div>
                         <div class="flex items-center gap-2">

--- a/tests/EventListener/WebhookListenerTest.php
+++ b/tests/EventListener/WebhookListenerTest.php
@@ -30,4 +30,24 @@ class WebhookListenerTest extends TestCase
         $listener = new WebhookListener($dispatcher);
         $listener->onUserDeleted(new UserEvent($user));
     }
+
+    public function testOnUserReset(): void
+    {
+        $user = new User('test@example.org');
+        $dispatcher = $this->createMock(WebhookDispatcher::class);
+        $dispatcher->expects($this->once())->method('dispatchUserEvent')->with($user, WebhookEvent::USER_RESET);
+        $listener = new WebhookListener($dispatcher);
+        $listener->onUserReset(new UserEvent($user));
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        $events = WebhookListener::getSubscribedEvents();
+        self::assertArrayHasKey(UserEvent::USER_CREATED, $events);
+        self::assertArrayHasKey(UserEvent::USER_DELETED, $events);
+        self::assertArrayHasKey(UserEvent::USER_RESET, $events);
+        self::assertEquals('onUserCreated', $events[UserEvent::USER_CREATED]);
+        self::assertEquals('onUserDeleted', $events[UserEvent::USER_DELETED]);
+        self::assertEquals('onUserReset', $events[UserEvent::USER_RESET]);
+    }
 }

--- a/tests/Service/UserResetServiceTest.php
+++ b/tests/Service/UserResetServiceTest.php
@@ -157,7 +157,7 @@ class UserResetServiceTest extends TestCase
             ->method('dispatch')
             ->with(
                 $this->callback(static fn ($event) => $event instanceof UserEvent && $event->getUser() === $user),
-                UserEvent::USER_RESTORED
+                UserEvent::USER_RESET
             );
 
         $service->resetUser($user, 'password123');


### PR DESCRIPTION
## Summary

- Add new `user.reset` webhook event, dispatched when a user is reset via `UserResetService` (password, MailCrypt keys, recovery token, and 2FA settings)
- Follows the same pattern as the existing `user.created` and `user.deleted` webhook events
- Replaces the unused `USER_RESTORED` Symfony event constant with `USER_RESET`

## Changes

| File | Change |
|---|---|
| `src/Event/UserEvent.php` | New constant `USER_RESET = 'user.reset'`, removed unused `USER_RESTORED` |
| `src/Enum/WebhookEvent.php` | New enum case `USER_RESET` |
| `src/EventListener/WebhookListener.php` | New `onUserReset()` method and event subscription |
| `src/Service/UserResetService.php` | Dispatch `USER_RESET` instead of `USER_RESTORED` |
| `templates/Settings/Webhook/Delivery/index.html.twig` | New filter option `user.reset` in dropdown |
| `docs/features/webhooks.md` | Document `user.reset` event |
| `tests/EventListener/WebhookListenerTest.php` | New test `testOnUserReset()` |
| `tests/Service/UserResetServiceTest.php` | Updated event constant reference |
| `features/settings_webhook.feature` | Check `user.reset` checkbox in create scenario |
| `src/DataFixtures/LoadWebhookData.php` | Include `USER_RESET` in fixture endpoint events |

---

> This PR was generated by OpenCode.