### PR TITLE
✅ Add unit tests for 16 previously uncovered classes

### DIFF
--- a/tests/Block/StatisticsBlockServiceTest.php
+++ b/tests/Block/StatisticsBlockServiceTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Block;
+
+use App\Block\StatisticsBlockService;
+use App\Entity\User;
+use App\Entity\Voucher;
+use App\Repository\UserRepository;
+use App\Repository\VoucherRepository;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
+
+class StatisticsBlockServiceTest extends TestCase
+{
+    public function testExecuteRendersTemplateWithStatistics(): void
+    {
+        $userRepository = $this->createStub(UserRepository::class);
+        $userRepository->method('findUsersSince')->willReturn([new User('a@b.org'), new User('c@d.org')]);
+        $userRepository->method('count')->willReturn(100);
+
+        $voucherRepository = $this->createStub(VoucherRepository::class);
+        $voucherRepository->method('count')->willReturn(50);
+        $voucherRepository->method('countRedeemedVouchers')->willReturn(25);
+
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $manager->method('getRepository')->willReturnCallback(
+            static function (string $class) use ($userRepository, $voucherRepository) {
+                return match ($class) {
+                    User::class => $userRepository,
+                    Voucher::class => $voucherRepository,
+                };
+            }
+        );
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with(
+                'Block/block_statistics.html.twig',
+                $this->callback(static function (array $context) {
+                    return $context['users_since'] === 2
+                        && $context['users_count'] === 100
+                        && $context['vouchers_count'] === 50
+                        && $context['vouchers_redeemed'] === 25
+                        && $context['vouchers_ratio'] === '50.00%';
+                })
+            )
+            ->willReturn('<div>rendered</div>');
+
+        $block = $this->createStub(BlockInterface::class);
+
+        $blockContext = $this->createStub(BlockContextInterface::class);
+        $blockContext->method('getSettings')->willReturn(['url' => false, 'title' => 'Statistics']);
+        $blockContext->method('getTemplate')->willReturn('Block/block_statistics.html.twig');
+        $blockContext->method('getBlock')->willReturn($block);
+
+        $response = new Response();
+
+        $service = new StatisticsBlockService($twig, $manager);
+        $result = $service->execute($blockContext, $response);
+
+        self::assertSame('<div>rendered</div>', $result->getContent());
+    }
+
+    public function testExecuteWithZeroVouchersShowsZeroPercent(): void
+    {
+        $userRepository = $this->createStub(UserRepository::class);
+        $userRepository->method('findUsersSince')->willReturn([]);
+        $userRepository->method('count')->willReturn(0);
+
+        $voucherRepository = $this->createStub(VoucherRepository::class);
+        $voucherRepository->method('count')->willReturn(0);
+        $voucherRepository->method('countRedeemedVouchers')->willReturn(0);
+
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $manager->method('getRepository')->willReturnCallback(
+            static function (string $class) use ($userRepository, $voucherRepository) {
+                return match ($class) {
+                    User::class => $userRepository,
+                    Voucher::class => $voucherRepository,
+                };
+            }
+        );
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->anything(),
+                $this->callback(static function (array $context) {
+                    return $context['users_since'] === 0
+                        && $context['vouchers_ratio'] === '0%';
+                })
+            )
+            ->willReturn('');
+
+        $block = $this->createStub(BlockInterface::class);
+
+        $blockContext = $this->createStub(BlockContextInterface::class);
+        $blockContext->method('getSettings')->willReturn([]);
+        $blockContext->method('getTemplate')->willReturn('Block/block_statistics.html.twig');
+        $blockContext->method('getBlock')->willReturn($block);
+
+        $response = new Response();
+        $service = new StatisticsBlockService($twig, $manager);
+        $service->execute($blockContext, $response);
+    }
+
+    public function testConfigureSettingsSetsDefaults(): void
+    {
+        $twig = $this->createStub(Environment::class);
+        $manager = $this->createStub(EntityManagerInterface::class);
+
+        $service = new StatisticsBlockService($twig, $manager);
+
+        $resolver = new OptionsResolver();
+        $service->configureSettings($resolver);
+
+        $resolved = $resolver->resolve([]);
+        self::assertFalse($resolved['url']);
+        self::assertSame('Statistics', $resolved['title']);
+        self::assertSame('Block/block_statistics.html.twig', $resolved['template']);
+    }
+
+    public function testGetCacheKeysReturnsBlockIdAndUpdatedAt(): void
+    {
+        $twig = $this->createStub(Environment::class);
+        $manager = $this->createStub(EntityManagerInterface::class);
+
+        $updatedAt = new DateTime('2026-01-15 10:00:00');
+
+        $block = $this->createStub(BlockInterface::class);
+        $block->method('getId')->willReturn(42);
+        $block->method('getUpdatedAt')->willReturn($updatedAt);
+
+        $service = new StatisticsBlockService($twig, $manager);
+        $keys = $service->getCacheKeys($block);
+
+        self::assertSame(42, $keys['block_id']);
+        self::assertSame($updatedAt->format('U'), $keys['updated_at']);
+    }
+
+    public function testGetCacheKeysUsesTimeWhenUpdatedAtIsNull(): void
+    {
+        $twig = $this->createStub(Environment::class);
+        $manager = $this->createStub(EntityManagerInterface::class);
+
+        $block = $this->createStub(BlockInterface::class);
+        $block->method('getId')->willReturn(1);
+        $block->method('getUpdatedAt')->willReturn(null);
+
+        $service = new StatisticsBlockService($twig, $manager);
+        $keys = $service->getCacheKeys($block);
+
+        self::assertSame(1, $keys['block_id']);
+        self::assertIsInt($keys['updated_at']);
+    }
+
+    public function testLoadDoesNothing(): void
+    {
+        $twig = $this->createStub(Environment::class);
+        $manager = $this->createStub(EntityManagerInterface::class);
+
+        $block = $this->createStub(BlockInterface::class);
+
+        $service = new StatisticsBlockService($twig, $manager);
+        // load() is a no-op, just verify it doesn't throw
+        $service->load($block);
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Command/ReportWeeklyCommandTest.php
+++ b/tests/Command/ReportWeeklyCommandTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\ReportWeeklyCommand;
+use App\Handler\UserRegistrationInfoHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ReportWeeklyCommandTest extends TestCase
+{
+    public function testExecuteCallsSendReport(): void
+    {
+        $handler = $this->createMock(UserRegistrationInfoHandler::class);
+        $handler->expects($this->once())->method('sendReport');
+
+        $command = new ReportWeeklyCommand($handler);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+    }
+}

--- a/tests/EventListener/AliasCreationListenerTest.php
+++ b/tests/EventListener/AliasCreationListenerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventListener;
+
+use App\Entity\Alias;
+use App\Entity\User;
+use App\Event\AliasCreatedEvent;
+use App\EventListener\AliasCreationListener;
+use App\Sender\AliasCreatedMessageSender;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class AliasCreationListenerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = AliasCreationListener::getSubscribedEvents();
+
+        self::assertArrayHasKey(AliasCreatedEvent::NAME, $events);
+        self::assertEquals('onAliasCreated', $events[AliasCreatedEvent::NAME]);
+    }
+
+    public function testOnAliasCreatedSendsMessageWithSessionLocale(): void
+    {
+        $user = new User('user@example.org');
+        $alias = new Alias();
+        $alias->setSource('alias@example.org');
+        $alias->setUser($user);
+
+        $session = $this->createStub(SessionInterface::class);
+        $session->method('get')->with('_locale', 'en')->willReturn('de');
+
+        $request = $this->createStub(Request::class);
+        $request->method('getSession')->willReturn($session);
+
+        $requestStack = $this->createStub(RequestStack::class);
+        $requestStack->method('getSession')->willReturn($session);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
+
+        $sender = $this->createMock(AliasCreatedMessageSender::class);
+        $sender->expects($this->once())
+            ->method('send')
+            ->with($user, $alias, 'de');
+
+        $listener = new AliasCreationListener($requestStack, $sender, 'en');
+        $listener->onAliasCreated(new AliasCreatedEvent($alias));
+    }
+
+    public function testOnAliasCreatedThrowsExceptionWhenUserIsNull(): void
+    {
+        $alias = new Alias();
+        $alias->setSource('alias@example.org');
+        // User is null
+
+        $requestStack = $this->createStub(RequestStack::class);
+        $sender = $this->createStub(AliasCreatedMessageSender::class);
+
+        $listener = new AliasCreationListener($requestStack, $sender, 'en');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User should not be null');
+        $listener->onAliasCreated(new AliasCreatedEvent($alias));
+    }
+}

