### PR TITLE
⬆️ Add Gitmoji prefix to Dependabot commit messages and PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "⬆️"
+      include: "scope"
     groups:
       npm-dependencies:
         patterns:
@@ -14,6 +17,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "⬆️"
+      include: "scope"
     allow:
       - dependency-name: "endroid/qr-code"
       - dependency-name: "ircmaxell/password-compat"
@@ -33,3 +39,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "⬆️"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Adds `commit-message` configuration to all three Dependabot update blocks (`npm`, `composer`, `github-actions`)
- Uses `⬆️` as prefix with `scope` included, so commits and PR titles follow the project's Gitmoji convention

## Example output

- `⬆️(npm): bump webpack from 5.90 to 5.91`
- `⬆️(composer): bump sonata-project/admin-bundle from 4.30 to 4.31`
- `⬆️(github-actions): bump actions/checkout from 4 to 5`

---
<sub>The changes and the PR were generated by OpenCode.</sub>