### PR TITLE
🐛 Fix release build to include bundle assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ build: clean prepare
 		composer install --no-dev --ignore-platform-reqs --no-scripts; \
 	APP_ENV=prod ${SQLITE_DB_URL} \
 		composer dump-autoload; \
+	APP_ENV=prod ${SQLITE_DB_URL} \
+		bin/console assets:install --no-interaction; \
 	yarn --pure-lockfile; \
 	yarn encore production
 


### PR DESCRIPTION
## Summary

- Add `bin/console assets:install` to the `build` target in the Makefile
- Ensures that assets from Symfony bundles (e.g. Symfony UX, Sonata) are included in the release artifact
- Previously, bundle assets were missing from the release build because `assets:install` was never executed

---
<sub>The changes and the PR were generated by OpenCode.</sub>