### PR TITLE
🐛 Fix Xdebug blocking all HTTP requests in dev environment

### DIFF
--- a/docker/userli/xdebug.ini
+++ b/docker/userli/xdebug.ini
@@ -2,7 +2,7 @@ zend_extension=xdebug
 
 xdebug.mode=develop,debug,profile
 xdebug.idekey=docker
-xdebug.start_with_request=yes
+xdebug.start_with_request=trigger
 xdebug.log=/dev/stdout
 xdebug.log_level=0
 xdebug.client_port=9003


### PR DESCRIPTION
## Summary

- Change `xdebug.start_with_request` from `yes` to `trigger` in `docker/userli/xdebug.ini`
- With `yes`, every HTTP request attempts to open a debug connection to the host IDE on port 9003. When no IDE is listening, requests block indefinitely (infinite loading in the browser)
- With `trigger`, Xdebug only activates when explicitly requested via browser extension (Xdebug Helper), cookie (`XDEBUG_TRIGGER`), or query parameter (`XDEBUG_TRIGGER=1`)

---

*This PR was generated by OpenCode.*