### PR TITLE
♻️ Replace domain with app_name setting in browser page titles

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -16,7 +16,7 @@ navbar:
   light-mode: Hellmodus
 
 start:
-  title: Willkommen bei %domain%
+  title: Willkommen bei %app_name%
   intro: Hier kannst du dein E-Mail-Konto erstellen und verwalten.
   registration-header: Registrierung
   registration-text: >

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -16,7 +16,7 @@ navbar:
   light-mode: Light mode
 
 start:
-  title: Welcome to %domain%
+  title: Welcome to %app_name%
   intro: Here you can set up and manage your e-mail account.
   registration-header: Registration
   registration-text: >

--- a/default_translations/es/messages.es.yml
+++ b/default_translations/es/messages.es.yml
@@ -10,7 +10,7 @@ navbar:
   open-main-menu: Abrir menú principal
 
 start:
-  title: Bienvenido a %domain%
+  title: Bienvenido a %app_name%
   intro: Aquí puedes configurar y gestionar tu cuenta de e-mail.
   registration-header: Registro
   registration-text: >

--- a/default_translations/fr/messages.fr.yml
+++ b/default_translations/fr/messages.fr.yml
@@ -10,7 +10,7 @@ navbar:
   open-main-menu: Ouvrir le menu principal
 
 start:
-  title: Bienvenue sur %domain%
+  title: Bienvenue sur %app_name%
   intro: Ici vous pouvez configurer et gérer vos comptes de messagerie.
   registration-header: Inscription
   registration-text: >

--- a/default_translations/gsw/messages.gsw.yml
+++ b/default_translations/gsw/messages.gsw.yml
@@ -75,7 +75,7 @@ start:
   vouchers-desc: Lad dini Fründe ii
   account-settings-desc: Passwörter und meh
   webmail-desc: E-Mails läse und schriibe
-  title: Wiukomme bi %domain%
+  title: Wiukomme bi %app_name%
   webmail: Webmail
 welcome:
   text: >

--- a/default_translations/it/messages.it.yml
+++ b/default_translations/it/messages.it.yml
@@ -11,7 +11,7 @@ navbar:
 
 start:
   registration-header: Registrazione
-  title: Benvenuto/a su %domain%
+  title: Benvenuto/a su %app_name%
   registration-button: Crea un account
   aliases: Indirizzi alias
   aliases-desc: Nascondi la tua identità

--- a/default_translations/nb/messages.nb.yml
+++ b/default_translations/nb/messages.nb.yml
@@ -8,7 +8,7 @@ navbar:
   open-main-menu: Åpne hovedmeny
 
 start:
-  title: Velkommen til %domain%
+  title: Velkommen til %app_name%
   intro: Her kan du sette opp og håndtere din e-postkonto.
   registration-header: Registrering
   registration-text: >

--- a/default_translations/pt/messages.pt.yml
+++ b/default_translations/pt/messages.pt.yml
@@ -8,7 +8,7 @@ navbar:
   open-main-menu: Abrir menu principal
 
 start:
-  title: Boas-vindas a %domain%
+  title: Boas-vindas a %app_name%
   intro: Aqui você pode criar e configurar a sua conta de e-mail.
   registration-header: Registo
   registration-text: >

--- a/features/start.feature
+++ b/features/start.feature
@@ -17,7 +17,7 @@ Feature: Start Page
     Scenario: Visit homepage unauthenticated
         When I am on "/"
         Then the response status code should be 200
-        And I should see "Welcome to example.org"
+        And I should see "Welcome to Userli"
 
     @start
     Scenario: Authenticated user redirects to start page

--- a/templates/Account/delete.html.twig
+++ b/templates/Account/delete.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "delete.user.headline"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "delete.user.headline"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Account/openpgp.html.twig
+++ b/templates/Account/openpgp.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "start.openpgp-settings"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "start.openpgp-settings"|trans }}{% endblock %}
 
 {% block page_title %}{{ "start.openpgp-settings"|trans }}{% endblock %}
 