--- a/tests/EventListener/CompromisedPasswordListenerTest.php
+++ b/tests/EventListener/CompromisedPasswordListenerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventListener;
+
+use App\Entity\User;
+use App\Event\LoginEvent;
+use App\EventListener\CompromisedPasswordListener;
+use App\Service\PasswordCompromisedService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+class CompromisedPasswordListenerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = CompromisedPasswordListener::getSubscribedEvents();
+
+        self::assertArrayHasKey(SecurityEvents::INTERACTIVE_LOGIN, $events);
+        self::assertEquals('onSecurityInteractiveLogin', $events[SecurityEvents::INTERACTIVE_LOGIN]);
+        self::assertArrayHasKey(LoginEvent::NAME, $events);
+        self::assertEquals('onLogin', $events[LoginEvent::NAME]);
+    }
+
+    public function testOnSecurityInteractiveLoginCallsCheckAndNotify(): void
+    {
+        $user = new User('user@example.org');
+        $password = 'secret123';
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        $request = new Request(request: ['_password' => $password]);
+        $request->setLocale('de');
+
+        $event = new InteractiveLoginEvent($request, $token);
+
+        $service = $this->createMock(PasswordCompromisedService::class);
+        $service->expects($this->once())
+            ->method('checkAndNotify')
+            ->with($user, $password, 'de');
+
+        $listener = new CompromisedPasswordListener($service, $this->createStub(RequestStack::class));
+        $listener->onSecurityInteractiveLogin($event);
+    }
+
+    public function testOnSecurityInteractiveLoginSkipsNonUserInstance(): void
+    {
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('getUser')->willReturn(null);
+
+        $request = new Request();
+        $event = new InteractiveLoginEvent($request, $token);
+
+        $service = $this->createMock(PasswordCompromisedService::class);
+        $service->expects($this->never())->method('checkAndNotify');
+
+        $listener = new CompromisedPasswordListener($service, $this->createStub(RequestStack::class));
+        $listener->onSecurityInteractiveLogin($event);
+    }
+
+    public function testOnSecurityInteractiveLoginSkipsWhenPasswordIsNull(): void
+    {
+        $user = new User('user@example.org');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        $request = new Request();
+        $event = new InteractiveLoginEvent($request, $token);
+
+        $service = $this->createMock(PasswordCompromisedService::class);
+        $service->expects($this->never())->method('checkAndNotify');
+
+        $listener = new CompromisedPasswordListener($service, $this->createStub(RequestStack::class));
+        $listener->onSecurityInteractiveLogin($event);
+    }
+
+    public function testOnLoginCallsCheckAndNotify(): void
+    {
+        $user = new User('user@example.org');
+        $password = 'secret123';
+
+        $request = $this->createStub(Request::class);
+        $request->method('getLocale')->willReturn('fr');
+
+        $requestStack = $this->createStub(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
+
+        $event = new LoginEvent($user, $password);
+
+        $service = $this->createMock(PasswordCompromisedService::class);
+        $service->expects($this->once())
+            ->method('checkAndNotify')
+            ->with($user, $password, 'fr');
+
+        $listener = new CompromisedPasswordListener($service, $requestStack);
+        $listener->onLogin($event);
+    }
+
+    public function testOnLoginUsesDefaultLocaleWhenNoRequest(): void
+    {
+        $user = new User('user@example.org');
+        $password = 'secret123';
+        $event = new LoginEvent($user, $password);
+
+        $requestStack = $this->createStub(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn(null);
+
+        $service = $this->createMock(PasswordCompromisedService::class);
+        $service->expects($this->once())
+            ->method('checkAndNotify')
+            ->with($user, $password, 'en');
+
+        $listener = new CompromisedPasswordListener($service, $requestStack, 'en');
+        $listener->onLogin($event);
+    }
+}

--- a/tests/EventListener/DomainCreationListenerTest.php
+++ b/tests/EventListener/DomainCreationListenerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventListener;
+
+use App\Entity\Alias;
+use App\Entity\Domain;
+use App\Event\DomainCreatedEvent;
+use App\EventListener\DomainCreationListener;
+use App\Handler\WkdHandler;
+use App\Repository\DomainRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class DomainCreationListenerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = DomainCreationListener::getSubscribedEvents();
+
+        self::assertArrayHasKey(DomainCreatedEvent::NAME, $events);
+        self::assertEquals('onDomainCreated', $events[DomainCreatedEvent::NAME]);
+    }
+
+    public function testOnDomainCreatedCreatesPostmasterAliasForNonDefaultDomain(): void
+    {
+        $defaultDomain = new Domain();
+        $defaultDomain->setName('default.org');
+
+        $newDomain = new Domain();
+        $newDomain->setName('new.org');
+
+        $repository = $this->createStub(DomainRepository::class);
+        $repository->method('getDefaultDomain')->willReturn($defaultDomain);
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->method('getRepository')->willReturn($repository);
+        $manager->expects($this->once())
+            ->method('persist')
+            ->with($this->callback(static function ($alias) {
+                return $alias instanceof Alias
+                    && $alias->getSource() === 'postmaster@new.org'
+                    && $alias->getDestination() === 'postmaster@default.org';
+            }));
+        $manager->expects($this->once())->method('flush');
+
+        $wkdHandler = $this->createMock(WkdHandler::class);
+        $wkdHandler->expects($this->once())
+            ->method('getDomainWkdPath')
+            ->with('new.org');
+
+        $listener = new DomainCreationListener($manager, $wkdHandler);
+        $listener->onDomainCreated(new DomainCreatedEvent($newDomain));
+    }
+
+    public function testOnDomainCreatedSkipsPostmasterAliasForDefaultDomain(): void
+    {
+        $defaultDomain = new Domain();
+        $defaultDomain->setName('default.org');
+
+        $repository = $this->createStub(DomainRepository::class);
+        $repository->method('getDefaultDomain')->willReturn($defaultDomain);
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->method('getRepository')->willReturn($repository);
+        $manager->expects($this->never())->method('persist');
+        $manager->expects($this->never())->method('flush');
+
+        $wkdHandler = $this->createMock(WkdHandler::class);
+        $wkdHandler->expects($this->once())
+            ->method('getDomainWkdPath')
+            ->with('default.org');
+
+        $listener = new DomainCreationListener($manager, $wkdHandler);
+        $listener->onDomainCreated(new DomainCreatedEvent($defaultDomain));
+    }
+}

