### PR TITLE
AliasAdmin: Relax EmailAddress() constraint

### DIFF
--- a/src/Admin/AliasAdmin.php
+++ b/src/Admin/AliasAdmin.php
@@ -47,7 +47,8 @@ final class AliasAdmin extends Admin
                     new Assert\NotNull(),
                     new Assert\Email(mode: 'strict'),
                     new Lowercase(),
-                    new EmailAddress(),
+                    // Admin is allowed to create Aliases for already existing sources
+                    new EmailAddress(exists: false),
                 ] : [],
             ])
             ->add('user', ModelAutocompleteType::class, ['property' => 'email', 'required' => false])

--- a/src/Validator/EmailAddress.php
+++ b/src/Validator/EmailAddress.php
@@ -10,4 +10,8 @@ use Symfony\Component\Validator\Constraint;
 #[Attribute]
 final class EmailAddress extends Constraint
 {
+    public function __construct(public bool $exists = true, ?array $groups = null, mixed $payload = null)
+    {
+        parent::__construct(groups: $groups, payload: $payload);
+    }
 }

--- a/src/Validator/EmailAddressValidator.php
+++ b/src/Validator/EmailAddressValidator.php
@@ -36,12 +36,15 @@ final class EmailAddressValidator extends ConstraintValidator
         }
 
         [$localPart, $domain] = explode('@', $value);
-        $user = $this->manager->getRepository(User::class)->findOneBy(['email' => $value]);
-        $alias = $this->manager->getRepository(Alias::class)->findOneBySource($value, true);
-        $reservedName = $this->manager->getRepository(ReservedName::class)->findByName($localPart);
 
-        if (null !== $user || null !== $alias || null !== $reservedName) {
-            $this->context->addViolation('registration.email-already-taken');
+        if ($constraint->exists) {
+            $user = $this->manager->getRepository(User::class)->findOneBy(['email' => $value]);
+            $alias = $this->manager->getRepository(Alias::class)->findOneBySource($value, true);
+            $reservedName = $this->manager->getRepository(ReservedName::class)->findByName($localPart);
+
+            if (null !== $user || null !== $alias || null !== $reservedName) {
+                $this->context->addViolation('registration.email-already-taken');
+            }
         }
 
         if (1 !== preg_match('/^[a-z0-9\-_.]*$/ui', $localPart)) {

--- a/tests/Validator/EmailAddressValidatorTest.php
+++ b/tests/Validator/EmailAddressValidatorTest.php
@@ -132,4 +132,20 @@ class EmailAddressValidatorTest extends ConstraintValidatorTestCase
             ['reserved@example.org', 'registration.email-already-taken'],
         ];
     }
+
+    #[DataProvider('getUsedAddressesNotExists')]
+    public function testValidateUsedEmailAddressWithoutExists(string $address): void
+    {
+        $this->validator->validate($address, new EmailAddress(exists: false));
+        self::assertNoViolation();
+    }
+
+    public static function getUsedAddressesNotExists(): array
+    {
+        return [
+            ['user@example.org'],
+            ['alias@example.org'],
+            ['reserved@example.org'],
+        ];
+    }
 }


### PR DESCRIPTION
Admins should be allowed to create Aliases with existing sources.

Fixes regression in #1002 