### PR TITLE
🐛 Fix optional settings not being saved

### DIFF
--- a/src/Service/SettingsService.php
+++ b/src/Service/SettingsService.php
@@ -65,8 +65,13 @@ final readonly class SettingsService
         $defaults = $this->configService->getSettings();
 
         foreach ($settings as $name => $value) {
-            // Skip undefined settings and null values
-            if (!isset($defaults[$name]) || $value === null) {
+            // Skip undefined settings
+            if (!isset($defaults[$name])) {
+                continue;
+            }
+
+            // Skip null values for non-optional settings
+            if ($value === null && empty($defaults[$name]['optional'])) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- Fix `SettingsService::setAll()` to correctly save `null` values for optional settings as empty strings instead of silently skipping them

### Why

After merging #1058, optional settings like `webmail_url` could not be cleared (set to empty) through the admin panel. When a user submitted the settings form with an empty optional field, the `null` value was skipped by `setAll()`, leaving the old value in place. This fix distinguishes between optional and non-optional settings: non-optional settings still skip `null` values, while optional settings save `null` as an empty string.

---
<sub>The changes and the PR were generated by OpenCode.</sub>