--- a/tests/EventListener/LogoutListenerTest.php
+++ b/tests/EventListener/LogoutListenerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventListener;
+
+use App\EventListener\LogoutListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+class LogoutListenerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = LogoutListener::getSubscribedEvents();
+
+        self::assertArrayHasKey(LogoutEvent::class, $events);
+        self::assertEquals('onLogoutSuccess', $events[LogoutEvent::class]);
+    }
+
+    public function testOnLogoutSuccessAddsFlashMessage(): void
+    {
+        $flashBag = $this->createMock(FlashBagInterface::class);
+        $flashBag->expects($this->once())
+            ->method('add')
+            ->with('success', 'flashes.logout-successful');
+
+        $session = $this->createStub(Session::class);
+        $session->method('getFlashBag')->willReturn($flashBag);
+
+        $request = $this->createStub(Request::class);
+        $request->method('getSession')->willReturn($session);
+
+        $event = new LogoutEvent($request, null);
+
+        $listener = new LogoutListener();
+        $listener->onLogoutSuccess($event);
+    }
+}

--- a/tests/EventListener/RandomAliasCreationListenerTest.php
+++ b/tests/EventListener/RandomAliasCreationListenerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventListener;
+
+use App\Entity\Alias;
+use App\Entity\Domain;
+use App\Event\RandomAliasCreatedEvent;
+use App\EventListener\RandomAliasCreationListener;
+use App\Repository\AliasRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class RandomAliasCreationListenerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = RandomAliasCreationListener::getSubscribedEvents();
+
+        self::assertArrayHasKey(RandomAliasCreatedEvent::NAME, $events);
+        self::assertEquals('onRandomAliasCreated', $events[RandomAliasCreatedEvent::NAME]);
+    }
+
+    public function testOnRandomAliasCreatedDoesNothingWhenNoCollision(): void
+    {
+        $alias = new Alias();
+        $alias->setSource('random123@example.org');
+
+        $repository = $this->createStub(AliasRepository::class);
+        $repository->method('findOneBySource')->willReturn(null);
+
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $manager->method('getRepository')->willReturn($repository);
+
+        $listener = new RandomAliasCreationListener($manager);
+        $listener->onRandomAliasCreated(new RandomAliasCreatedEvent($alias));
+
+        self::assertSame('random123@example.org', $alias->getSource());
+    }
+
+    public function testOnRandomAliasCreatedRegeneratesSourceOnCollision(): void
+    {
+        $domain = new Domain();
+        $domain->setName('example.org');
+
+        $alias = new Alias();
+        $alias->setSource('collision@example.org');
+        $alias->setDomain($domain);
+
+        $existingAlias = new Alias();
+        $callCount = 0;
+
+        $repository = $this->createStub(AliasRepository::class);
+        $repository->method('findOneBySource')->willReturnCallback(
+            static function () use (&$callCount, $existingAlias) {
+                ++$callCount;
+
+                // First call returns existing alias (collision), second returns null (no collision)
+                return $callCount === 1 ? $existingAlias : null;
+            }
+        );
+
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $manager->method('getRepository')->willReturn($repository);
+
+        $listener = new RandomAliasCreationListener($manager);
+        $listener->onRandomAliasCreated(new RandomAliasCreatedEvent($alias));
+
+        // Source should have been regenerated
+        self::assertNotSame('collision@example.org', $alias->getSource());
+        self::assertStringEndsWith('@example.org', $alias->getSource());
+    }
+}

