### PR TITLE
🗃️ Rename database tables to remove virtual_ prefix

### DIFF
--- a/docs/features/mail_crypt.md
+++ b/docs/features/mail_crypt.md
@@ -22,7 +22,7 @@ have MailCrypt enabled per default, you can set `MAIL_CRYPT=1` in the dotenv
   documentation about migrating legacy users for more info
 
 MailCrypt can be turned on/off for individual users by setting the `mail_crypt`
-switch in the `virtual_users` database table. This switch is mainly meant to
+switch in the `users` database table. This switch is mainly meant to
 provide a migration path from legacy users without MailCrypt keys. On new
 setups, it's recommended to keep MailCrypt enabled for all users.
 
@@ -52,7 +52,7 @@ In order to enable MailCrypt for a legacy user, do the following:
 1. Ensure that they have a recovery token generated. This will automatically
    generate MailCrypt key pair as well. This step can only be done by the
    account holder, as the user password is required to do so.
-2. Manually set `mail_crypt=1` for the user in the `virtual_users` database
+2. Manually set `mail_crypt=1` for the user in the `users` database
    table. This needs to be done on a per-user basis on purpose (e.g. by a
    cron script).
 
@@ -62,7 +62,7 @@ Or, alternatively, to enforce MailCrypt for all legacy users:
    MailCrypt key pair being generated automatically when legacy users log
    in the next time. Again, we cannot do this step without the user logging
    in, as the user password is required to do so.
-2. Manually set `mail_crypt=1` for all users in the `virtual_users` database
+2. Manually set `mail_crypt=1` for all users in the `users` database
    table that have a MailCrypt key pair generated but MailCrypt not enabled
    yet. This needs to be done on a per-user basis on purpose (e.g. by a cron
    script).
@@ -75,5 +75,5 @@ The following SQL statement can be used to enable MailCrypt for all legacy
 users that got a MailCrypt key pair generated. Use with caution!
 
 ```sql
-UPDATE virtual_users SET mail_crypt=1 WHERE mail_crypt_secret_box IS NOT NULL AND mail_crypt = 0;
+UPDATE users SET mail_crypt=1 WHERE mail_crypt_secret_box IS NOT NULL AND mail_crypt = 0;
 ```

