### PR TITLE
♻️ Migrate JavaScript to TypeScript

### DIFF
--- a/assets/controllers/clipboard_controller.ts
+++ b/assets/controllers/clipboard_controller.ts
@@ -25,21 +25,37 @@ import Clipboard from "@stimulus-components/clipboard";
  *     </button>
  *   </div>
  */
+
+declare type ClipboardWithSourceTarget = Clipboard & {
+  hasSourceTarget: boolean;
+  sourceTarget: HTMLInputElement;
+  hasContentValue: boolean;
+  contentValue: string;
+  hasSuccessContentValue: boolean;
+  successContentValue: string;
+  hasButtonTarget: boolean;
+  buttonTarget: HTMLElement;
+  originalContent: string;
+  successDurationValue: number;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
 export default class extends Clipboard {
   static values = {
     ...Clipboard.values,
     content: String,
   };
 
-  copy(event) {
+  copy(event: Event): void {
     event.preventDefault();
 
-    let text;
+    const self = this as unknown as ClipboardWithSourceTarget;
+    let text: string;
 
-    if (this.hasSourceTarget) {
-      text = this.sourceTarget.innerHTML || this.sourceTarget.value;
-    } else if (this.hasContentValue) {
-      text = this.contentValue;
+    if (self.hasSourceTarget) {
+      text = self.sourceTarget.innerHTML || self.sourceTarget.value;
+    } else if (self.hasContentValue) {
+      text = self.contentValue;
     } else {
       return;
     }
@@ -47,29 +63,32 @@ export default class extends Clipboard {
     navigator.clipboard.writeText(text).then(() => this.copied());
   }
 
-  get _feedbackElement() {
-    return this.hasButtonTarget ? this.buttonTarget : this.element;
+  get _feedbackElement(): HTMLElement {
+    const self = this as unknown as ClipboardWithSourceTarget;
+    return self.hasButtonTarget ? self.buttonTarget : this.element as HTMLElement;
   }
 
-  connect() {
-    this.originalContent = this._feedbackElement.innerHTML;
+  connect(): void {
+    (this as unknown as ClipboardWithSourceTarget).originalContent =
+      this._feedbackElement.innerHTML;
   }
 
-  copied() {
+  copied(): void {
+    const self = this as unknown as ClipboardWithSourceTarget;
     const el = this._feedbackElement;
 
-    if (this.timeout) {
-      clearTimeout(this.timeout);
+    if (self.timeout) {
+      clearTimeout(self.timeout);
     }
 
-    const content = this.hasSuccessContentValue
-      ? this.successContentValue
+    const content = self.hasSuccessContentValue
+      ? self.successContentValue
       : '<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path></svg>';
 
     el.innerHTML = content;
 
-    this.timeout = setTimeout(() => {
-      el.innerHTML = this.originalContent;
-    }, this.successDurationValue);
+    self.timeout = setTimeout(() => {
+      el.innerHTML = self.originalContent;
+    }, self.successDurationValue);
   }
 }

--- a/assets/controllers/confirm_controller.ts
+++ b/assets/controllers/confirm_controller.ts
@@ -13,11 +13,13 @@ import { Controller } from "@hotwired/stimulus";
  *   </form>
  */
 export default class extends Controller {
+  declare messageValue: string;
+
   static values = {
     message: { type: String, default: "Are you sure?" },
   };
 
-  prompt(event) {
+  prompt(event: Event): void {
     if (!window.confirm(this.messageValue)) {
       event.preventDefault();
     }

--- a/assets/controllers/dark_mode_controller.ts
+++ b/assets/controllers/dark_mode_controller.ts
@@ -21,22 +21,28 @@ import { Controller } from "@hotwired/stimulus";
  *     <svg data-dark-mode-target="moon">...</svg>
  *   </button>
  */
-export default class extends Controller {
+export default class extends Controller<HTMLElement> {
+  declare hasSunTarget: boolean;
+  declare sunTarget: HTMLElement;
+  declare hasMoonTarget: boolean;
+  declare moonTarget: HTMLElement;
+
   static targets = ["sun", "moon"];
 
-  connect() {
-    this._onSystemChange = this._onSystemChange.bind(this);
+  private _mediaQuery!: MediaQueryList;
+
+  connect(): void {
     this._mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     this._mediaQuery.addEventListener("change", this._onSystemChange);
 
     this._updateIcons();
   }
 
-  disconnect() {
+  disconnect(): void {
     this._mediaQuery.removeEventListener("change", this._onSystemChange);
   }
 
-  toggle() {
+  toggle(): void {
     const isDark = document.documentElement.classList.contains("dark");
 
     if (isDark) {
@@ -50,7 +56,7 @@ export default class extends Controller {
     this._updateIcons();
   }
 
-  _updateIcons() {
+  private _updateIcons(): void {
     const isDark = document.documentElement.classList.contains("dark");
 
     this.element.setAttribute("aria-pressed", isDark ? "true" : "false");
@@ -66,7 +72,7 @@ export default class extends Controller {
     }
   }
 
-  _onSystemChange(event) {
+  private _onSystemChange = (event: MediaQueryListEvent): void => {
     // Only apply system preference if user hasn't set an explicit preference
     if (!localStorage.getItem("theme")) {
       if (event.matches) {
@@ -76,5 +82,5 @@ export default class extends Controller {
       }
       this._updateIcons();
     }
-  }
+  };
 }

--- a/assets/controllers/dropdown_controller.ts
+++ b/assets/controllers/dropdown_controller.ts
@@ -31,13 +31,24 @@ import { Controller } from "@hotwired/stimulus";
  *   </div>
  */
 export default class extends Controller {
+  declare modeValue: string;
+  declare hasMenuTarget: boolean;
+  declare menuTarget: HTMLElement;
+  declare hasButtonTarget: boolean;
+  declare buttonTarget: HTMLElement;
+  declare hasArrowTarget: boolean;
+  declare arrowTarget: HTMLElement;
+  declare hasIconOpenTarget: boolean;
+  declare iconOpenTarget: HTMLElement;
+  declare hasIconCloseTarget: boolean;
+  declare iconCloseTarget: HTMLElement;
+
   static targets = ["button", "menu", "arrow", "iconOpen", "iconClose"];
   static values = { mode: { type: String, default: "animated" } };
 
-  connect() {
-    this.isOpen = false;
+  private isOpen: boolean = false;
 
-    // Bind handlers so we can add/remove them cleanly
+  connect(): void {
     this._onOutsideClick = this._onOutsideClick.bind(this);
     this._onKeydown = this._onKeydown.bind(this);
 
@@ -45,12 +56,12 @@ export default class extends Controller {
     document.addEventListener("keydown", this._onKeydown);
   }
 
-  disconnect() {
+  disconnect(): void {
     document.removeEventListener("click", this._onOutsideClick);
     document.removeEventListener("keydown", this._onKeydown);
   }
 
-  toggle(event) {
+  toggle(event: Event): void {
     event.preventDefault();
     event.stopPropagation();
 
@@ -61,7 +72,7 @@ export default class extends Controller {
     }
   }
 
-  open() {
+  open(): void {
     if (!this.hasMenuTarget) return;
 
     this.isOpen = true;
@@ -75,7 +86,7 @@ export default class extends Controller {
       this.menuTarget.classList.remove(
         "opacity-0",
         "scale-95",
-        "pointer-events-none"
+        "pointer-events-none",
       );
       this.menuTarget.classList.add("opacity-100", "scale-100");
       if (this.hasArrowTarget) this.arrowTarget.classList.add("rotate-180");
@@ -86,7 +97,7 @@ export default class extends Controller {
     }
   }
 
-  close() {
+  close(): void {
     if (!this.hasMenuTarget) return;
 
     this.isOpen = false;
@@ -101,7 +112,7 @@ export default class extends Controller {
       this.menuTarget.classList.add(
         "opacity-0",
         "scale-95",
-        "pointer-events-none"
+        "pointer-events-none",
       );
       if (this.hasArrowTarget) this.arrowTarget.classList.remove("rotate-180");
     }
@@ -111,13 +122,13 @@ export default class extends Controller {
     }
   }
 
-  _onOutsideClick(event) {
-    if (this.isOpen && !this.element.contains(event.target)) {
+  private _onOutsideClick(event: Event): void {
+    if (this.isOpen && !this.element.contains(event.target as Node)) {
       this.close();
     }
   }
 
-  _onKeydown(event) {
+  private _onKeydown(event: KeyboardEvent): void {
     if (event.key === "Escape" && this.isOpen) {
       this.close();
       if (this.hasButtonTarget) this.buttonTarget.focus();

--- a/assets/controllers/flash_notification_controller.ts
+++ b/assets/controllers/flash_notification_controller.ts
@@ -15,27 +15,29 @@ import { Controller } from "@hotwired/stimulus";
  * Values:
  *   autoDismiss (Number): Delay in ms before auto-dismissing. 0 = disabled.
  */
-export default class extends Controller {
+export default class extends Controller<HTMLElement> {
+  declare autoDismissValue: number;
+
   static values = {
     autoDismiss: { type: Number, default: 0 },
   };
 
-  connect() {
-    this._timer = null;
+  private _timer: ReturnType<typeof setTimeout> | null = null;
 
+  connect(): void {
     if (this.autoDismissValue > 0) {
       this._timer = setTimeout(() => this.dismiss(), this.autoDismissValue);
     }
   }
 
-  disconnect() {
+  disconnect(): void {
     if (this._timer) {
       clearTimeout(this._timer);
       this._timer = null;
     }
   }
 
-  dismiss() {
+  dismiss(): void {
     if (this._timer) {
       clearTimeout(this._timer);
       this._timer = null;

--- a/assets/controllers/tooltip_controller.ts
+++ b/assets/controllers/tooltip_controller.ts
@@ -19,14 +19,17 @@ import { Controller } from "@hotwired/stimulus";
  *   </button>
  */
 export default class extends Controller {
+  declare hasContentValue: boolean;
+  declare contentValue: string;
+
   static values = {
     content: String,
   };
 
-  connect() {
-    this._tooltip = null;
-    this._title = "";
+  private _tooltip: HTMLDivElement | null = null;
+  private _title: string = "";
 
+  connect(): void {
     this._show = this._show.bind(this);
     this._hide = this._hide.bind(this);
 
@@ -36,7 +39,7 @@ export default class extends Controller {
     this.element.addEventListener("blur", this._hide);
   }
 
-  disconnect() {
+  disconnect(): void {
     this._hide();
     this.element.removeEventListener("mouseenter", this._show);
     this.element.removeEventListener("mouseleave", this._hide);
@@ -44,7 +47,7 @@ export default class extends Controller {
     this.element.removeEventListener("blur", this._hide);
   }
 
-  _show() {
+  private _show(): void {
     const text =
       this.hasContentValue && this.contentValue
         ? this.contentValue
@@ -75,7 +78,7 @@ export default class extends Controller {
     this._tooltip = tooltip;
   }
 
-  _hide() {
+  private _hide(): void {
     if (this._tooltip) {
       this._tooltip.remove();
       this._tooltip = null;

--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -1,7 +1,7 @@
-require("../css/app.css");
+import "../css/app.css";
 import "../bootstrap.js";
 import { initializeSafeHtml } from "./sanitize";
 
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("DOMContentLoaded", () => {
   initializeSafeHtml();
 });

--- a/assets/js/sanitize.ts
+++ b/assets/js/sanitize.ts
@@ -1,19 +1,25 @@
 import DOMPurify from "dompurify";
 
+declare global {
+  interface Window {
+    sanitizeHTML: typeof sanitizeHTML;
+  }
+}
+
 /**
  * Sanitize HTML with DOMPurify.
  *
  * Allows only a safe subset of tags and attributes so user-generated
  * content can be rendered without XSS risk.
  *
- * Usage in JavaScript:
+ * Usage in TypeScript:
  *   import { sanitizeHTML } from '../js/sanitize';
  *   element.innerHTML = sanitizeHTML(userContent);
  *
  * The function is also available globally as window.sanitizeHTML for
  * legacy callers and the SafeHtmlExtension Twig filter.
  */
-export function sanitizeHTML(html) {
+export function sanitizeHTML(html: string): string {
   return DOMPurify.sanitize(html, {
     ALLOWED_TAGS: [
       "b",
@@ -41,7 +47,7 @@ window.sanitizeHTML = sanitizeHTML;
  * Called once on DOMContentLoaded. Each matching element's innerHTML is
  * passed through sanitizeHTML and the marker attribute is removed.
  */
-export function initializeSafeHtml() {
+export function initializeSafeHtml(): void {
   const elements = document.querySelectorAll("[data-safe-html]");
   elements.forEach((element) => {
     const originalContent = element.innerHTML;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "postcss": "^8.5.6",
     "postcss-loader": "^8.2.0",
     "tailwindcss": "^4.1.18",
+    "ts-loader": "^9.5.4",
+    "typescript": "^5.9.3",
     "webpack": "^5.104.1",
     "webpack-cli": "^6.0.1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false,
+    "sourceMap": true,
+    "declaration": false,
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "types": ["webpack-env"]
+  },
+  "include": ["assets/**/*.ts"],
+  "exclude": ["node_modules", "public", "vendor"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ Encore
    * Each entry will result in one JavaScript file (e.g. app.js)
    * and one CSS file (e.g. app.css) if you JavaScript imports CSS.
    */
-  .addEntry("app", "./assets/js/app.js")
+  .addEntry("app", "./assets/js/app.ts")
 
   // impossible, because webpack tries to find the included images
   //.addStyleEntry('AdminLTE.min.css', './assets/css/AdminLTE.min.css')
@@ -31,8 +31,8 @@ Encore
   // enables hashed filenames (e.g. app.abc123.css)
   .enableVersioning(Encore.isProduction())
 
-  // uncomment if you use TypeScript
-  //.enableTypeScriptLoader()
+  // Enable TypeScript support
+  .enableTypeScriptLoader()
 
   // uncomment if you use Sass/SCSS files
   //.enableSassLoader()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,6 +1497,13 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
+
 browserslist@^4.0.0, browserslist@^4.23.3, browserslist@^4.24.0, browserslist@^4.28.1:
   version "4.28.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.1.tgz#7f534594628c53c63101079e27e40de490456a95"
@@ -1547,7 +1554,7 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1913,6 +1920,14 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
+enhanced-resolve@^5.0.0:
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz#6687446a15e969eaa63c2fa2694510e17ae6d97c"
+  integrity sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.3.0"
+
 enhanced-resolve@^5.17.4, enhanced-resolve@^5.18.3:
   version "5.18.4"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz#c22d33055f3952035ce6a144ce092447c525f828"
@@ -2024,6 +2039,13 @@ fdir@^6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
   integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
+
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
+  dependencies:
+    to-regex-range "^5.0.1"
 
 find-up@^4.0.0:
   version "4.1.0"
@@ -2154,6 +2176,11 @@ is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-plain-object@^2.0.4:
   version "2.0.4"
@@ -2421,6 +2448,14 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+micromatch@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -2543,7 +2578,7 @@ picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.2.3:
+picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3002,6 +3037,11 @@ semver@^7.3.2, semver@^7.5.4, semver@^7.6.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
+semver@^7.3.4:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
 serialize-javascript@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
@@ -3050,6 +3090,11 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.4:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
+  integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
 
 stackframe@^1.3.4:
   version "1.3.4"
@@ -3168,10 +3213,33 @@ tmp@^0.2.5:
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
   integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
+ts-loader@^9.5.4:
+  version "9.5.4"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.4.tgz#44b571165c10fb5a90744aa5b7e119233c4f4585"
+  integrity sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.0.0"
+    micromatch "^4.0.0"
+    semver "^7.3.4"
+    source-map "^0.7.4"
+
 tslib@^2.4.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 undici-types@~6.20.0:
   version "6.20.0"


### PR DESCRIPTION
## Summary

- Convert all Stimulus controllers and utility modules from JavaScript to TypeScript with strict typing
- Add `typescript` (5.9.3) and `ts-loader` (9.5.4) as dev dependencies
- Configure `tsconfig.json` with strict mode enabled
- Update webpack entry point to use `.ts` extension

### Files converted (9 files)
- `assets/js/app.js` → `app.ts`
- `assets/js/sanitize.js` → `sanitize.ts`
- `assets/controllers/confirm_controller.js` → `.ts`
- `assets/controllers/clipboard_controller.js` → `.ts`
- `assets/controllers/dark_mode_controller.js` → `.ts`
- `assets/controllers/dropdown_controller.js` → `.ts`
- `assets/controllers/flash_notification_controller.js` → `.ts`
- `assets/controllers/password_strength_controller.js` → `.ts`
- `assets/controllers/tooltip_controller.js` → `.ts`

### Files intentionally kept as JS
- `assets/bootstrap.js` — Uses `require.context()` (Webpack-specific), regex already matches `.ts`
- `assets/controllers/csrf_protection_controller.js` — Symfony ecosystem file, may be overwritten by updates

### TypeScript patterns used
- Stimulus `declare` for runtime-injected value/target properties
- `Controller<HTMLElement>` generic for typed element access
- Arrow function for event listener binding (avoids manual `.bind(this)`)
- Proper type casting for `this.constructor` static property access
- `ReturnType<typeof setTimeout>` for timer handles

Closes #1045

---
<sub>The changes and the PR were generated by OpenCode.</sub>