--- a/tests/EventListener/RecoveryProcessListenerTest.php
+++ b/tests/EventListener/RecoveryProcessListenerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventListener;
+
+use App\Entity\User;
+use App\Event\UserEvent;
+use App\EventListener\RecoveryProcessListener;
+use App\Sender\RecoveryProcessMessageSender;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class RecoveryProcessListenerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = RecoveryProcessListener::getSubscribedEvents();
+
+        self::assertArrayHasKey(UserEvent::RECOVERY_PROCESS_STARTED, $events);
+        self::assertEquals('onRecoveryProcessStarted', $events[UserEvent::RECOVERY_PROCESS_STARTED]);
+    }
+
+    public function testOnRecoveryProcessStartedSendsMessageWithSessionLocale(): void
+    {
+        $user = new User('user@example.org');
+
+        $session = $this->createStub(SessionInterface::class);
+        $session->method('get')->with('_locale', 'en')->willReturn('fr');
+
+        $request = $this->createStub(Request::class);
+        $request->method('getSession')->willReturn($session);
+
+        $requestStack = $this->createStub(RequestStack::class);
+        $requestStack->method('getSession')->willReturn($session);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
+
+        $sender = $this->createMock(RecoveryProcessMessageSender::class);
+        $sender->expects($this->once())
+            ->method('send')
+            ->with($user, 'fr');
+
+        $listener = new RecoveryProcessListener($requestStack, $sender, 'en');
+        $listener->onRecoveryProcessStarted(new UserEvent($user));
+    }
+
+    public function testOnRecoveryProcessStartedUsesDefaultLocaleWhenSessionReturnsNull(): void
+    {
+        $user = new User('user@example.org');
+
+        $session = $this->createStub(SessionInterface::class);
+        $session->method('get')->with('_locale', 'en')->willReturn('en');
+
+        $request = $this->createStub(Request::class);
+        $request->method('getSession')->willReturn($session);
+
+        $requestStack = $this->createStub(RequestStack::class);
+        $requestStack->method('getSession')->willReturn($session);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
+
+        $sender = $this->createMock(RecoveryProcessMessageSender::class);
+        $sender->expects($this->once())
+            ->method('send')
+            ->with($user, 'en');
+
+        $listener = new RecoveryProcessListener($requestStack, $sender, 'en');
+        $listener->onRecoveryProcessStarted(new UserEvent($user));
+    }
+}