--- a/migrations/Version20260225000000.php
+++ b/migrations/Version20260225000000.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Migration to remove the virtual_ prefix from table names.
+ */
+final class Version20260225000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename tables to remove the virtual_ prefix';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('RENAME TABLE virtual_aliases TO aliases');
+        $this->addSql('RENAME TABLE virtual_domains TO domains');
+        $this->addSql('RENAME TABLE virtual_openpgp_keys TO openpgp_keys');
+        $this->addSql('RENAME TABLE virtual_reserved_names TO reserved_names');
+        $this->addSql('RENAME TABLE virtual_users TO users');
+        $this->addSql('RENAME TABLE virtual_vouchers TO vouchers');
+
+        // Rename auto-generated indexes to match new table names
+        $this->addSql('ALTER TABLE aliases RENAME INDEX idx_696568f6115f0ee5 TO IDX_5F12BB39115F0EE5');
+        $this->addSql('ALTER TABLE aliases RENAME INDEX idx_696568f6a76ed395 TO IDX_5F12BB39A76ED395');
+        $this->addSql('ALTER TABLE domains RENAME INDEX uniq_ba0c6c525e237e06 TO UNIQ_8C7BBF9D5E237E06');
+        $this->addSql('ALTER TABLE openpgp_keys RENAME INDEX uniq_3db259eae7927c74 TO UNIQ_BAB4DF37E7927C74');
+        $this->addSql('ALTER TABLE openpgp_keys RENAME INDEX idx_3db259eaa76ed395 TO IDX_BAB4DF37A76ED395');
+        $this->addSql('ALTER TABLE reserved_names RENAME INDEX uniq_d44239f15e237e06 TO UNIQ_E40F23B05E237E06');
+        $this->addSql('ALTER TABLE users RENAME INDEX uniq_3c68956ae7927c74 TO UNIQ_1483A5E9E7927C74');
+        $this->addSql('ALTER TABLE users RENAME INDEX idx_3c68956a115f0ee5 TO IDX_1483A5E9115F0EE5');
+        $this->addSql('ALTER TABLE users RENAME INDEX uniq_3c68956ab29b3622 TO UNIQ_1483A5E9B29B3622');
+        $this->addSql('ALTER TABLE vouchers RENAME INDEX uniq_98f8afba77153098 TO UNIQ_9315074877153098');
+        $this->addSql('ALTER TABLE vouchers RENAME INDEX idx_98f8afbaa76ed395 TO IDX_93150748A76ED395');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Restore original auto-generated index names before renaming tables
+        $this->addSql('ALTER TABLE aliases RENAME INDEX IDX_5F12BB39115F0EE5 TO idx_696568f6115f0ee5');
+        $this->addSql('ALTER TABLE aliases RENAME INDEX IDX_5F12BB39A76ED395 TO idx_696568f6a76ed395');
+        $this->addSql('ALTER TABLE domains RENAME INDEX UNIQ_8C7BBF9D5E237E06 TO uniq_ba0c6c525e237e06');
+        $this->addSql('ALTER TABLE openpgp_keys RENAME INDEX UNIQ_BAB4DF37E7927C74 TO uniq_3db259eae7927c74');
+        $this->addSql('ALTER TABLE openpgp_keys RENAME INDEX IDX_BAB4DF37A76ED395 TO idx_3db259eaa76ed395');
+        $this->addSql('ALTER TABLE reserved_names RENAME INDEX UNIQ_E40F23B05E237E06 TO uniq_d44239f15e237e06');
+        $this->addSql('ALTER TABLE users RENAME INDEX UNIQ_1483A5E9E7927C74 TO uniq_3c68956ae7927c74');
+        $this->addSql('ALTER TABLE users RENAME INDEX IDX_1483A5E9115F0EE5 TO idx_3c68956a115f0ee5');
+        $this->addSql('ALTER TABLE users RENAME INDEX UNIQ_1483A5E9B29B3622 TO uniq_3c68956ab29b3622');
+        $this->addSql('ALTER TABLE vouchers RENAME INDEX UNIQ_9315074877153098 TO uniq_98f8afba77153098');
+        $this->addSql('ALTER TABLE vouchers RENAME INDEX IDX_93150748A76ED395 TO idx_98f8afbaa76ed395');
+
+        $this->addSql('RENAME TABLE aliases TO virtual_aliases');
+        $this->addSql('RENAME TABLE domains TO virtual_domains');
+        $this->addSql('RENAME TABLE openpgp_keys TO virtual_openpgp_keys');
+        $this->addSql('RENAME TABLE reserved_names TO virtual_reserved_names');
+        $this->addSql('RENAME TABLE users TO virtual_users');
+        $this->addSql('RENAME TABLE vouchers TO virtual_vouchers');
+    }
+}

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -22,7 +22,7 @@ use Stringable;
 
 #[ORM\Entity(repositoryClass: AliasRepository::class)]
 #[ORM\AssociationOverrides([new AssociationOverride(name: 'domain', joinColumns: new ORM\JoinColumn(nullable: true))])]
-#[ORM\Table(name: 'virtual_aliases')]
+#[ORM\Table(name: 'aliases')]
 #[Index(columns: ['source', 'deleted'], name: 'source_deleted_idx')]
 #[Index(columns: ['destination', 'deleted'], name: 'destination_deleted_idx')]
 #[Index(columns: ['user_id', 'deleted'], name: 'user_deleted_idx')]

--- a/src/Entity/Domain.php
+++ b/src/Entity/Domain.php
@@ -15,7 +15,7 @@ use Override;
 use Stringable;
 
 #[ORM\Entity(repositoryClass: DomainRepository::class)]
