### PR TITLE
👷 Improve Dependabot grouping for Composer and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,18 +20,34 @@ updates:
     commit-message:
       prefix: "⬆️"
       include: "scope"
-    allow:
-      - dependency-name: "endroid/qr-code"
-      - dependency-name: "ircmaxell/password-compat"
-      - dependency-name: "nelmio/security-bundle"
-      - dependency-name: "pear/crypt_gpg"
-      - dependency-name: "ramsey/uuid"
-      - dependency-name: "scheb/*"
-      - dependency-name: "sonata-project/*"
-      - dependency-name: "tuupola/base32"
-      - dependency-name: "friends-of-behat/*"
     groups:
-      php-dependencies:
+      symfony:
+        patterns:
+          - "symfony/*"
+      doctrine:
+        patterns:
+          - "doctrine/*"
+      scheb:
+        patterns:
+          - "scheb/*"
+      sonata:
+        patterns:
+          - "sonata-project/*"
+      twig:
+        patterns:
+          - "twig/*"
+      php-dev-tools:
+        patterns:
+          - "friendsofphp/*"
+          - "vimeo/psalm"
+          - "psalm/*"
+          - "rector/*"
+      behat:
+        patterns:
+          - "behat/*"
+          - "friends-of-behat/*"
+          - "dvdoug/behat-code-coverage"
+      php-other:
         patterns:
           - "*"
 
@@ -42,3 +58,7 @@ updates:
     commit-message:
       prefix: "⬆️"
       include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Remove the restrictive `allow`-list for Composer dependencies that prevented Dependabot from updating Symfony, Doctrine, Twig, PHPUnit, and most other dependencies
- Replace the single `php-dependencies` catch-all group with granular groups: `symfony`, `doctrine`, `scheb`, `sonata`, `twig`, `php-dev-tools`, `behat`, and `php-other`
- Add a catch-all group for GitHub Actions so all action updates land in a single PR
- Remove the obsolete `ircmaxell/password-compat` entry (no longer a dependency)

This ensures all dependencies are covered by Dependabot while keeping the number of PRs manageable through sensible grouping.

---
<sub>The changes and the PR were generated by OpenCode.</sub>