### PR TITLE
🐛 Fix untranslated voucher-invalid flash message

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -265,6 +265,7 @@ flashes:
   recovery-next-login: Du kannst dich nun einloggen.
   openpgp-deletion-successful: Dein OpenPGP-Schlüssel wurde gelöscht.
   openpgp-key-upload-successful: Dein OpenPGP-Schlüssel wurde hochgeladen.
+  voucher-invalid: Der Einladungscode ist ungültig.
   openpgp-key-upload-error-no-openpgp: Die hochgadene Datei enthält keine OpenPGP-Schlüssel.
   openpgp-key-upload-error-no-keys: Die hochgeladene Datei enthält keine Schlüssel für deine E-Mail-Adresse.
   openpgp-key-upload-error-multiple-keys: Die hochgeladene Datei enhält mehr als einen Schlüssel für deine E-Mail-Adresse. Bitte lade nur einen Schlüssel hoch.

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -271,6 +271,7 @@ flashes:
   openpgp-key-upload-successful: Your OpenPGP key got uploaded.
   openpgp-key-upload-error-no-openpgp: The uploaded file doesn't contain OpenPGP data.
   openpgp-key-upload-error-no-keys: No keys for your mail address found in uploaded data.
+  voucher-invalid: The invite code is invalid.
   openpgp-key-upload-error-multiple-keys: More than one key for your mail address found in uploaded data. Please upload only one key.
 flash_batch_remove_vouchers_success: Unredeemed invite codes deleted.
 error:

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -50,7 +50,7 @@ final class RegistrationController extends AbstractController
 
         // Validate voucher before showing the registration form
         if (!$this->isVoucherValid($voucher)) {
-            $this->addFlash('error', 'registration.voucher-invalid');
+            $this->addFlash('error', 'flashes.voucher-invalid');
 
             return $this->redirectToRoute('index');
         }


### PR DESCRIPTION
## Summary

- Fix the `registration.voucher-invalid` flash message not being translated when displayed to users
- The flash message used a translation key from the `validators` domain, but the `_flashes.html.twig` template uses `|trans` without a domain (defaults to `messages`)
- Renamed the flash key to `flashes.voucher-invalid` (consistent with all other flash messages) and added translations to the EN and DE `messages` files

The validator translation key `registration.voucher-invalid` in the `validators` domain remains unchanged, as it is still used by `VoucherExistsValidator`.

---
<sub>The changes and the PR were generated by OpenCode.</sub>