### PR TITLE
♻️ Clean up entity constructors: remove redundant defaults and fix OpenPgpKeys init

### DIFF
--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -49,11 +49,7 @@ class Alias implements SoftDeletableInterface, UpdatedTimeInterface, Stringable
      */
     public function __construct()
     {
-        $this->deleted = false;
-        $this->random = false;
-        $currentDateTime = new DateTimeImmutable();
-        $this->creationTime = $currentDateTime;
-        $this->updatedTime = $currentDateTime;
+        $this->creationTime = new DateTimeImmutable();
     }
 
     public function getSource(): ?string

--- a/src/Entity/Domain.php
+++ b/src/Entity/Domain.php
@@ -25,9 +25,7 @@ class Domain implements UpdatedTimeInterface, Stringable
 
     public function __construct()
     {
-        $currentDateTime = new DateTimeImmutable();
-        $this->creationTime = $currentDateTime;
-        $this->updatedTime = $currentDateTime;
+        $this->creationTime = new DateTimeImmutable();
     }
 
     #[Override]

--- a/src/Entity/ReservedName.php
+++ b/src/Entity/ReservedName.php
@@ -28,9 +28,7 @@ class ReservedName implements UpdatedTimeInterface, Stringable
      */
     public function __construct()
     {
-        $currentDateTime = new DateTimeImmutable();
-        $this->creationTime = $currentDateTime;
-        $this->updatedTime = $currentDateTime;
+        $this->creationTime = new DateTimeImmutable();
     }
 
     #[Override]

--- a/src/Entity/Setting.php
+++ b/src/Entity/Setting.php
@@ -36,7 +36,6 @@ class Setting implements UpdatedTimeInterface
         $this->name = $name;
         $this->value = $value;
         $this->creationTime = new DateTimeImmutable();
-        $this->updatedTime = new DateTimeImmutable();
     }
 
     public function getId(): ?int

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -29,6 +29,7 @@ use App\Traits\TwofactorBackupCodeTrait;
 use App\Traits\TwofactorTrait;
 use App\Traits\UpdatedTimeTrait;
 use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Index;
@@ -87,12 +88,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
     public function __construct(string $email)
     {
         $this->email = $email;
-        $this->deleted = false;
         $this->passwordVersion = self::CURRENT_PASSWORD_VERSION;
         $this->passwordChangeRequired = false;
-        $currentDateTime = new DateTimeImmutable();
-        $this->creationTime = $currentDateTime;
-        $this->updatedTime = $currentDateTime;
+        $this->creationTime = new DateTimeImmutable();
+        $this->openPgpKeys = new ArrayCollection();
     }
 
     #[Override]

--- a/src/Entity/WebhookEndpoint.php
+++ b/src/Entity/WebhookEndpoint.php
@@ -39,7 +39,6 @@ class WebhookEndpoint implements UpdatedTimeInterface
         $this->url = $url;
         $this->secret = $secret;
         $this->creationTime = new DateTimeImmutable();
-        $this->updatedTime = new DateTimeImmutable();
     }
 
     public function getId(): ?int

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -82,11 +82,10 @@ class UserTest extends TestCase
         self::assertEquals($user->getCreationTime()->format('Y-m-d'), $today->format('Y-m-d'));
     }
 
-    public function testHasUpdatedTimeSet(): void
+    public function testUpdatedTimeIsNullBeforePersist(): void
     {
         $user = new User('test@example.org');
-        $today = new DateTimeImmutable();
-        self::assertEquals($user->getUpdatedTime()->format('Y-m-d'), $today->format('Y-m-d'));
+        self::assertNull($user->getUpdatedTime());
     }
 
     public function testTotp(): void


### PR DESCRIPTION
## Summary

- Remove redundant property assignments in entity constructors that duplicate inline trait defaults (`$deleted=false`, `$random=false`)
- Remove `$updatedTime` assignments from all 6 entities implementing `UpdatedTimeInterface`, since `UpdatedTimeListener` already handles this centrally on `prePersist`
- Fix potential bug: initialize `$openPgpKeys` as `ArrayCollection` in `User` constructor, because the `OpenPgpKeyAwareTrait` constructor is overridden by User's own constructor and the collection would remain uninitialized

## Affected Entities

| Entity | Changes |
|---|---|
| `User` | Remove `$deleted=false`, `$updatedTime`; add `$openPgpKeys` init |
| `Alias` | Remove `$deleted=false`, `$random=false`, `$updatedTime` |
| `Domain` | Remove `$updatedTime` |
| `ReservedName` | Remove `$updatedTime` |
| `Setting` | Remove `$updatedTime` |
| `WebhookEndpoint` | Remove `$updatedTime` |

## Test Changes

- `UserTest::testHasUpdatedTimeSet` renamed to `testUpdatedTimeIsNullBeforePersist` — asserts that `updatedTime` is `null` after construction (since the listener sets it on persist)

---

*This PR was generated by OpenCode*