--- a/tests/EventListener/TwigGlobalListenerTest.php
+++ b/tests/EventListener/TwigGlobalListenerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventListener;
+
+use App\Entity\Domain;
+use App\EventListener\TwigGlobalListener;
+use App\Repository\DomainRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Twig\Environment;
+
+class TwigGlobalListenerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = TwigGlobalListener::getSubscribedEvents();
+
+        self::assertArrayHasKey(KernelEvents::CONTROLLER, $events);
+        self::assertEquals('injectGlobalVariables', $events[KernelEvents::CONTROLLER]);
+    }
+
+    public function testInjectGlobalVariablesSetsDomainName(): void
+    {
+        $domain = new Domain();
+        $domain->setName('example.org');
+
+        $repository = $this->createStub(DomainRepository::class);
+        $repository->method('getDefaultDomain')->willReturn($domain);
+
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $manager->method('getRepository')->willReturn($repository);
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('addGlobal')
+            ->with('domain', 'example.org');
+
+        $event = new ControllerEvent(
+            $this->createStub(HttpKernelInterface::class),
+            static function (): void {},
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $listener = new TwigGlobalListener($twig, $manager);
+        $listener->injectGlobalVariables($event);
+    }
+
+    public function testInjectGlobalVariablesFallsBackToDefaultDomain(): void
+    {
+        $repository = $this->createStub(DomainRepository::class);
+        $repository->method('getDefaultDomain')->willReturn(null);
+
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $manager->method('getRepository')->willReturn($repository);
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('addGlobal')
+            ->with('domain', 'defaultdomain');
+
+        $event = new ControllerEvent(
+            $this->createStub(HttpKernelInterface::class),
+            static function (): void {},
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $listener = new TwigGlobalListener($twig, $manager);
+        $listener->injectGlobalVariables($event);
+    }
+}

--- a/tests/Helper/TotpBackupCodeGeneratorTest.php
+++ b/tests/Helper/TotpBackupCodeGeneratorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Helper;
+
+use App\Helper\TotpBackupCodeGenerator;
+use PHPUnit\Framework\TestCase;
+
+class TotpBackupCodeGeneratorTest extends TestCase
+{
+    public function testGenerateReturnsCorrectCount(): void
+    {
+        $generator = new TotpBackupCodeGenerator();
+        $codes = $generator->generate(6);
+
+        self::assertCount(6, $codes);
+    }
+
+    public function testGenerateReturnsCustomCount(): void
+    {
+        $generator = new TotpBackupCodeGenerator();
+        $codes = $generator->generate(3);
+
+        self::assertCount(3, $codes);
+    }
+
+    public function testGenerateReturnsSixDigitCodes(): void
+    {
+        $generator = new TotpBackupCodeGenerator();
+        $codes = $generator->generate(10);
+
+        foreach ($codes as $code) {
+            self::assertMatchesRegularExpression('/^\d{6}$/', $code);
+        }
+    }
+
+    public function testGenerateReturnsStrings(): void
+    {
+        $generator = new TotpBackupCodeGenerator();
+        $codes = $generator->generate();
+
+        foreach ($codes as $code) {
+            self::assertIsString($code);
+        }
+    }
+
+    public function testGenerateDefaultsToSixCodes(): void
+    {
+        $generator = new TotpBackupCodeGenerator();
+        $codes = $generator->generate();
+
+        self::assertCount(6, $codes);
+    }
+
+    public function testGenerateReturnsUniqueishCodes(): void
+    {
+        $generator = new TotpBackupCodeGenerator();
+        // Generate enough codes that duplicates are extremely unlikely
+        $codes = $generator->generate(6);
+
+        // While not guaranteed, 6 codes from a range of 100000-999999 should be unique
+        self::assertSame(count($codes), count(array_unique($codes)));
+    }
+}

--- a/tests/Sender/AliasCreatedMessageSenderTest.php
+++ b/tests/Sender/AliasCreatedMessageSenderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Sender;
+
+use App\Builder\AliasCreatedMessageBuilder;
+use App\Entity\Alias;
+use App\Entity\User;
+use App\Handler\MailHandler;
+use App\Sender\AliasCreatedMessageSender;
+use PHPUnit\Framework\TestCase;
+
+class AliasCreatedMessageSenderTest extends TestCase
+{
+    public function testSendCallsBuilderAndMailHandler(): void
+    {
+        $user = new User('user@example.org');
+
+        $alias = new Alias();
+        $alias->setSource('alias@example.org');
+
+        $builder = $this->createMock(AliasCreatedMessageBuilder::class);
+        $builder->expects($this->once())
+            ->method('buildBody')
+            ->with('en', 'user@example.org', 'alias@example.org')
+            ->willReturn('Alias body');
+        $builder->expects($this->once())
+            ->method('buildSubject')
+            ->with('en', 'user@example.org')
+            ->willReturn('Alias subject');
+
+        $handler = $this->createMock(MailHandler::class);
+        $handler->expects($this->once())
+            ->method('send')
+            ->with('user@example.org', 'Alias body', 'Alias subject');
+
+        $sender = new AliasCreatedMessageSender($handler, $builder);
+        $sender->send($user, $alias, 'en');
+    }
+
+    public function testSendPassesLocaleToBuilder(): void
+    {
+        $user = new User('user@example.org');
+        $alias = new Alias();
+        $alias->setSource('alias@example.org');
+
+        $builder = $this->createMock(AliasCreatedMessageBuilder::class);
+        $builder->expects($this->once())
+            ->method('buildBody')
+            ->with('de')
+            ->willReturn('Alias Nachricht');
+        $builder->expects($this->once())
+            ->method('buildSubject')
+            ->with('de')
+            ->willReturn('Alias Betreff');
+
+        $handler = $this->createMock(MailHandler::class);
+        $handler->expects($this->once())->method('send');
+
+        $sender = new AliasCreatedMessageSender($handler, $builder);
+        $sender->send($user, $alias, 'de');
+    }
+}

--- a/tests/Sender/RecoveryProcessMessageSenderTest.php
+++ b/tests/Sender/RecoveryProcessMessageSenderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Sender;
+
+use App\Builder\RecoveryProcessMessageBuilder;
+use App\Entity\User;
+use App\Handler\MailHandler;
+use App\Sender\RecoveryProcessMessageSender;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class RecoveryProcessMessageSenderTest extends TestCase
+{
+    public function testSendCallsBuilderAndMailHandler(): void
+    {
+        $user = new User('user@example.org');
+        $user->setRecoveryStartTime(new DateTimeImmutable('2026-01-15 10:00:00'));
+
+        $builder = $this->createMock(RecoveryProcessMessageBuilder::class);
+        $builder->expects($this->once())
+            ->method('buildBody')
+            ->with('en', 'user@example.org', $this->isType('string'))
+            ->willReturn('Recovery body');
+        $builder->expects($this->once())
+            ->method('buildSubject')
+            ->with('en', 'user@example.org')
+            ->willReturn('Recovery subject');
+
+        $handler = $this->createMock(MailHandler::class);
+        $handler->expects($this->once())
+            ->method('send')
+            ->with('user@example.org', 'Recovery body', 'Recovery subject');
+
+        $sender = new RecoveryProcessMessageSender($handler, $builder);
+        $sender->send($user, 'en');
+    }
+
+    public function testSendPassesLocaleToBuilder(): void
+    {
+        $user = new User('user@example.org');
+        $user->setRecoveryStartTime(new DateTimeImmutable('2026-01-15 10:00:00'));
+
+        $builder = $this->createMock(RecoveryProcessMessageBuilder::class);
+        $builder->expects($this->once())
+            ->method('buildBody')
+            ->with('de', 'user@example.org', $this->isType('string'))
+            ->willReturn('Wiederherstellung');
+        $builder->expects($this->once())
+            ->method('buildSubject')
+            ->with('de', 'user@example.org')
+            ->willReturn('Betreff');
+
+        $handler = $this->createMock(MailHandler::class);
+        $handler->expects($this->once())->method('send');
+
+        $sender = new RecoveryProcessMessageSender($handler, $builder);
+        $sender->send($user, 'de');
+    }
+}

--- a/tests/Service/WebhookEndpointManagerTest.php
+++ b/tests/Service/WebhookEndpointManagerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\WebhookEndpoint;
+use App\Service\WebhookEndpointManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+
+class WebhookEndpointManagerTest extends TestCase
+{
+    public function testFindAllDelegatesToRepository(): void
+    {
+        $endpoints = [new WebhookEndpoint('https://example.org/hook', 'secret1')];
+
+        $repository = $this->createStub(EntityRepository::class);
+        $repository->method('findBy')->with([], ['id' => 'ASC'])->willReturn($endpoints);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getRepository')->with(WebhookEndpoint::class)->willReturn($repository);
+
+        $manager = new WebhookEndpointManager($em);
+
+        self::assertSame($endpoints, $manager->findAll());
+    }
+
+    public function testCreatePersistsAndFlushes(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())
+            ->method('persist')
+            ->with($this->callback(static function ($endpoint) {
+                return $endpoint instanceof WebhookEndpoint
+                    && $endpoint->getUrl() === 'https://example.org/hook'
+                    && $endpoint->getSecret() === 'my-secret'
+                    && $endpoint->getEvents() === ['user.created']
+                    && $endpoint->isEnabled() === true;
+            }));
+        $em->expects($this->once())->method('flush');
+
+        $manager = new WebhookEndpointManager($em);
+        $result = $manager->create('https://example.org/hook', 'my-secret', ['user.created'], true);
+
+        self::assertInstanceOf(WebhookEndpoint::class, $result);
+        self::assertSame('https://example.org/hook', $result->getUrl());
+    }
+
+    public function testUpdateModifiesEndpointAndFlushes(): void
+    {
+        $endpoint = new WebhookEndpoint('https://old.org/hook', 'old-secret');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $manager = new WebhookEndpointManager($em);
+        $manager->update($endpoint, 'https://new.org/hook', 'new-secret', ['user.deleted'], false);
+
+        self::assertSame('https://new.org/hook', $endpoint->getUrl());
+        self::assertSame('new-secret', $endpoint->getSecret());
+        self::assertSame(['user.deleted'], $endpoint->getEvents());
+        self::assertFalse($endpoint->isEnabled());
+    }
+
+    public function testDeleteRemovesEndpointAndFlushes(): void
+    {
+        $endpoint = new WebhookEndpoint('https://example.org/hook', 'secret');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('remove')->with($endpoint);
+        $em->expects($this->once())->method('flush');
+
+        $manager = new WebhookEndpointManager($em);
+        $manager->delete($endpoint);
+    }
+}