-#[ORM\Table(name: 'virtual_domains')]
+#[ORM\Table(name: 'domains')]
 class Domain implements UpdatedTimeInterface, Stringable
 {
     use CreationTimeTrait;

--- a/src/Entity/OpenPgpKey.php
+++ b/src/Entity/OpenPgpKey.php
@@ -11,7 +11,7 @@ use App\Traits\OpenPgpKeyTrait;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: OpenPgpKeyRepository::class)]
-#[ORM\Table(name: 'virtual_openpgp_keys')]
+#[ORM\Table(name: 'openpgp_keys')]
 #[ORM\Index(name: 'idx_wkd_hash', columns: ['wkd_hash'])]
 class OpenPgpKey
 {

--- a/src/Entity/ReservedName.php
+++ b/src/Entity/ReservedName.php
@@ -15,7 +15,7 @@ use Override;
 use Stringable;
 
 #[ORM\Entity(repositoryClass: ReservedNameRepository::class)]
-#[ORM\Table(name: 'virtual_reserved_names')]
+#[ORM\Table(name: 'reserved_names')]
 class ReservedName implements UpdatedTimeInterface, Stringable
 {
     use CreationTimeTrait;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -42,7 +42,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
-#[ORM\Table(name: 'virtual_users')]
+#[ORM\Table(name: 'users')]
 #[Index(columns: ['email'], name: 'email_idx')]
 #[Index(columns: ['creation_time'], name: 'creation_time_idx')]
 #[Index(columns: ['deleted'], name: 'deleted_idx')]

--- a/src/Entity/Voucher.php
+++ b/src/Entity/Voucher.php
@@ -15,7 +15,7 @@ use Override;
 use Stringable;
 
 #[ORM\Entity(repositoryClass: VoucherRepository::class)]
-#[ORM\Table(name: 'virtual_vouchers')]
+#[ORM\Table(name: 'vouchers')]
 #[Index(columns: ['code'], name: 'code_idx')]
 class Voucher implements Stringable
 {


### PR DESCRIPTION
## Summary

- Remove the legacy `virtual_` prefix from 6 database tables to follow a consistent plural naming convention (`virtual_aliases` → `aliases`, `virtual_domains` → `domains`, `virtual_openpgp_keys` → `openpgp_keys`, `virtual_reserved_names` → `reserved_names`, `virtual_users` → `users`, `virtual_vouchers` → `vouchers`)
- Add a Doctrine migration that renames the tables and their auto-generated indexes, with a fully reversible `down()` method
- Update entity `#[ORM\Table]` attributes and active documentation references

## Details

The `virtual_` prefix is a legacy artifact from the original Postfix virtual mailbox setup. The 5 newer tables (`settings`, `api_tokens`, `user_notifications`, `webhook_endpoints`, `webhook_deliveries`) already use plain plural names. This change brings the older tables in line.

### What changed
- **6 Entity classes**: Updated `#[ORM\Table(name: '...')]` attribute
- **1 new Migration** (`Version20260217000000`): `RENAME TABLE` + `RENAME INDEX` for all affected tables, fully reversible
- **Documentation** (`docs/features/mail_crypt.md`): Updated active SQL examples and table references

### What was NOT changed
- **Existing migrations**: Kept as-is since they are historical snapshots
- **CHANGELOG.md / UPGRADE.md**: Historical references left unchanged
- **Application code** (`src/`): No changes needed — all queries use Doctrine ORM/DQL, no hardcoded table names

### Validated with
- `doctrine:migrations:migrate` (from scratch) — all 8 migrations pass
- `doctrine:schema:validate` — mapping and DB schema in sync
- Migration rollback (`--down`) and re-apply (`--up`) — both succeed
- `composer psalm` — no errors
- `composer cs-check` — no new issues

---
<sub>The changes and the PR were generated by OpenCode.</sub>