### PR TITLE
👷 Add concurrency group to Docker build job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,6 +75,9 @@ jobs:
     name: Build & Push Docker Image
     if: github.actor != 'dependabot[bot]'
     needs: test
+    concurrency:
+      group: docker-build-push
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Add a `concurrency` group (`docker-build-push`) with `cancel-in-progress: true` to the Docker build job in the integration workflow
- Since only the `latest` tag is pushed on `main`, parallel runs are redundant and waste CI resources
- When multiple pushes to `main` happen in quick succession, older in-progress Docker builds are now automatically cancelled

---
<sub>The changes and the PR were generated by OpenCode.</sub>