--- a/tests/Twig/SafeHtmlExtensionTest.php
+++ b/tests/Twig/SafeHtmlExtensionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Twig;
+
+use App\Twig\SafeHtmlExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Twig\Markup;
+
+class SafeHtmlExtensionTest extends TestCase
+{
+    private SafeHtmlExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new SafeHtmlExtension();
+    }
+
+    public function testSafeHtmlReturnsMarkupInstance(): void
+    {
+        $result = $this->extension->safeHtml('Hello');
+
+        self::assertInstanceOf(Markup::class, $result);
+    }
+
+    public function testSafeHtmlWrapsContentInSpan(): void
+    {
+        $result = (string) $this->extension->safeHtml('Hello');
+
+        self::assertStringContainsString('<span data-safe-html class="text-inherit">', $result);
+        self::assertStringContainsString('Hello', $result);
+        self::assertStringEndsWith('</span>', $result);
+    }
+
+    public function testSafeHtmlAllowsSafeTags(): void
+    {
+        $input = '<b>bold</b> <i>italic</i> <em>em</em> <strong>strong</strong> <u>underline</u>';
+        $result = (string) $this->extension->safeHtml($input);
+
+        self::assertStringContainsString('<b>bold</b>', $result);
+        self::assertStringContainsString('<i>italic</i>', $result);
+        self::assertStringContainsString('<em>em</em>', $result);
+        self::assertStringContainsString('<strong>strong</strong>', $result);
+        self::assertStringContainsString('<u>underline</u>', $result);
+    }
+
+    public function testSafeHtmlStripsDisallowedTags(): void
+    {
+        $input = '<script>alert("xss")</script><img src="x" onerror="alert(1)">';
+        $result = (string) $this->extension->safeHtml($input);
+
+        self::assertStringNotContainsString('<script>', $result);
+        self::assertStringNotContainsString('<img', $result);
+        self::assertStringContainsString('alert("xss")', $result);
+    }
+
+    #[DataProvider('javascriptUrlProvider')]
+    public function testSafeHtmlRemovesJavascriptUrls(string $input, string $notExpected): void
+    {
+        $result = (string) $this->extension->safeHtml($input);
+
+        self::assertStringNotContainsString($notExpected, $result);
+        self::assertStringContainsString('href="#"', $result);
+    }
+
+    public static function javascriptUrlProvider(): array
+    {
+        return [
+            'lowercase javascript:' => [
+                '<a href="javascript:alert(1)">click</a>',
+                'javascript:',
+            ],
+            'uppercase JAVASCRIPT:' => [
+                '<a href="JAVASCRIPT:alert(1)">click</a>',
+                'JAVASCRIPT:',
+            ],
+            'data: url' => [
+                '<a href="data:text/html,<script>alert(1)</script>">click</a>',
+                'data:',
+            ],
+        ];
+    }
+
+    public function testSafeHtmlAllowsNormalLinks(): void
+    {
+        $input = '<a href="https://example.org">link</a>';
+        $result = (string) $this->extension->safeHtml($input);
+
+        self::assertStringContainsString('href="https://example.org"', $result);
+        self::assertStringContainsString('>link</a>', $result);
+    }
+
+    public function testSafeHtmlHandlesEmptyString(): void
+    {
+        $result = (string) $this->extension->safeHtml('');
+
+        self::assertSame('<span data-safe-html class="text-inherit"></span>', $result);
+    }
+
+    public function testSafeHtmlHandlesPlainText(): void
+    {
+        $result = (string) $this->extension->safeHtml('Just plain text');
+
+        self::assertStringContainsString('Just plain text', $result);
+    }
+}