--- a/templates/Account/openpgp_delete.html.twig
+++ b/templates/Account/openpgp_delete.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "start.openpgp-delete"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "start.openpgp-delete"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Account/password.html.twig
+++ b/templates/Account/password.html.twig
@@ -5,7 +5,7 @@
 {# Do not show the password compromised notification in the password change template #}
 {% block notifications %}{% endblock %}
 
-{% block title %}{{ domain }} - {{ "account.password.title"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "account.password.title"|trans }}{% endblock %}
 
 {% block step_icon %}
     <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/50 rounded-xl flex items-center justify-center">

--- a/templates/Account/recovery_token.html.twig
+++ b/templates/Account/recovery_token.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "recovery-token.headline"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "recovery-token.headline"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Account/show.html.twig
+++ b/templates/Account/show.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "start.account-settings"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "start.account-settings"|trans }}{% endblock %}
 
 {% block page_title %}{{ "start.account-settings"|trans }}{% endblock %}
 

--- a/templates/Account/twofactor_backup_code_confirm.html.twig
+++ b/templates/Account/twofactor_backup_code_confirm.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Account/twofactor_confirm.html.twig
+++ b/templates/Account/twofactor_confirm.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Account/twofactor_disable.html.twig
+++ b/templates/Account/twofactor_disable.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Account/twofactor_enable.html.twig
+++ b/templates/Account/twofactor_enable.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Account/twofactor_show.html.twig
+++ b/templates/Account/twofactor_show.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "account.twofactor.headline"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 {% form_theme disableForm 'Form/fields.html.twig' %}

--- a/templates/Alias/delete.html.twig
+++ b/templates/Alias/delete.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "delete.alias.headline_generic"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "delete.alias.headline_generic"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Alias/show.html.twig
+++ b/templates/Alias/show.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "start.aliases"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "start.aliases"|trans }}{% endblock %}
 
 {% form_theme custom_alias_form 'Form/fields.html.twig' %}
 {% form_theme random_alias_form 'Form/fields.html.twig' %}

--- a/templates/Init/domain.html.twig
+++ b/templates/Init/domain.html.twig
@@ -2,7 +2,7 @@
 
 {% form_theme form 'Form/fields.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "init.title"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "init.title"|trans }}{% endblock %}
 
 {% block content %}
     <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">

--- a/templates/Init/settings.html.twig
+++ b/templates/Init/settings.html.twig
@@ -2,7 +2,7 @@
 
 {% form_theme form 'Form/fields.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "init.title"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "init.title"|trans }}{% endblock %}
 
 {% block content %}
     <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">

--- a/templates/Init/user.html.twig
+++ b/templates/Init/user.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "init.title"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "init.title"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Recovery/recovery.html.twig
+++ b/templates/Recovery/recovery.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "recovery.header"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "recovery.header"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Recovery/recovery_token.html.twig
+++ b/templates/Recovery/recovery_token.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "recovery.token-lead"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "recovery.token-lead"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Recovery/reset_password.html.twig
+++ b/templates/Recovery/reset_password.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "recovery.header"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "recovery.header"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Registration/recovery_token.html.twig
+++ b/templates/Registration/recovery_token.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "registration.recovery-token-headline"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "registration.recovery-token-headline"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Registration/register.html.twig
+++ b/templates/Registration/register.html.twig
@@ -2,7 +2,7 @@
 
 
 
-{% block title %}{{ domain }} - {{ "form.register-header"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "form.register-header"|trans }}{% endblock %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 

--- a/templates/Registration/welcome.html.twig
+++ b/templates/Registration/welcome.html.twig
@@ -3,9 +3,9 @@
 {% set project_name = setting('project_name') %}
 {% set app_url = setting('app_url') %}
 
-{% block title %}{{ domain }} - {{ "welcome.headline"|trans({'%domain%': domain, '%project_name%': project_name}) }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "welcome.headline"|trans({'%project_name%': project_name}) }}{% endblock %}
 
-{% block page_title %}{{ "welcome.headline"|trans({'%domain%': domain, '%project_name%': project_name}) }}{% endblock %}
+{% block page_title %}{{ "welcome.headline"|trans({'%project_name%': project_name}) }}{% endblock %}
 
 {% block page_subtitle %}{{ "welcome.lead"|trans }}{% endblock %}
 

--- a/templates/Security/2fa_form.html.twig
+++ b/templates/Security/2fa_form.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "form.twofactor-login"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "form.twofactor-login"|trans }}{% endblock %}
 
 {% block step_icon %}
     <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/50 rounded-xl flex items-center justify-center">

