### PR TITLE
🐛 Restore PHPUnit coverage and test result reporting for SonarCloud

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: PHPUnit
         run: |
-          bin/phpunit
+          bin/phpunit --coverage-clover build/clover-phpunit.xml --log-junit build/result-phpunit.xml
 
       - name: Behat
         run: |


### PR DESCRIPTION
## Summary

- Restores PHPUnit coverage (`build/clover-phpunit.xml`) and test result (`build/result-phpunit.xml`) reporting for SonarCloud, which broke during the PHPUnit 9-to-12 upgrade (#1021)
- Adds `--coverage-clover` and `--log-junit` CLI flags to the PHPUnit CI step, replacing the removed `<coverage>` and `<logging>` XML config elements that no longer exist in PHPUnit 12

## Context

The PHPUnit 12 upgrade removed the `<coverage>` and `<logging>` XML configuration blocks from `phpunit.xml` because these elements were dropped in PHPUnit 12. However, the CI workflow was not updated to pass the equivalent CLI flags, so `build/clover-phpunit.xml` and `build/result-phpunit.xml` were no longer generated. SonarCloud still expects these files (configured in `sonar-project.properties`).

---

> This PR was generated by OpenCode.