--- a/tests/Twig/SettingsExtensionTest.php
+++ b/tests/Twig/SettingsExtensionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Twig;
+
+use App\Service\SettingsService;
+use App\Twig\SettingsExtension;
+use PHPUnit\Framework\TestCase;
+use Twig\TwigFunction;
+
+class SettingsExtensionTest extends TestCase
+{
+    public function testGetFunctionsReturnsSettingFunction(): void
+    {
+        $settings = $this->createStub(SettingsService::class);
+        $extension = new SettingsExtension($settings);
+
+        $functions = $extension->getFunctions();
+
+        self::assertCount(1, $functions);
+        self::assertInstanceOf(TwigFunction::class, $functions[0]);
+        self::assertSame('setting', $functions[0]->getName());
+    }
+
+    public function testSettingFunctionCallsSettingsService(): void
+    {
+        $settings = $this->createMock(SettingsService::class);
+        $settings->expects($this->once())
+            ->method('get')
+            ->with('app_name')
+            ->willReturn('Userli');
+
+        $extension = new SettingsExtension($settings);
+        $functions = $extension->getFunctions();
+
+        $callable = $functions[0]->getCallable();
+        $result = $callable('app_name');
+
+        self::assertSame('Userli', $result);
+    }
+}

--- a/tests/Twig/UserNotificationExtensionTest.php
+++ b/tests/Twig/UserNotificationExtensionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Twig;
+
+use App\Entity\User;
+use App\Entity\UserNotification;
+use App\Twig\UserNotificationExtension;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class UserNotificationExtensionTest extends TestCase
+{
+    public function testHasNotificationsReturnsFalseWhenNotLoggedIn(): void
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+
+        $extension = new UserNotificationExtension($security, $em);
+
+        self::assertFalse($extension->hasNotifications());
+    }
+
+    public function testHasNotificationsReturnsTrueWhenNotificationsExist(): void
+    {
+        $user = new User('user@example.org');
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $notification = $this->createStub(UserNotification::class);
+
+        $repository = $this->createStub(EntityRepository::class);
+        $repository->method('findBy')
+            ->with(['user' => $user])
+            ->willReturn([$notification]);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+
+        $extension = new UserNotificationExtension($security, $em);
+
+        self::assertTrue($extension->hasNotifications());
+    }
+
+    public function testHasNotificationsReturnsFalseWhenNoNotifications(): void
+    {
+        $user = new User('user@example.org');
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $repository = $this->createStub(EntityRepository::class);
+        $repository->method('findBy')
+            ->with(['user' => $user])
+            ->willReturn([]);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+
+        $extension = new UserNotificationExtension($security, $em);
+
+        self::assertFalse($extension->hasNotifications());
+    }
+
+    public function testHasNotificationsWithTypeFilter(): void
+    {
+        $user = new User('user@example.org');
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $notification = $this->createStub(UserNotification::class);
+
+        $repository = $this->createStub(EntityRepository::class);
+        $repository->method('findBy')
+            ->with(['user' => $user, 'type' => 'compromised_password'])
+            ->willReturn([$notification]);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+
+        $extension = new UserNotificationExtension($security, $em);
+
+        self::assertTrue($extension->hasNotifications('compromised_password'));
+    }
+
+    public function testHasNotificationsWithTypeFilterReturnsFlaseWhenEmpty(): void
+    {
+        $user = new User('user@example.org');
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $repository = $this->createStub(EntityRepository::class);
+        $repository->method('findBy')
+            ->with(['user' => $user, 'type' => 'compromised_password'])
+            ->willReturn([]);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+
+        $extension = new UserNotificationExtension($security, $em);
+
+        self::assertFalse($extension->hasNotifications('compromised_password'));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 16 new unit test files covering previously untested classes across Twig extensions, event listeners, message senders, services, commands, helpers, and the statistics block service
- Increases overall test coverage from ~50% line coverage to a higher level by targeting classes that had zero test coverage
- All 671 tests pass (including the 16 new test files)

## New Test Files

| Category | Test File | Covered Class |
|----------|-----------|---------------|
| Twig | `SafeHtmlExtensionTest` | `SafeHtmlExtension` |
| Twig | `UserNotificationExtensionTest` | `UserNotificationExtension` |
| Twig | `SettingsExtensionTest` | `SettingsExtension` |
| Block | `StatisticsBlockServiceTest` | `StatisticsBlockService` |
| EventListener | `CompromisedPasswordListenerTest` | `CompromisedPasswordListener` |
| EventListener | `DomainCreationListenerTest` | `DomainCreationListener` |
| EventListener | `RandomAliasCreationListenerTest` | `RandomAliasCreationListener` |
| EventListener | `AliasCreationListenerTest` | `AliasCreationListener` |
| EventListener | `RecoveryProcessListenerTest` | `RecoveryProcessListener` |
| EventListener | `TwigGlobalListenerTest` | `TwigGlobalListener` |
| EventListener | `LogoutListenerTest` | `LogoutListener` |
| Service | `WebhookEndpointManagerTest` | `WebhookEndpointManager` |
| Sender | `RecoveryProcessMessageSenderTest` | `RecoveryProcessMessageSender` |
| Sender | `AliasCreatedMessageSenderTest` | `AliasCreatedMessageSender` |
| Command | `ReportWeeklyCommandTest` | `ReportWeeklyCommand` |
| Helper | `TotpBackupCodeGeneratorTest` | `TotpBackupCodeGenerator` |

---
*This PR was generated by OpenCode.*