### PR TITLE
🔧 Fix Dependabot commit prefix spacing and ignore Symfony >= 8.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "⬆️"
+      prefix: "⬆️ "
       include: "scope"
     groups:
       npm-dependencies:
@@ -18,8 +18,11 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "⬆️"
+      prefix: "⬆️ "
       include: "scope"
+    ignore:
+      - dependency-name: "symfony/*"
+        versions: [">= 8.0"]
     groups:
       symfony:
         patterns:
@@ -56,7 +59,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "⬆️"
+      prefix: "⬆️ "
       include: "scope"
     groups:
       github-actions:


### PR DESCRIPTION
## Summary

- Add a space after the Gitmoji prefix (`⬆️ `) in Dependabot commit messages for all three ecosystems (npm, composer, github-actions)
- Ignore Symfony packages >= 8.0 to restrict updates to the 7.4.x line

---
<sub>The changes and the PR were generated by OpenCode.</sub>