### PR TITLE
💄 Return cross-domain, but no random aliases in RoundcubeController

### DIFF
--- a/src/Controller/RoundcubeController.php
+++ b/src/Controller/RoundcubeController.php
@@ -35,7 +35,8 @@ final class RoundcubeController extends AbstractController
             throw new AuthenticationException('Bad credentials', 401);
         }
 
-        $aliases = $this->manager->getRepository(Alias::class)->findByUser($user);
+        // Fetch all non random aliases for user, disabling domain filter.
+        $aliases = $this->manager->getRepository(Alias::class)->findByUser($user, false, true);
         $aliasSources = array_map(static fn ($alias) => $alias->getSource(), $aliases);
 
         return $this->json($aliasSources);


### PR DESCRIPTION
Disable domain filter, fixes #737

Do not return random aliases. I don't see a use case for random aliases as a sender address and it makes Roundcube hard to use with >20 aliases