### PR TITLE
🐛 Allow composer-diff plugin in global Composer config

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Generate update summary
         run: |
+          composer global config allow-plugins.ion-bazan/composer-diff true
           composer global require ion-bazan/composer-diff
           {
             echo "## Composer Update Summary"


### PR DESCRIPTION
## Summary

- Adds `composer global config allow-plugins.ion-bazan/composer-diff true` before installing the plugin in the `composer-update` workflow

## Why

The `ion-bazan/composer-diff` Composer plugin is blocked by Composer's default `allow-plugins` policy. The "Generate update summary" step in the `composer-update` workflow fails with:

```
ion-bazan/composer-diff (installed globally) contains a Composer plugin
which is blocked by your allow-plugins config.
```

See failed run: https://github.com/systemli/userli/actions/runs/22524432426/job/65254182874

---
<sub>The changes and the PR were generated by OpenCode.</sub>