### PR TITLE
🐛 Fix misleading Prometheus exporter label for user count

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ The `WEBMAIL_URL` environment variable has been removed. The webmail URL is now 
 
 If you previously had `WEBMAIL_URL` set, you need to configure it manually in the settings after upgrading.
 
+### Prometheus metrics changes
+
+The `userli_users_total` metric now includes both active and deleted users. Previously, it only counted active users. A new `userli_users_active_total` metric has been added to report the number of active users separately. If you have dashboards or alerts based on `userli_users_total`, update them accordingly.
+
 ## Upgrade to 6.0.0
 
 ### PHP 8.4 Required

--- a/src/Command/MetricsCommand.php
+++ b/src/Command/MetricsCommand.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Command;
 
-use App\Entity\Alias;
-use App\Entity\Domain;
-use App\Entity\OpenPgpKey;
-use App\Entity\User;
-use App\Entity\Voucher;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Repository\AliasRepository;
+use App\Repository\DomainRepository;
+use App\Repository\OpenPgpKeyRepository;
+use App\Repository\UserRepository;
+use App\Repository\VoucherRepository;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -29,16 +28,21 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:metrics', description: 'Global Metrics for Userli')]
 final class MetricsCommand extends Command
 {
-    public function __construct(private readonly EntityManagerInterface $manager)
-    {
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly VoucherRepository $voucherRepository,
+        private readonly DomainRepository $domainRepository,
+        private readonly AliasRepository $aliasRepository,
+        private readonly OpenPgpKeyRepository $openPgpKeyRepository,
+    ) {
         parent::__construct();
     }
 
     #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $activeUsersTotal = $this->manager->getRepository(User::class)->countUsers();
-        $deletedUsersTotal = $this->manager->getRepository(User::class)->countDeletedUsers();
+        $activeUsersTotal = $this->userRepository->countUsers();
+        $deletedUsersTotal = $this->userRepository->countDeletedUsers();
         $usersTotal = $activeUsersTotal + $deletedUsersTotal;
 
         $output->writeln('# HELP userli_users_total Total number of users');
@@ -53,39 +57,39 @@ final class MetricsCommand extends Command
         $output->writeln('# TYPE userli_users_deleted_total gauge');
         $output->writeln('userli_users_deleted_total '.$deletedUsersTotal);
 
-        $usersRecoveryTokenTotal = $this->manager->getRepository(User::class)->countUsersWithRecoveryToken();
+        $usersRecoveryTokenTotal = $this->userRepository->countUsersWithRecoveryToken();
         $output->writeln('# HELP userli_users_recovery_token_total Total number of users with recovery token');
         $output->writeln('# TYPE userli_users_recovery_token_total gauge');
         $output->writeln('userli_users_recovery_token_total '.$usersRecoveryTokenTotal);
 
-        $usersMailCryptTotal = $this->manager->getRepository(User::class)->countUsersWithMailCrypt();
+        $usersMailCryptTotal = $this->userRepository->countUsersWithMailCrypt();
         $output->writeln('# HELP userli_users_mailcrypt_total Total number of users with enabled mailcrypt');
         $output->writeln('# TYPE userli_users_mailcrypt_total gauge');
         $output->writeln('userli_users_mailcrypt_total '.$usersMailCryptTotal);
 
-        $usersTwofactorTotal = $this->manager->getRepository(User::class)->countUsersWithTwofactor();
+        $usersTwofactorTotal = $this->userRepository->countUsersWithTwofactor();
         $output->writeln('# HELP userli_users_twofactor_total Total number of users with enabled two factor authentication');
         $output->writeln('# TYPE userli_users_twofactor_total gauge');
         $output->writeln('userli_users_twofactor_total '.$usersTwofactorTotal);
 
-        $redeemedVouchersTotal = $this->manager->getRepository(Voucher::class)->countRedeemedVouchers();
-        $unredeemedVouchersTotal = $this->manager->getRepository(Voucher::class)->countUnredeemedVouchers();
+        $redeemedVouchersTotal = $this->voucherRepository->countRedeemedVouchers();
+        $unredeemedVouchersTotal = $this->voucherRepository->countUnredeemedVouchers();
         $output->writeln('# HELP userli_vouchers_total Total number of vouchers');
         $output->writeln('# TYPE userli_vouchers_total gauge');
         $output->writeln('userli_vouchers_total{type="unredeemed"} '.$unredeemedVouchersTotal);
         $output->writeln('userli_vouchers_total{type="redeemed"} '.$redeemedVouchersTotal);
 
-        $domainsTotal = $this->manager->getRepository(Domain::class)->count([]);
+        $domainsTotal = $this->domainRepository->count([]);
         $output->writeln('# HELP userli_domains_total Total number of domains');
         $output->writeln('# TYPE userli_domains_total gauge');
         $output->writeln('userli_domains_total '.$domainsTotal);
 
-        $aliasesTotal = $this->manager->getRepository(Alias::class)->count(['deleted' => false]);
+        $aliasesTotal = $this->aliasRepository->count(['deleted' => false]);
         $output->writeln('# HELP userli_aliases_total Total number of aliases');
         $output->writeln('# TYPE userli_aliases_total gauge');
         $output->writeln('userli_aliases_total '.$aliasesTotal);
 
-        $openPgpKeysTotal = $this->manager->getRepository(OpenPgpKey::class)->countKeys();
+        $openPgpKeysTotal = $this->openPgpKeyRepository->countKeys();
         $output->writeln('# HELP userli_openpgpkeys_total Total number of OpenPGP keys');
         $output->writeln('# TYPE userli_openpgpkeys_total gauge');
         $output->writeln('userli_openpgpkeys_total '.$openPgpKeysTotal);

--- a/tests/Command/MetricsCommandTest.php
+++ b/tests/Command/MetricsCommandTest.php
@@ -5,17 +5,11 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\MetricsCommand;
-use App\Entity\Alias;
-use App\Entity\Domain;
-use App\Entity\OpenPgpKey;
-use App\Entity\User;
-use App\Entity\Voucher;
 use App\Repository\AliasRepository;
 use App\Repository\DomainRepository;
 use App\Repository\OpenPgpKeyRepository;
 use App\Repository\UserRepository;
 use App\Repository\VoucherRepository;
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -43,16 +37,7 @@ class MetricsCommandTest extends TestCase
         $voucherRepository->method('countRedeemedVouchers')->willReturn(1);
         $voucherRepository->method('countUnredeemedVouchers')->willReturn(7);
 
-        $manager = $this->createStub(EntityManagerInterface::class);
-        $manager->method('getRepository')->willReturnMap([
-            [User::class, $userRepository],
-            [OpenPgpKey::class, $openPgpKeyRepository],
-            [Alias::class, $aliasRepository],
-            [Domain::class, $domainRepository],
-            [Voucher::class, $voucherRepository],
-        ]);
-
-        $command = new MetricsCommand($manager);
+        $command = new MetricsCommand($userRepository, $voucherRepository, $domainRepository, $aliasRepository, $openPgpKeyRepository);
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);


### PR DESCRIPTION
Fix userli_users_total to actually report total user count (deleted+active users) 
Add userli_users_active_total metric

Bit unnecessary to have all three (active, deleted, total), as one could add and substract wherever one processes these metrics, but seems the best solution to preserver backwards compatibility (for example for grafana dashboards)

Closes #713