### PR TITLE
♻️ Replace clipboard JS with @stimulus-components/clipboard

### DIFF
--- a/assets/controllers/clipboard_controller.js
+++ b/assets/controllers/clipboard_controller.js
@@ -1,0 +1,75 @@
+import Clipboard from "@stimulus-components/clipboard";
+
+/**
+ * Extended clipboard controller based on @stimulus-components/clipboard.
+ *
+ * Additions over the base controller:
+ *   - Supports a `content` value as an alternative to the `source` target,
+ *     so the text to copy can be specified as a data attribute directly.
+ *   - Provides a default success content (checkmark SVG) when no custom
+ *     `successContent` value is set.
+ *
+ * Usage with content value (most common in this app):
+ *   <div data-controller="clipboard"
+ *        data-clipboard-content-value="text to copy">
+ *     <button data-action="clipboard#copy" data-clipboard-target="button">
+ *       <svg>...</svg>
+ *     </button>
+ *   </div>
+ *
+ * Usage with source target (library default):
+ *   <div data-controller="clipboard">
+ *     <input data-clipboard-target="source" value="text to copy" />
+ *     <button data-action="clipboard#copy" data-clipboard-target="button">
+ *       Copy
+ *     </button>
+ *   </div>
+ */
+export default class extends Clipboard {
+  static values = {
+    ...Clipboard.values,
+    content: String,
+  };
+
+  copy(event) {
+    event.preventDefault();
+
+    let text;
+
+    if (this.hasSourceTarget) {
+      text = this.sourceTarget.innerHTML || this.sourceTarget.value;
+    } else if (this.hasContentValue) {
+      text = this.contentValue;
+    } else {
+      return;
+    }
+
+    navigator.clipboard.writeText(text).then(() => this.copied());
+  }
+
+  get _feedbackElement() {
+    return this.hasButtonTarget ? this.buttonTarget : this.element;
+  }
+
+  connect() {
+    this.originalContent = this._feedbackElement.innerHTML;
+  }
+
+  copied() {
+    const el = this._feedbackElement;
+
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+
+    const content = this.hasSuccessContentValue
+      ? this.successContentValue
+      : '<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path></svg>';
+
+    el.innerHTML = content;
+
+    this.timeout = setTimeout(() => {
+      el.innerHTML = this.originalContent;
+    }, this.successDurationValue);
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -274,98 +274,6 @@ document.addEventListener("DOMContentLoaded", function () {
   // Initialize password strength meter
   initializePasswordStrength();
 
-  // Event handler that copies the value of element's [data-link]
-  // attribute to clipboard.
-  //
-  // Usage example:
-  //
-  //   <button data-value="foo">Copy foo to clickboard</button>
-  //
-  //   let el = document.querySelector('button');
-  //   el.addEventListener('click', copyToClipboard);
-  //
-  // To do so it creates a non visible textarea with the value,
-  // selects it and tell the browser to copy the selected content.
-  // After the value has been copied, the textarea is removed from
-  // DOM again.
-  function copyToClipboard(event) {
-    const button = event.currentTarget;
-    const textToCopy = button.dataset.value;
-
-    // Use modern clipboard API with fallback
-    if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard
-        .writeText(textToCopy)
-        .then(function () {
-          showCopySuccess(button);
-        })
-        .catch(function (err) {
-          console.error("Copy failed:", err);
-          fallbackCopy(textToCopy);
-          showCopySuccess(button);
-        });
-    } else {
-      // Fallback for older browsers or non-secure contexts
-      fallbackCopy(textToCopy);
-      showCopySuccess(button);
-    }
-  }
-
-  function fallbackCopy(text) {
-    let el = document.createElement("textarea");
-    el.value = text;
-    el.setAttribute("readonly", "");
-    el.style.position = "absolute";
-    el.style.left = "-9999px";
-    document.body.appendChild(el);
-    el.select();
-    document.execCommand("copy");
-    document.body.removeChild(el);
-  }
-
-  function showCopySuccess(button) {
-    // Store original content and update button to show success
-    const originalContent = button.innerHTML;
-    button.innerHTML = `<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path></svg>`;
-
-    // Add success styling
-    button.classList.add("text-green-600", "border-green-300", "bg-green-50");
-    const originalClasses = [];
-
-    // Store and remove original color classes
-    if (button.classList.contains("text-gray-700")) {
-      originalClasses.push("text-gray-700");
-      button.classList.remove("text-gray-700");
-    }
-    if (button.classList.contains("text-green-700")) {
-      originalClasses.push("text-green-700");
-      button.classList.remove("text-green-700");
-    }
-    if (button.classList.contains("bg-gray-100")) {
-      originalClasses.push("bg-gray-100");
-      button.classList.remove("bg-gray-100");
-    }
-    if (button.classList.contains("bg-white")) {
-      originalClasses.push("bg-white");
-      button.classList.remove("bg-white");
-    }
-    if (button.classList.contains("border-gray-300")) {
-      originalClasses.push("border-gray-300");
-      button.classList.remove("border-gray-300");
-    }
-
-    // Reset after 2 seconds
-    setTimeout(function () {
-      button.innerHTML = originalContent;
-      button.classList.remove(
-        "text-green-600",
-        "border-green-300",
-        "bg-green-50"
-      );
-      originalClasses.forEach((cls) => button.classList.add(cls));
-    }, 2000);
-  }
-
   // Initialize tooltips (replacing Bootstrap's jQuery tooltip)
   function initializeTooltips() {
     const tooltipElements = document.querySelectorAll(
@@ -420,11 +328,4 @@ document.addEventListener("DOMContentLoaded", function () {
   // Initialize all components
   initializeTooltips();
   initializeSafeHtml();
-
-  // initialize copy-to-clickboard buttons
-  document
-    .querySelectorAll('[data-button="copy-to-clipboard"]')
-    .forEach(function (el) {
-      el.addEventListener("click", copyToClipboard);
-    });
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "packageManager": "yarn@1.22.19",
   "dependencies": {
+    "@stimulus-components/clipboard": "^5.0.0",
     "@zxcvbn-ts/core": "^3.0.4",
     "@zxcvbn-ts/language-common": "^3.0.4",
     "@zxcvbn-ts/language-de": "^3.0.2",

--- a/templates/Account/recovery_token.html.twig
+++ b/templates/Account/recovery_token.html.twig
@@ -31,8 +31,9 @@
                                     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3">
                                         <code class="font-stretch-semi-condensed text-sm font-mono text-gray-900 dark:text-gray-100 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>                                            <button type="button"
                                                     class="inline-flex items-center p-2 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md hover:bg-gray-100 dark:hover:bg-gray-500 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-700 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
-                                                    data-button="copy-to-clipboard"
-                                                    data-value="{{ recovery_token }}"
+                                                    data-controller="clipboard"
+                                                    data-clipboard-content-value="{{ recovery_token }}"
+                                                    data-action="clipboard#copy"
                                                     title="{{ "copy-to-clipboard"|trans }}"
                                                     aria-label="{{ "copy-to-clipboard"|trans }}">
                                                 {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}

--- a/templates/Account/twofactor_backup_code_confirm.html.twig
+++ b/templates/Account/twofactor_backup_code_confirm.html.twig
@@ -33,8 +33,9 @@
                         <div class="mb-4 flex items-center justify-start">
                             <button type="button"
                                     class="inline-flex items-center p-2 text-xs font-medium text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-gray-500 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-700 transition-colors duration-200"
-                                    data-button="copy-to-clipboard"
-                                    data-value="{% for key, value in user.totpBackupCodes %}{{ value }}{{ not loop.last ? '\n' : '' }}{% endfor %}"
+                                    data-controller="clipboard"
+                                    data-clipboard-content-value="{% for key, value in user.totpBackupCodes %}{{ value }}{{ not loop.last ? '\n' : '' }}{% endfor %}"
+                                    data-action="clipboard#copy"
                                     title="{{ "copy-to-clipboard"|trans }}"
                                     aria-label="{{ "copy-to-clipboard"|trans }}">
                                 {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}

--- a/templates/Account/twofactor_confirm.html.twig
+++ b/templates/Account/twofactor_confirm.html.twig
@@ -48,9 +48,9 @@
                             </div>
                             <button type="button"
                                     class="inline-flex items-center p-2 text-xs font-medium text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-gray-500 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-700 transition-colors duration-200"
-                                    onclick="copyToClipboard('{{ user.totpSecret }}', this)"
-                                    data-button="copy-to-clipboard"
-                                    data-value="{{ user.totpSecret }}"
+                                    data-controller="clipboard"
+                                    data-clipboard-content-value="{{ user.totpSecret }}"
+                                    data-action="clipboard#copy"
                                     title="{{ "copy-to-clipboard"|trans }}"
                                     aria-label="{{ "copy-to-clipboard"|trans }}">
                                 {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}

--- a/templates/Alias/show.html.twig
+++ b/templates/Alias/show.html.twig
@@ -125,8 +125,9 @@
                                             <div class="flex items-center space-x-2 flex-shrink-0">
                                                 <button type="button"
                                                         class="inline-flex items-center p-2 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-600 rounded hover:bg-gray-200 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 dark:focus:ring-offset-gray-700 transition-colors"
-                                                        data-button="copy-to-clipboard"
-                                                        data-value="{{ alias.source }}"
+                                                        data-controller="clipboard"
+                                                        data-clipboard-content-value="{{ alias.source }}"
+                                                        data-action="clipboard#copy"
                                                         title="{{ "copy-to-clipboard"|trans }}"
                                                         aria-label="{{ "copy-to-clipboard"|trans }}"
                                                         data-toggle="tooltip"
@@ -254,8 +255,9 @@
                                             <div class="flex items-center space-x-2 flex-shrink-0">
                                                 <button type="button"
                                                         class="inline-flex items-center p-2 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-600 rounded hover:bg-gray-200 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 dark:focus:ring-offset-gray-700 transition-colors"
-                                                        data-button="copy-to-clipboard"
-                                                        data-value="{{ alias.source }}"
+                                                        data-controller="clipboard"
+                                                        data-clipboard-content-value="{{ alias.source }}"
+                                                        data-action="clipboard#copy"
                                                         title="{{ "copy-to-clipboard"|trans }}"
                                                         aria-label="{{ "copy-to-clipboard"|trans }}"
                                                         data-toggle="tooltip"

--- a/templates/Recovery/recovery_token.html.twig
+++ b/templates/Recovery/recovery_token.html.twig
@@ -27,8 +27,9 @@
                 <code class="font-stretch-semi-condensed text-sm font-mono text-gray-900 dark:text-gray-100 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>
                 <button type="button"
                         class="inline-flex items-center p-2 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md hover:bg-gray-100 dark:hover:bg-gray-500 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-700 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
-                        data-button="copy-to-clipboard"
-                        data-value="{{ recovery_token }}"
+                        data-controller="clipboard"
+                        data-clipboard-content-value="{{ recovery_token }}"
+                        data-action="clipboard#copy"
                         title="{{ "copy-to-clipboard"|trans }}"
                         aria-label="{{ "copy-to-clipboard"|trans }}">
                     {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}

--- a/templates/Recovery/show_recovery_token.html.twig
+++ b/templates/Recovery/show_recovery_token.html.twig
@@ -7,8 +7,9 @@
             <code class="font-stretch-semi-condensed text-sm font-mono text-gray-900 dark:text-gray-100 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>
             <button type="button"
                     class="inline-flex items-center p-2 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md hover:bg-gray-100 dark:hover:bg-gray-500 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-700 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
-                    data-button="copy-to-clipboard"
-                    data-value="{{ recovery_token }}"
+                    data-controller="clipboard"
+                    data-clipboard-content-value="{{ recovery_token }}"
+                    data-action="clipboard#copy"
                     title="{{ "copy-to-clipboard"|trans }}"
                     aria-label="{{ "copy-to-clipboard"|trans }}">
                 {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}

--- a/templates/Settings/Api/show.html.twig
+++ b/templates/Settings/Api/show.html.twig
@@ -32,10 +32,12 @@
                             {{ ux_icon('heroicons:check-circle', {class: 'w-5 h-5 text-green-600 dark:text-green-400 mr-2'}) }}
                             <span class="text-sm font-medium text-green-800 dark:text-green-200">{{ "settings.api.created.title"|trans }}</span>
                         </div>
-                        <div class="flex items-center bg-white dark:bg-gray-700 border border-green-200 dark:border-green-700 rounded-lg p-3">
-                            <pre id="new-token-display" class="flex-1 text-sm font-mono text-gray-900 dark:text-gray-100 mr-3 whitespace-pre-wrap break-all">{{ newToken }}</pre>
+                        <div class="flex items-center bg-white dark:bg-gray-700 border border-green-200 dark:border-green-700 rounded-lg p-3"
+                             data-controller="clipboard">
+                            <pre data-clipboard-target="source" class="flex-1 text-sm font-mono text-gray-900 dark:text-gray-100 mr-3 whitespace-pre-wrap break-all">{{ newToken }}</pre>
                             <button type="button"
-                                    onclick="copyToClipboard('new-token-display')"
+                                    data-clipboard-target="button"
+                                    data-action="clipboard#copy"
                                     class="px-3 py-2 bg-green-600 dark:bg-green-500 text-white rounded hover:bg-green-700 dark:hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors flex-shrink-0">
                                 <!-- heroicons:clipboard -->
                                 {{ ux_icon('heroicons:clipboard', {class: 'w-4 h-4'}) }}
@@ -148,65 +150,6 @@
     </div>
 
     <script>
-        {% if newToken is defined and newToken is not null %}
-            function copyToClipboard(elementId) {
-                const element = document.getElementById(elementId);
-                const text = element.textContent;
-
-                try {
-                    navigator.clipboard.writeText(text).then(() => {
-                        // Visual feedback
-                        const button = element.nextElementSibling;
-                        const originalContent = button.innerHTML;
-                        button.innerHTML = '{{ ux_icon('heroicons:check', {class: 'w-4 h-4'}) }}';
-                        button.classList.remove('bg-green-600', 'hover:bg-green-700');
-                        button.classList.add('bg-green-700');
-
-                        setTimeout(() => {
-                            button.innerHTML = originalContent;
-                            button.classList.remove('bg-green-700');
-                            button.classList.add('bg-green-600', 'hover:bg-green-700');
-                        }, 2000);
-                    }).catch(() => {
-                        // Fallback for older browsers
-                        fallbackCopy(text, element);
-                    });
-                } catch (err) {
-                    // Fallback for older browsers
-                    fallbackCopy(text, element);
-                }
-            }
-
-            function fallbackCopy(text, element) {
-                const textArea = document.createElement('textarea');
-                textArea.value = text;
-                document.body.appendChild(textArea);
-                textArea.select();
-
-                try {
-                    document.execCommand('copy');
-
-                    // Visual feedback
-                    const button = element.nextElementSibling;
-                    const originalContent = button.innerHTML;
-                    button.innerHTML = '{{ ux_icon('heroicons:check', {class: 'w-4 h-4'}) }}';
-                    button.classList.remove('bg-green-600', 'hover:bg-green-700');
-                    button.classList.add('bg-green-700');
-
-                    setTimeout(() => {
-                        button.innerHTML = originalContent;
-                        button.classList.remove('bg-green-700');
-                        button.classList.add('bg-green-600', 'hover:bg-green-700');
-                    }, 2000);
-
-                } catch (err) {
-                    console.error('Failed to copy token: ', err);
-                }
-
-                document.body.removeChild(textArea);
-            }
-        {% endif %}
-
         function confirmDelete(tokenId, tokenName) {
             const message = '{{ "settings.api.delete.confirm"|trans({'%name%': '__TOKEN_NAME__'})|e('js') }}'.replace('__TOKEN_NAME__', tokenName);
 

--- a/templates/Voucher/show.html.twig
+++ b/templates/Voucher/show.html.twig
@@ -86,8 +86,9 @@
                                                     <button type="button"
                                                             class="inline-flex items-center p-2 border border-green-300 dark:border-green-700 rounded-lg text-sm font-medium text-green-700 dark:text-green-300 bg-white dark:bg-gray-800 hover:bg-green-50 dark:hover:bg-green-900/30 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors duration-200 cursor-pointer"
                                                             title="{{ "copy-to-clipboard"|trans }}"
-                                                            data-button="copy-to-clipboard"
-                                                            data-value="{{ url('register_voucher', {'voucher': voucher.code}) }}"
+                                                            data-controller="clipboard"
+                                                            data-clipboard-content-value="{{ url('register_voucher', {'voucher': voucher.code}) }}"
+                                                            data-action="clipboard#copy"
                                                             aria-label="{{ "copy-to-clipboard"|trans }}">
                                                         {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
                                                     </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -985,6 +985,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@stimulus-components/clipboard@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-components/clipboard/-/clipboard-5.0.0.tgz#1d119c4ba8827c6c11c2e1b9214d0de79bc0cc87"
+  integrity sha512-gbwU1sVBiKfMGGCt6oyXx9mGD+cEcHBSqaz//5UVepoQqzl2jYEUWQGFIO0f48LMOamEQwR1azQKfHq6llv6oA==
+
 "@symfony/stimulus-bridge@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@symfony/stimulus-bridge/-/stimulus-bridge-4.0.1.tgz#af0ddabc88254648a812fc328c0f407a6d5f40dc"


### PR DESCRIPTION
## Summary

- Install `@stimulus-components/clipboard` and create a local extending controller (`assets/controllers/clipboard_controller.js`) that adds:
  - A `content` value for copying text from a data attribute (our primary pattern)
  - Fallback to `this.element` when no explicit `button` target exists (allows placing `data-controller` directly on the button)
  - Default checkmark SVG as success feedback
- Convert all 8 copy-to-clipboard buttons across 7 templates from imperative `data-button`/`data-value`/`onclick` patterns to declarative Stimulus attributes
- Remove ~100 lines of clipboard JS from `app.js` (`copyToClipboard`, `fallbackCopy`, `showCopySuccess`)
- Remove ~60 lines of inline `<script>` from the API token settings page (keep only `confirmDelete` for now)

Part of #1045

---
<sub>The changes and the PR were generated by OpenCode.</sub>