### PR TITLE
🔧 Ignore symfony/monolog-bundle >= 4.0 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
     ignore:
       - dependency-name: "symfony/*"
         versions: [">= 8.0"]
+      - dependency-name: "symfony/monolog-bundle"
+        versions: [">= 4.0"]
     groups:
       symfony:
         patterns:


### PR DESCRIPTION
## Summary

- Add Dependabot ignore rule for `symfony/monolog-bundle >= 4.0`

## Motivation

`symfony/monolog-bundle` follows its own versioning scheme (not Symfony core versioning). Version 4.0 requires Symfony 8 as a dependency. The existing ignore rule `symfony/* >= 8.0` does not cover monolog-bundle because its version is `4.0.1`, not `8.0`.

This caused Dependabot to propose upgrading monolog-bundle from `^3.8.0` to `^4.0.1` in #1104, which pulled in ~19 Symfony 8 packages as transitive dependencies — despite the `^7.4` constraints we added in #1103.

---
<sub>The changes and the PR were generated by OpenCode.</sub>