--- a/templates/Security/login.html.twig
+++ b/templates/Security/login.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_step.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "form.signin-header"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "form.signin-header"|trans }}{% endblock %}
 
 {% block step_icon %}
     <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/50 rounded-xl flex items-center justify-center">

--- a/templates/Settings/Api/create.html.twig
+++ b/templates/Settings/Api/create.html.twig
@@ -2,7 +2,7 @@
 
 {% form_theme form 'Form/fields.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "settings.api.create.title"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "settings.api.create.title"|trans }}{% endblock %}
 
 {% block page_title %}{{ "settings.title"|trans }}{% endblock %}
 

--- a/templates/Settings/Api/show.html.twig
+++ b/templates/Settings/Api/show.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "settings.api.title"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "settings.api.title"|trans }}{% endblock %}
 
 {% block page_title %}{{ "settings.title"|trans }}{% endblock %}
 

--- a/templates/Settings/Maintenance/show.html.twig
+++ b/templates/Settings/Maintenance/show.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ 'settings.maintenance.title'|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ 'settings.maintenance.title'|trans }}{% endblock %}
 {% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
 {% block page_subtitle %}{{ 'settings.maintenance.subtitle'|trans }}{% endblock %}
 

--- a/templates/Settings/Webhook/Delivery/index.html.twig
+++ b/templates/Settings/Webhook/Delivery/index.html.twig
@@ -1,5 +1,5 @@
 {% extends 'base_page.html.twig' %}
-{% block title %}{{ domain }} - {{ 'settings.webhook.deliveries.title'|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ 'settings.webhook.deliveries.title'|trans }}{% endblock %}
 {% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
 {% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
 {% block page_content %}

--- a/templates/Settings/Webhook/Delivery/show.html.twig
+++ b/templates/Settings/Webhook/Delivery/show.html.twig
@@ -1,5 +1,5 @@
 {% extends 'base_page.html.twig' %}
-{% block title %}{{ domain }} - {{ 'settings.webhook.delivery.title'|trans({'%id%': delivery.id}) }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ 'settings.webhook.delivery.title'|trans({'%id%': delivery.id}) }}{% endblock %}
 {% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
 {% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
 {% block page_content %}

--- a/templates/Settings/Webhook/Endpoint/form.html.twig
+++ b/templates/Settings/Webhook/Endpoint/form.html.twig
@@ -5,7 +5,7 @@
 
 {# Dynamic page title: use specific create/edit keys #}
 {% block title %}
-    {{ domain }} - {{ is_edit ? 'settings.webhook.edit.title'|trans : 'settings.webhook.create.title'|trans }}
+    {{ setting('app_name') }} - {{ is_edit ? 'settings.webhook.edit.title'|trans : 'settings.webhook.create.title'|trans }}
 {% endblock %}
 {% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
 {% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}

--- a/templates/Settings/Webhook/Endpoint/index.html.twig
+++ b/templates/Settings/Webhook/Endpoint/index.html.twig
@@ -1,5 +1,5 @@
 {% extends 'base_page.html.twig' %}
-{% block title %}{{ domain }} - {{ 'settings.webhook.title'|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ 'settings.webhook.title'|trans }}{% endblock %}
 {% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
 {% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
 {% block page_content %}

--- a/templates/Settings/show.html.twig
+++ b/templates/Settings/show.html.twig
@@ -2,7 +2,7 @@
 
 {% form_theme form 'Form/fields.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "settings.title"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "settings.title"|trans }}{% endblock %}
 {% block page_title %}{{ "settings.title"|trans }}{% endblock %}
 {% block page_subtitle %}{{ "settings.subtitle"|trans }}{% endblock %}
 

--- a/templates/Start/index_anonymous.html.twig
+++ b/templates/Start/index_anonymous.html.twig
@@ -1,8 +1,8 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ "start.title"|trans({'%domain%': domain}) }}{% endblock %}
+{% block title %}{{ "start.title"|trans({'%app_name%': setting('app_name')}) }}{% endblock %}
 
-{% block page_title %}{{ "start.title"|trans({'%domain%': domain}) }}{% endblock %}
+{% block page_title %}{{ "start.title"|trans({'%app_name%': setting('app_name')}) }}{% endblock %}
 
 {% block page_subtitle %}{{ "start.intro"|trans }}{% endblock %}
 

--- a/templates/Start/index_spam.html.twig
+++ b/templates/Start/index_spam.html.twig
@@ -1,8 +1,8 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "spam.title"|trans({'%domain%': domain}) }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "spam.title"|trans }}{% endblock %}
 
-{% block page_title %}{{ "spam.title"|trans({'%domain%': domain}) }}{% endblock %}
+{% block page_title %}{{ "spam.title"|trans }}{% endblock %}
 
 {% block page_subtitle %}{{ "spam.text"|trans }}{% endblock %}
 

--- a/templates/Voucher/show.html.twig
+++ b/templates/Voucher/show.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base_page.html.twig' %}
 
-{% block title %}{{ domain }} - {{ "start.vouchers"|trans }}{% endblock %}
+{% block title %}{{ setting('app_name') }} - {{ "start.vouchers"|trans }}{% endblock %}
 
 {% block page_title %}{{ "start.vouchers"|trans }}{% endblock %}
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}{{ domain }} - {{ "index.title"|trans }}{% endblock %}</title>
+    <title>{% block title %}{{ setting('app_name') }} - {{ "index.title"|trans }}{% endblock %}</title>
 
     {% block head_style %}
         <link rel="stylesheet" href="{{ asset('build/app.css') }}">

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if domain is defined %}{{ domain }} - {% endif %}{{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
+    <title>{{ setting('app_name') }} - {{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
     <link rel="stylesheet" href="{{ asset('build/app.css') }}">
     <script>
         (function() {

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if domain is defined %}{{ domain }} - {% endif %}{{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
+    <title>{{ setting('app_name') }} - {{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
     <link rel="stylesheet" href="{{ asset('build/app.css') }}">
     <script>
         (function() {

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if domain is defined %}{{ domain }} - {% endif %}{{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
+    <title>{{ setting('app_name') }} - {{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
     <link rel="stylesheet" href="{{ asset('build/app.css') }}">
     <script>
         (function() {


### PR DESCRIPTION
## Summary

- Replace all usages of the `domain` Twig global variable in `{% block title %}` tags with `{{ setting('app_name') }}` (configurable, default: "Userli")
- Update `start.title` translation parameter from `%domain%` to `%app_name%` across all 8 language files (en, de, es, fr, it, nb, pt, gsw)
- Remove unused `%domain%` parameters from `index_spam.html.twig` and `welcome.html.twig` title blocks
- Simplify error templates by replacing `{% if domain is defined %}` guard with direct `setting('app_name')` call

## Motivation

This decouples browser tab titles from the primary domain concept, replacing it with the configurable `app_name` setting. This is a step toward eventually removing the hard dependency on `primaryDomain` / `getDefaultDomain()`. All other uses of the `domain` variable (content text, navbar logic, registration form `@domain` suffix) remain unchanged.

## What's NOT changed

- `TwigGlobalListener` still injects the `domain` Twig global — it's still used in content areas, navbar logic, and forms
- No PHP source files were modified
- Translation keys that use `%domain%` in page content (e.g. `start.registration-text`) are untouched

## Testing

- All 692 PHPUnit tests pass
- All 174 Behat scenarios (1712 steps) pass

---
<sub>The changes and the PR were generated by OpenCode.</sub>