### PR TITLE
🌐 Remove %domain% variable from translations

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -20,7 +20,7 @@ start:
   intro: Hier kannst du dein E-Mail-Konto erstellen und verwalten.
   registration-header: Registrierung
   registration-text: >
-    Du hast noch kein E-Mail-Konto bei %domain%? Kein Problem!
+    Du hast noch kein E-Mail-Konto? Kein Problem!
     Lass dir von einer Freund:in einen Einladungscode schicken. Damit kannst
     du sofort ein Konto erstellen.
   registration-button: Konto anlegen

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -20,7 +20,7 @@ start:
   intro: Here you can set up and manage your e-mail account.
   registration-header: Registration
   registration-text: >
-    You don't have an e-mail account with %domain% yet? No problem!
+    You don't have an e-mail account yet? No problem!
     If one of your friends already has an account,
     you can get an invite code from them and immediately set up your own account.
   registration-button: Create account

--- a/default_translations/es/messages.es.yml
+++ b/default_translations/es/messages.es.yml
@@ -14,7 +14,7 @@ start:
   intro: Aquí puedes configurar y gestionar tu cuenta de e-mail.
   registration-header: Registro
   registration-text: >
-    ¿No tienes una cuenta de e-mail con %domain% aún? ¡No hay problema!
+    ¿No tienes una cuenta de e-mail aún? ¡No hay problema!
     Si uno de tus amigos ya tiene una cuenta, puedes obtener un código de invitación de ellos y configurar inmediatamente tu propia cuenta.
   registration-button: Crear cuenta
   account-settings: Configuración de la cuenta

--- a/default_translations/fr/messages.fr.yml
+++ b/default_translations/fr/messages.fr.yml
@@ -14,7 +14,7 @@ start:
   intro: Ici vous pouvez configurer et gérer vos comptes de messagerie.
   registration-header: Inscription
   registration-text: >
-    Vous n'avez pas encore de compte de messagerie avec le domaine %domain%? Aucun problème!
+    Vous n'avez pas encore de compte de messagerie? Aucun problème!
     Si l'un de vos amis a déjà un compte, vous pouvez obtenir un code d'invitation et configurer votre compte immédiatement.
   registration-button: Créer un compte
   account-settings: Paramètres du compte

--- a/default_translations/gsw/messages.gsw.yml
+++ b/default_translations/gsw/messages.gsw.yml
@@ -68,7 +68,7 @@ start:
   registration-button: Account erschteue
   vouchers: Invite Codes
   registration-text: >
-    Du hesch no ke E-Mail Account bi %domain%? Kes Problem!
+    Du hesch no ke E-Mail Account? Kes Problem!
     We eine vo dine Fründe scho e Account het, frag ne doch umne Invite Code und erschteu dr sofort di Account.
   intro: Hie chasch e E-Mail Account erschteue und verwaute.
   registration-header: Regischtration

--- a/default_translations/it/messages.it.yml
+++ b/default_translations/it/messages.it.yml
@@ -23,7 +23,7 @@ start:
   openpgp-settings: OpenPGP
   intro: Qui puoi impostare e gestire il tuo account di posta elettronica.
   registration-text: >
-    Non hai ancora un account di posta elettronica con %domain%?
+    Non hai ancora un account di posta elettronica?
     Nessun problema! Se uno dei tuoi amici ha già un account, puoi ottenere un codice invito da loro e creare immediatamente il tuo account.
   account-settings: Impostazioni dell'account
   account-settings-desc: Password e altro

--- a/default_translations/nb/messages.nb.yml
+++ b/default_translations/nb/messages.nb.yml
@@ -12,7 +12,7 @@ start:
   intro: Her kan du sette opp og håndtere din e-postkonto.
   registration-header: Registrering
   registration-text: >
-    Har du ikke en e-postkonto på %domain% enda? Ikke noe problem.
+    Har du ikke en e-postkonto enda? Ikke noe problem.
     Hvis én av vennene dine allerede har en konto, kan du få en invitasjonskode fra vedkommende og sette opp egen konto omgående.
   registration-button: Opprett konto
   account-settings: Kontoinnstillinger

--- a/default_translations/pt/messages.pt.yml
+++ b/default_translations/pt/messages.pt.yml
@@ -12,7 +12,7 @@ start:
   intro: Aqui você pode criar e configurar a sua conta de e-mail.
   registration-header: Registo
   registration-text: >
-    Ainda não tem uma conta em %domain%? Sem problemas! Se você conhece alguém que
+    Ainda não tem uma conta? Sem problemas! Se você conhece alguém que
     já possua uma conta você pode pedir um convite e começar imediatamente a criar
     a sua própria.
   registration-button: Criar conta

--- a/templates/Registration/register.html.twig
+++ b/templates/Registration/register.html.twig
@@ -22,7 +22,7 @@
                     </h2>
                     <div class="space-y-4">
                         <p class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
-                            {{ "registration.information-intro"|trans({'%domain%': domain, '%project_name%': setting('project_name'), '%project_url%': setting('project_url')})|raw }}
+                            {{ "registration.information-intro"|trans({'%project_name%': setting('project_name'), '%project_url%': setting('project_url')})|raw }}
                         </p>
                         <div class="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
                             <div class="flex items-start">

--- a/templates/Start/index_anonymous.html.twig
+++ b/templates/Start/index_anonymous.html.twig
@@ -20,7 +20,7 @@
                             <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ "start.registration-header"|trans }}</h2>
                         </div>
 
-                        <p class="text-gray-600 dark:text-gray-300 mb-6">{{ "start.registration-text"|trans({'%domain%': domain}) }}</p>
+                        <p class="text-gray-600 dark:text-gray-300 mb-6">{{ "start.registration-text"|trans }}</p>
 
                         <div class="flex justify-center sm:justify-start">
                             <a href="{{ path('register') }}"


### PR DESCRIPTION
## Summary

- Remove the `%domain%` variable from the `start.registration-text` translation key across all 8 languages (en, de, nb, gsw, pt, it, es, fr), rephrasing the text to be more generic
- Remove the unused `%domain%` parameter from the `registration.information-intro` `trans()` call in `register.html.twig` (the translation values never used it)
- Remove the `%domain%` parameter from the `start.registration-text` `trans()` call in `index_anonymous.html.twig`

Note: `init_user.text` still uses `%domain%` intentionally (for the `postmaster@%domain%` reference) and was left unchanged.

---
<sub>The changes and the PR were generated by OpenCode.</sub>