### PR TITLE
⚡ Use lightweight queries and repository methods for Postfix lookups

### DIFF
--- a/src/Repository/DomainRepository.php
+++ b/src/Repository/DomainRepository.php
@@ -5,16 +5,33 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Domain;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
- * @extends EntityRepository<Domain>
+ * @extends ServiceEntityRepository<Domain>
  */
-final class DomainRepository extends EntityRepository
+final class DomainRepository extends ServiceEntityRepository
 {
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Domain::class);
+    }
+
     public function findByName(string $name): ?Domain
     {
         return $this->findOneBy(['name' => $name]);
+    }
+
+    public function existsByName(string $name): bool
+    {
+        return (bool) $this->createQueryBuilder('d')
+            ->select('1')
+            ->where('d.name = :name')
+            ->setParameter('name', $name)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 
     public function getDefaultDomain(): ?Domain


### PR DESCRIPTION
## Summary

- Replace full entity hydration with efficient scalar/existence queries in Postfix API endpoints
- Add dedicated repository methods for the specific query patterns used by PostfixController
- Refactor controller to use typed repositories instead of generic `EntityManagerInterface` calls

## Changes

- **`src/Repository/DomainRepository.php`**: Add `existsByName()` — uses `SELECT 1` instead of loading the full Domain entity
- **`src/Repository/UserRepository.php`**: Add `existsByEmail()` — uses `SELECT 1` with `deleted = false` filter instead of loading the full User entity (which includes password hashes, MailCrypt keys, TOTP secrets, etc.)
- **`src/Repository/AliasRepository.php`**: Add `findDestinationsBySource()` — selects only the `destination` column as scalars instead of hydrating full Alias entities
- **`src/Controller/PostfixController.php`**: Use the new repository methods, resolving repositories via `EntityManagerInterface::getRepository()` in the constructor

## Why

The `getMailbox` and `getDomain` endpoints previously loaded entire entities just to check if they exist. The User entity is particularly large with many columns from traits (password, MailCrypt keys, TOTP secrets, recovery data, etc.). Using `SELECT 1` queries avoids transferring and hydrating all this unnecessary data.

Similarly, `getAliasUsers` loaded full Alias entities just to extract the `destination` string. The new `findDestinationsBySource()` method returns only the destination values as a flat array.

---

> This PR was generated by OpenCode