### PR TITLE
♻️ Replace inline dropdown JS with Stimulus controller

### DIFF
--- a/assets/controllers/dropdown_controller.js
+++ b/assets/controllers/dropdown_controller.js
@@ -1,0 +1,126 @@
+import { Controller } from "@hotwired/stimulus";
+
+/**
+ * Reusable dropdown controller for toggling menus.
+ *
+ * Supports two modes configured via the `mode` value:
+ *   - "animated" (default): Uses opacity/scale CSS transitions.
+ *   - "simple": Toggles the `hidden` class on the menu target.
+ *
+ * Targets:
+ *   - button:  The toggle trigger element. Gets aria-expanded updated.
+ *   - menu:    The dropdown/panel that is shown/hidden.
+ *   - arrow:   (optional) A chevron icon that rotates 180° when open.
+ *   - iconOpen:  (optional, simple mode) Icon shown when menu is closed.
+ *   - iconClose: (optional, simple mode) Icon shown when menu is open.
+ *
+ * Usage (animated):
+ *   <div data-controller="dropdown">
+ *     <button data-dropdown-target="button" data-action="dropdown#toggle">...</button>
+ *     <div data-dropdown-target="menu" class="opacity-0 scale-95 pointer-events-none ...">
+ *       ...
+ *     </div>
+ *   </div>
+ *
+ * Usage (simple):
+ *   <div data-controller="dropdown" data-dropdown-mode-value="simple">
+ *     <button data-dropdown-target="button" data-action="dropdown#toggle">...</button>
+ *     <div data-dropdown-target="menu" class="hidden">...</div>
+ *     <svg data-dropdown-target="iconOpen">...</svg>
+ *     <svg data-dropdown-target="iconClose" class="hidden">...</svg>
+ *   </div>
+ */
+export default class extends Controller {
+  static targets = ["button", "menu", "arrow", "iconOpen", "iconClose"];
+  static values = { mode: { type: String, default: "animated" } };
+
+  connect() {
+    this.isOpen = false;
+
+    // Bind handlers so we can add/remove them cleanly
+    this._onOutsideClick = this._onOutsideClick.bind(this);
+    this._onKeydown = this._onKeydown.bind(this);
+
+    document.addEventListener("click", this._onOutsideClick);
+    document.addEventListener("keydown", this._onKeydown);
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this._onOutsideClick);
+    document.removeEventListener("keydown", this._onKeydown);
+  }
+
+  toggle(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (this.isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  open() {
+    if (!this.hasMenuTarget) return;
+
+    this.isOpen = true;
+
+    if (this.modeValue === "simple") {
+      this.menuTarget.classList.remove("hidden");
+      if (this.hasIconOpenTarget) this.iconOpenTarget.classList.add("hidden");
+      if (this.hasIconCloseTarget)
+        this.iconCloseTarget.classList.remove("hidden");
+    } else {
+      this.menuTarget.classList.remove(
+        "opacity-0",
+        "scale-95",
+        "pointer-events-none"
+      );
+      this.menuTarget.classList.add("opacity-100", "scale-100");
+      if (this.hasArrowTarget) this.arrowTarget.classList.add("rotate-180");
+    }
+
+    if (this.hasButtonTarget) {
+      this.buttonTarget.setAttribute("aria-expanded", "true");
+    }
+  }
+
+  close() {
+    if (!this.hasMenuTarget) return;
+
+    this.isOpen = false;
+
+    if (this.modeValue === "simple") {
+      this.menuTarget.classList.add("hidden");
+      if (this.hasIconOpenTarget)
+        this.iconOpenTarget.classList.remove("hidden");
+      if (this.hasIconCloseTarget) this.iconCloseTarget.classList.add("hidden");
+    } else {
+      this.menuTarget.classList.remove("opacity-100", "scale-100");
+      this.menuTarget.classList.add(
+        "opacity-0",
+        "scale-95",
+        "pointer-events-none"
+      );
+      if (this.hasArrowTarget) this.arrowTarget.classList.remove("rotate-180");
+    }
+
+    if (this.hasButtonTarget) {
+      this.buttonTarget.setAttribute("aria-expanded", "false");
+    }
+  }
+
+  _onOutsideClick(event) {
+    if (this.isOpen && !this.element.contains(event.target)) {
+      this.close();
+    }
+  }
+
+  _onKeydown(event) {
+    if (event.key === "Escape" && this.isOpen) {
+      this.close();
+      if (this.hasButtonTarget) this.buttonTarget.focus();
+    }
+  }
+}

--- a/templates/_locale_switcher.html.twig
+++ b/templates/_locale_switcher.html.twig
@@ -34,12 +34,13 @@
     </div>
 {% else %}
     {# Modern language switcher for main navigation #}
-    <div class="relative inline-block text-left" id="language-switcher">
+    <div class="relative inline-block text-left" data-controller="dropdown">
         <div>
             <button
                 type="button"
                 class="inline-flex items-center justify-center px-2 lg:px-3 py-2 text-sm font-medium text-white hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-white/50 rounded-2xl transition-all duration-300 hover:bg-white/10 hover:scale-105"
-                id="language-menu-button"
+                data-dropdown-target="button"
+                data-action="dropdown#toggle"
                 aria-expanded="false"
                 aria-haspopup="true"
                 title="{{ 'navbar.language'|trans }}"
@@ -47,17 +48,16 @@
                 {{ ux_icon('heroicons:language', {class: 'w-4 h-4 lg:mr-1 xl:mr-2'}) }}
                 <span class="sr-only">{{ 'navbar.language'|trans }}:</span>
                 <span class="hidden lg:inline xl:inline">{{ app.request.locale|upper }}</span>
-                {{ ux_icon('heroicons:chevron-down', {class: 'w-3 h-3 lg:ml-1 transition-transform duration-200', id: 'language-arrow'}) }}
+                {{ ux_icon('heroicons:chevron-down', {class: 'w-3 h-3 lg:ml-1 transition-transform duration-200', 'data-dropdown-target': 'arrow'}) }}
             </button>
         </div>
 
         {# Dropdown menu #}
         <div
-            id="language-menu"
+            data-dropdown-target="menu"
             class="absolute right-0 z-50 mt-3 w-48 origin-top-right bg-white dark:bg-gray-800 rounded-3xl shadow-2xl ring-1 ring-black/10 dark:ring-white/10 divide-y divide-gray-100 dark:divide-gray-700 focus:outline-none opacity-0 scale-95 pointer-events-none transition-all duration-300"
             role="menu"
             aria-orientation="vertical"
-            aria-labelledby="language-menu-button"
         >
             <div class="py-2" role="none">
                 {% for locale in locales %}
@@ -110,69 +110,4 @@
     </div>
 </noscript>
 
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const switcher = document.getElementById('language-switcher');
-    const button = document.getElementById('language-menu-button');
-    const menu = document.getElementById('language-menu');
-    const arrow = document.getElementById('language-arrow');
-
-    if (!switcher || !button || !menu || !arrow) return;
-
-    let isOpen = false;
-
-    function openMenu() {
-        isOpen = true;
-        menu.classList.remove('opacity-0', 'scale-95', 'pointer-events-none');
-        menu.classList.add('opacity-100', 'scale-100');
-        arrow.classList.add('rotate-180');
-        button.setAttribute('aria-expanded', 'true');
-    }
-
-    function closeMenu() {
-        isOpen = false;
-        menu.classList.remove('opacity-100', 'scale-100');
-        menu.classList.add('opacity-0', 'scale-95', 'pointer-events-none');
-        arrow.classList.remove('rotate-180');
-        button.setAttribute('aria-expanded', 'false');
-    }
-
-    function toggleMenu() {
-        if (isOpen) {
-            closeMenu();
-        } else {
-            openMenu();
-        }
-    }
-
-    // Toggle menu on button click
-    button.addEventListener('click', function(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        toggleMenu();
-    });
-
-    // Close menu when clicking outside
-    document.addEventListener('click', function(e) {
-        if (!switcher.contains(e.target)) {
-            closeMenu();
-        }
-    });
-
-    // Close menu on escape key
-    document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape' && isOpen) {
-            closeMenu();
-            button.focus();
-        }
-    });
-
-    // Close menu when clicking on a menu item
-    menu.addEventListener('click', function(e) {
-        if (e.target.tagName === 'A') {
-            closeMenu();
-        }
-    });
-});
-</script>
 {% endif %}

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -2,7 +2,8 @@
 
 {# Floating Navigation Bar #}
 <div class="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-7xl px-4">
-    <nav class="bg-gray-900/95 backdrop-blur-md border border-gray-700/50 rounded-3xl shadow-2xl overflow-visible">
+    <nav class="bg-gray-900/95 backdrop-blur-md border border-gray-700/50 rounded-3xl shadow-2xl overflow-visible"
+         {% if app.user %}data-controller="dropdown" data-dropdown-mode-value="simple"{% endif %}>
         <div class="flex items-center h-16 px-4 lg:px-6">
             {# Brand/Logo - Always left #}
             <div class="flex items-center">
@@ -34,93 +35,3 @@
 
 {# Add padding to body to account for floating navbar #}
 <div class="h-20"></div>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Desktop user dropdown functionality
-    const userMenu = document.getElementById('user-menu');
-    const userMenuButton = document.getElementById('user-menu-button');
-    const userMenuDropdown = document.getElementById('user-menu-dropdown');
-    const userMenuArrow = document.getElementById('user-menu-arrow');
-
-    if (userMenu && userMenuButton && userMenuDropdown && userMenuArrow) {
-        let isUserMenuOpen = false;
-
-        function openUserMenu() {
-            isUserMenuOpen = true;
-            userMenuDropdown.classList.remove('opacity-0', 'scale-95', 'pointer-events-none');
-            userMenuDropdown.classList.add('opacity-100', 'scale-100');
-            userMenuArrow.classList.add('rotate-180');
-            userMenuButton.setAttribute('aria-expanded', 'true');
-        }
-
-        function closeUserMenu() {
-            isUserMenuOpen = false;
-            userMenuDropdown.classList.remove('opacity-100', 'scale-100');
-            userMenuDropdown.classList.add('opacity-0', 'scale-95', 'pointer-events-none');
-            userMenuArrow.classList.remove('rotate-180');
-            userMenuButton.setAttribute('aria-expanded', 'false');
-        }
-
-        function toggleUserMenu() {
-            if (isUserMenuOpen) {
-                closeUserMenu();
-            } else {
-                openUserMenu();
-            }
-        }
-
-        userMenuButton.addEventListener('click', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleUserMenu();
-        });
-
-        // Close dropdown when clicking outside
-        document.addEventListener('click', function(e) {
-            if (!userMenu.contains(e.target)) {
-                closeUserMenu();
-            }
-        });
-
-        // Close dropdown on escape key
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && isUserMenuOpen) {
-                closeUserMenu();
-                userMenuButton.focus();
-            }
-        });
-    }
-
-    // Mobile menu functionality
-    const mobileMenuButton = document.getElementById('mobile-menu-button');
-    const mobileMenu = document.getElementById('mobile-menu');
-    const mobileMenuIconOpen = document.getElementById('mobile-menu-icon-open');
-    const mobileMenuIconClose = document.getElementById('mobile-menu-icon-close');
-
-    if (mobileMenuButton && mobileMenu && mobileMenuIconOpen && mobileMenuIconClose) {
-        let isMobileMenuOpen = false;
-
-        function toggleMobileMenu() {
-            isMobileMenuOpen = !isMobileMenuOpen;
-
-            if (isMobileMenuOpen) {
-                mobileMenu.classList.remove('hidden');
-                mobileMenuIconOpen.classList.add('hidden');
-                mobileMenuIconClose.classList.remove('hidden');
-                mobileMenuButton.setAttribute('aria-expanded', 'true');
-            } else {
-                mobileMenu.classList.add('hidden');
-                mobileMenuIconOpen.classList.remove('hidden');
-                mobileMenuIconClose.classList.add('hidden');
-                mobileMenuButton.setAttribute('aria-expanded', 'false');
-            }
-        }
-
-        mobileMenuButton.addEventListener('click', function(e) {
-            e.preventDefault();
-            toggleMobileMenu();
-        });
-    }
-});
-</script>

