### PR TITLE
🔥 Fix eraseCredentials() deprecation for Symfony 8.0 compatibility

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -43,5 +43,17 @@
                 <directory name="src/Entity" />
             </errorLevel>
         </ClassMustBeFinal>
+
+        <!--
+            MissingOverrideAttribute - eraseCredentials() deprecation
+            ==========================================================
+            UserInterface::eraseCredentials() was removed in Symfony 8.0, so
+            #[Override] cannot be used without breaking forward-compatibility.
+        -->
+        <MissingOverrideAttribute>
+            <errorLevel type="suppress">
+                <file name="src/Entity/User.php" />
+            </errorLevel>
+        </MissingOverrideAttribute>
     </issueHandlers>
 </psalm>

--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -112,7 +112,7 @@ final class AccountController extends AbstractController
             }
 
             $user->setPasswordChangeRequired(false);
-            $user->eraseCredentials();
+            $user->clearSensitiveData();
 
             $this->manager->flush();
 
@@ -215,7 +215,7 @@ final class AccountController extends AbstractController
             }
 
             // Clear sensitive plaintext data from User object
-            $user->eraseCredentials();
+            $user->clearSensitiveData();
 
             return $this->redirectToRoute('account_recovery_token_confirm', ['recovery_token' => $recoveryToken]);
         }

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -126,7 +126,7 @@ final class RegistrationController extends AbstractController
         $recoveryToken = $user->getPlainRecoveryToken();
         // We have fetched plainRecoveryToken, which we need to show and can now remove
         // all sensitive values from the user object
-        $user->eraseCredentials();
+        $user->clearSensitiveData();
 
         $recoveryTokenAck = new RecoveryTokenConfirm();
         $recoveryTokenAck->setRecoveryToken($recoveryToken);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -29,6 +29,7 @@ use App\Traits\TwofactorBackupCodeTrait;
 use App\Traits\TwofactorTrait;
 use App\Traits\UpdatedTimeTrait;
 use DateTimeImmutable;
+use Deprecated;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -144,10 +145,16 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Passwor
         return null;
     }
 
-    #[Override]
+    #[Deprecated(since: 'symfony/security-core 7.3')]
     public function eraseCredentials(): void
     {
-        // If you store any temporary, sensitive data on the user, clear it here
+    }
+
+    /**
+     * Removes sensitive plaintext data from the user object.
+     */
+    public function clearSensitiveData(): void
+    {
         $this->erasePlainMailCryptPrivateKey();
         $this->erasePlainRecoveryToken();
     }

--- a/src/Handler/RecoveryHandler.php
+++ b/src/Handler/RecoveryHandler.php
@@ -112,7 +112,7 @@ final readonly class RecoveryHandler
         $user->setTotpBackupCodes([]);
 
         // Clear sensitive plaintext data from User object
-        $user->eraseCredentials();
+        $user->clearSensitiveData();
         sodium_memzero($mailCryptPrivateKey);
 
         $this->manager->flush();

--- a/src/Service/UserResetService.php
+++ b/src/Service/UserResetService.php
@@ -56,7 +56,7 @@ final readonly class UserResetService
         $user->setTotpBackupCodes([]);
 
         // Clear sensitive plaintext data from User object
-        $user->eraseCredentials();
+        $user->clearSensitiveData();
 
         $this->manager->flush();
 


### PR DESCRIPTION
## Summary

- Replace all `eraseCredentials()` calls with a new `clearSensitiveData()` method that holds the actual logic for clearing sensitive plaintext data (`plainMailCryptPrivateKey`, `plainRecoveryToken`)
- Mark `eraseCredentials()` as deprecated (empty body) with PHP 8.4 `#[Deprecated]` attribute, matching Symfony's own approach
- Remove `#[Override]` from `eraseCredentials()` to fix the fatal error when Symfony 8.0 removes the method from `UserInterface`
- Suppress Psalm's `MissingOverrideAttribute` for `User.php` since `#[Override]` cannot be used without breaking forward-compatibility with Symfony 8.0

This fixes the CI failure in #1098 where `bin/console cache:warmup` crashes with:
```
PHP Fatal error: App\Entity\User::eraseCredentials() has #[\Override] attribute,
but no matching parent method exists
```

## Changed files

- `src/Entity/User.php` — deprecated empty `eraseCredentials()`, new `clearSensitiveData()`
- `src/Controller/AccountController.php` — migrate to `clearSensitiveData()`
- `src/Controller/RegistrationController.php` — migrate to `clearSensitiveData()`
- `src/Handler/RecoveryHandler.php` — migrate to `clearSensitiveData()`
- `src/Service/UserResetService.php` — migrate to `clearSensitiveData()`
- `psalm.xml` — suppress `MissingOverrideAttribute` for `User.php`

---
<sub>The changes and the PR were generated by OpenCode.</sub>