### PR TITLE
♻️ Replace Criteria API with QueryBuilder in VoucherRepository and VoucherRemover

### DIFF
--- a/src/Remover/VoucherRemover.php
+++ b/src/Remover/VoucherRemover.php
@@ -6,7 +6,6 @@ namespace App\Remover;
 
 use App\Entity\User;
 use App\Entity\Voucher;
-use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -28,14 +27,12 @@ final readonly class VoucherRemover
 
     public function removeUnredeemedVouchersByUsers(array $users): void
     {
-        $criteria = Criteria::create()
-            ->where(Criteria::expr()->isNull('redeemedTime'))
-            ->andWhere(Criteria::expr()->in('user', $users));
-
         $this->manager->getRepository(Voucher::class)
-            ->createQueryBuilder('a')
-            ->addCriteria($criteria)
+            ->createQueryBuilder('v')
             ->delete()
+            ->where('v.redeemedTime IS NULL')
+            ->andWhere('v.user IN (:users)')
+            ->setParameter('users', $users)
             ->getQuery()
             ->execute();
     }


### PR DESCRIPTION
## Summary

- Replace `Criteria::create()` with native Doctrine QueryBuilder queries in `VoucherRepository` and `VoucherRemover`
- Fix `doctrine/collections` deprecation about raw field value access (`Criteria.php:78`, [doctrine/collections#472](https://github.com/doctrine/collections/pull/472))
- Improve query efficiency: count methods now use `SELECT COUNT()` in SQL instead of loading all entities into memory and counting in PHP via `->matching()->count()`

## Changes

**`src/Repository/VoucherRepository.php`**
- `countRedeemedVouchers()`: QueryBuilder with `COUNT(v.id)` instead of `matching()->count()`
- `countUnredeemedVouchers()`: QueryBuilder with `COUNT(v.id)` instead of `matching()->count()`
- `countVouchersByUser()`: QueryBuilder with `COUNT(v.id)` instead of `matching()->count()`

**`src/Remover/VoucherRemover.php`**
- `removeUnredeemedVouchersByUsers()`: Direct QueryBuilder `delete()` instead of Criteria + `addCriteria()`

Both files no longer import `Doctrine\Common\Collections\Criteria`.

---
<sub>The changes and the PR were generated by OpenCode.</sub>