--- a/templates/_navbar_mobile.html.twig
+++ b/templates/_navbar_mobile.html.twig
@@ -1,5 +1,5 @@
 {# Mobile menu, show/hide based on menu state (only on small screens) #}
-<div class="md:hidden hidden mt-3" id="mobile-menu">
+<div class="md:hidden hidden mt-3" id="mobile-menu" data-dropdown-target="menu">
     <div class="bg-white dark:bg-gray-800 rounded-3xl shadow-2xl ring-1 ring-black/10 dark:ring-white/10 divide-y divide-gray-100 dark:divide-gray-700 max-h-[calc(100vh-8rem)] overflow-y-auto">
         {# User Info Section #}
         <div class="p-3 sm:p-4">

--- a/templates/_navbar_user_menu.html.twig
+++ b/templates/_navbar_user_menu.html.twig
@@ -15,26 +15,26 @@
         </button>
 
         {# User Dropdown - Visible on md screens and up #}
-        <div class="hidden md:block relative" id="user-menu">
+        <div class="hidden md:block relative" data-controller="dropdown">
             <button type="button"
                     class="bg-white/10 hover:bg-white/20 flex text-sm rounded-2xl focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-transparent transition-all duration-300 hover:scale-105 backdrop-blur-sm max-w-xs"
-                    id="user-menu-button"
+                    data-dropdown-target="button"
+                    data-action="dropdown#toggle"
                     aria-expanded="false"
                     aria-haspopup="true">
                 <span class="sr-only">{{ "navbar.open-user-menu"|trans }}</span>
                 <div class="flex items-center px-2 lg:px-3 py-2 space-x-2 min-w-0">
                     {{ ux_icon('heroicons:user-solid', {class: 'w-5 h-5 text-gray-300 flex-shrink-0'}) }}
                     <span class="text-gray-300 text-sm font-medium hidden lg:block truncate min-w-0" title="{{ app.user.email }}">{{ app.user.email }}</span>
-                    {{ ux_icon('heroicons:chevron-down', {class: 'w-4 h-4 text-gray-300 transition-transform duration-200 flex-shrink-0', id: 'user-menu-arrow'}) }}
+                    {{ ux_icon('heroicons:chevron-down', {class: 'w-4 h-4 text-gray-300 transition-transform duration-200 flex-shrink-0', 'data-dropdown-target': 'arrow'}) }}
                 </div>
             </button>
 
             {# Dropdown menu #}
             <div class="absolute right-0 z-50 mt-3 w-72 sm:w-80 origin-top-right bg-white dark:bg-gray-800 rounded-3xl shadow-2xl ring-1 ring-black/10 dark:ring-white/10 divide-y divide-gray-100 dark:divide-gray-700 focus:outline-none opacity-0 scale-95 pointer-events-none transition-all duration-300"
-                 id="user-menu-dropdown"
+                 data-dropdown-target="menu"
                  role="menu"
-                 aria-orientation="vertical"
-                 aria-labelledby="user-menu-button">
+                 aria-orientation="vertical">
                 <div class="px-5 py-4" role="none">
                     <div class="text-xs text-gray-500 dark:text-gray-300">{{ "navbar.signed-in-as"|trans }}</div>
                     <div class="font-semibold break-all text-sm leading-5 text-gray-700 dark:text-gray-300 mt-1">{{ app.user.email }}</div>
@@ -64,12 +64,14 @@
             {# Mobile menu button #}
             <button type="button"
                     class="bg-white/10 hover:bg-white/20 inline-flex items-center justify-center p-2 rounded-2xl text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/50 transition-all duration-300 hover:scale-105 backdrop-blur-sm"
-                    id="mobile-menu-button"
+                    data-dropdown-target="button"
+                    data-action="dropdown#toggle"
                     aria-controls="mobile-menu"
                     aria-expanded="false">
                 <span class="sr-only">{{ "navbar.open-main-menu"|trans }}</span>
-                {{ ux_icon('heroicons:bars-3-solid', {class: 'block h-5 w-5', id: 'mobile-menu-icon-open'}) }}
-                {{ ux_icon('heroicons:x-mark-solid', {class: 'hidden h-5 w-5', id: 'mobile-menu-icon-close'}) }}
+                {{ ux_icon('heroicons:bars-3-solid', {class: 'block h-5 w-5', 'data-dropdown-target': 'iconOpen'}) }}
+                {{ ux_icon('heroicons:x-mark-solid', {class: 'hidden h-5 w-5', 'data-dropdown-target': 'iconClose'}) }}
+            </button>
             </button>
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Introduce a reusable `dropdown` Stimulus controller (`assets/controllers/dropdown_controller.js`) that supports two modes:
  - **animated** (default): opacity/scale CSS transitions for desktop dropdowns (user menu, language switcher)
  - **simple**: `hidden` class toggle with icon swap for the mobile menu
- Replace ~155 lines of inline `<script>` blocks in `_navbar.html.twig` and `_locale_switcher.html.twig` with declarative `data-controller` / `data-action` / `data-dropdown-target` attributes
- All three dropdown instances (user menu, mobile menu, language switcher) now use the same controller with outside-click-to-close, Escape-to-close, focus management, and `aria-expanded` updates

Part of #1045

---
<sub>The changes and the PR were generated by OpenCode.</sub>