### PR TITLE
💄 Redesign settings navigation for responsiveness and scalability

### DIFF
--- a/templates/Settings/Api/create.html.twig
+++ b/templates/Settings/Api/create.html.twig
@@ -1,88 +1,73 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'api' %}
+{% extends 'Settings/base_settings.html.twig' %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 
 {% block title %}{{ setting('app_name') }} - {{ "settings.api.create.title"|trans }}{% endblock %}
 
-{% block page_title %}{{ "settings.title"|trans }}{% endblock %}
-
-{% block page_subtitle %}{{ "settings.subtitle"|trans }}{% endblock %}
-
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {# Settings Navigation #}
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'api'} %}
-
-        {# Form Container with centered, narrower width #}
-        <div class="max-w-2xl mx-auto">
-            {# Main form card #}
-            <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-                <div class="p-6 sm:p-8">
-                    <div class="flex items-center mb-6">
-                        <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/50 rounded-xl flex items-center justify-center mr-4">
-                            <!-- heroicons:plus -->
-                            {{ ux_icon('heroicons:plus', {class: 'w-6 h-6 text-blue-600 dark:text-blue-400'}) }}
-                        </div>
-                        <div>
-                            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ "settings.api.create.form.title"|trans }}</h3>
-                            <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ "settings.api.create.form.description"|trans }}</p>
-                        </div>
-                    </div>
-
-                    {# Form #}
-                    {{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
-                    {{ form_errors(form) }}
-
-                    <div class="space-y-6">
-                        {# Token Name Field #}
-                        <div>
-                            {{ form_label(form.name, "settings.api.create.form.name.label"|trans, {
-                                'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}
-                            }) }}
-                            {{ form_errors(form.name) }}
-                            {{ form_widget(form.name, {
-                                'attr': {
-                                    'placeholder': 'settings.api.create.form.name.placeholder'|trans,
-                                    'class': 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors duration-200'
-                                }
-                            }) }}
-                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">{{ "settings.api.create.form.name.help"|trans }}</p>
-                        </div>
-
-                        {# Scopes Field #}
-                        <div>
-                            {{ form_label(form.scopes, "settings.api.create.form.scopes.label"|trans, {
-                                'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}
-                            }) }}
-                            {{ form_errors(form.scopes) }}
-                            {{ form_widget(form.scopes, {
-                                'attr': {
-                                    'class': 'w-full'
-                                }
-                            }) }}
-                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">{{ "settings.api.create.form.scopes.help"|trans }}</p>
-                        </div>
-
-                        {# Form Actions #}
-                        <div class="flex items-center justify-between pt-6">
-                            <a href="{{ path('settings_api_show') }}"
-                               class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                                <!-- heroicons:arrow-left -->
-                                {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
-                                {{ "settings.api.create.form.cancel"|trans }}
-                            </a>
-
-                            {{ form_widget(form.submit, {
-                                'label': 'settings.api.create.form.submit'|trans,
-                                'attr': {
-                                    'class': 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors duration-200'
-                                }
-                            }) }}
-                        </div>
-                    </div>
-                    {{ form_end(form) }}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            <div class="flex items-center mb-6">
+                <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/50 rounded-xl flex items-center justify-center mr-4">
+                    {{ ux_icon('heroicons:plus', {class: 'w-6 h-6 text-blue-600 dark:text-blue-400'}) }}
+                </div>
+                <div>
+                    <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ "settings.api.create.form.title"|trans }}</h3>
+                    <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ "settings.api.create.form.description"|trans }}</p>
                 </div>
             </div>
-        </div> {# End Form Container #}
+
+            {{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
+            {{ form_errors(form) }}
+
+            <div class="space-y-6">
+                {# Token Name Field #}
+                <div>
+                    {{ form_label(form.name, "settings.api.create.form.name.label"|trans, {
+                        'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}
+                    }) }}
+                    {{ form_errors(form.name) }}
+                    {{ form_widget(form.name, {
+                        'attr': {
+                            'placeholder': 'settings.api.create.form.name.placeholder'|trans,
+                            'class': 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors duration-200'
+                        }
+                    }) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">{{ "settings.api.create.form.name.help"|trans }}</p>
+                </div>
+
+                {# Scopes Field #}
+                <div>
+                    {{ form_label(form.scopes, "settings.api.create.form.scopes.label"|trans, {
+                        'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}
+                    }) }}
+                    {{ form_errors(form.scopes) }}
+                    {{ form_widget(form.scopes, {
+                        'attr': {
+                            'class': 'w-full'
+                        }
+                    }) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">{{ "settings.api.create.form.scopes.help"|trans }}</p>
+                </div>
+
+                {# Form Actions #}
+                <div class="flex items-center justify-between pt-6">
+                    <a href="{{ path('settings_api_show') }}"
+                       class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ "settings.api.create.form.cancel"|trans }}
+                    </a>
+
+                    {{ form_widget(form.submit, {
+                        'label': 'settings.api.create.form.submit'|trans,
+                        'attr': {
+                            'class': 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors duration-200'
+                        }
+                    }) }}
+                </div>
+            </div>
+            {{ form_end(form) }}
+        </div>
     </div>
 {% endblock %}

--- a/templates/Settings/Api/show.html.twig
+++ b/templates/Settings/Api/show.html.twig
@@ -1,118 +1,112 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'api' %}
+{% extends 'Settings/base_settings.html.twig' %}
 
 {% block title %}{{ setting('app_name') }} - {{ "settings.api.title"|trans }}{% endblock %}
 
-{% block page_title %}{{ "settings.title"|trans }}{% endblock %}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:key',
+                icon_color: 'blue',
+                heading_key: 'settings.api.table.title',
+                description_key: 'settings.api.table.description',
+            } %}
 
-{% block page_subtitle %}{{ "settings.subtitle"|trans }}{% endblock %}
-
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'api'} %}
-        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div class="p-6 sm:p-8">
-                {% include 'Settings/_section_header.html.twig' with {
-                    icon: 'heroicons:key',
-                    icon_color: 'blue',
-                    heading_key: 'settings.api.table.title',
-                    description_key: 'settings.api.table.description',
-                } %}
-
-                {% if newToken is defined and newToken is not null %}
-                    <div class="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg p-4 mb-6">
-                        <div class="flex items-center mb-3">
-                            {{ ux_icon('heroicons:check-circle', {class: 'w-5 h-5 text-green-600 dark:text-green-400 mr-2'}) }}
-                            <span class="text-sm font-medium text-green-800 dark:text-green-200">{{ "settings.api.created.title"|trans }}</span>
-                        </div>
-                        <div class="flex items-center bg-white dark:bg-gray-700 border border-green-200 dark:border-green-700 rounded-lg p-3"
-                             data-controller="clipboard">
-                            <pre data-clipboard-target="source" class="flex-1 text-sm font-mono text-gray-900 dark:text-gray-100 mr-3 whitespace-pre-wrap break-all">{{ newToken }}</pre>
-                            <button type="button"
-                                    data-controller="tooltip"
-                                    data-clipboard-target="button"
-                                    data-action="clipboard#copy"
-                                    title="{{ "copy-to-clipboard"|trans }}"
-                                    aria-label="{{ "copy-to-clipboard"|trans }}"
-                                    class="px-3 py-2 bg-green-600 dark:bg-green-500 text-white rounded hover:bg-green-700 dark:hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors flex-shrink-0">
-                                {{ ux_icon('heroicons:clipboard', {class: 'w-4 h-4'}) }}
-                            </button>
-                        </div>
+            {% if newToken is defined and newToken is not null %}
+                <div class="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg p-4 mb-6">
+                    <div class="flex items-center mb-3">
+                        {{ ux_icon('heroicons:check-circle', {class: 'w-5 h-5 text-green-600 dark:text-green-400 mr-2'}) }}
+                        <span class="text-sm font-medium text-green-800 dark:text-green-200">{{ "settings.api.created.title"|trans }}</span>
                     </div>
-                {% endif %}
-
-                <div class="mb-6">
-                    <a href="{{ path('settings_api_create') }}"
-                       class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                        {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
-                        {{ "settings.api.create.button"|trans }}
-                    </a>
+                    <div class="flex items-center bg-white dark:bg-gray-700 border border-green-200 dark:border-green-700 rounded-lg p-3"
+                         data-controller="clipboard">
+                        <pre data-clipboard-target="source" class="flex-1 text-sm font-mono text-gray-900 dark:text-gray-100 mr-3 whitespace-pre-wrap break-all">{{ newToken }}</pre>
+                        <button type="button"
+                                data-controller="tooltip"
+                                data-clipboard-target="button"
+                                data-action="clipboard#copy"
+                                title="{{ "copy-to-clipboard"|trans }}"
+                                aria-label="{{ "copy-to-clipboard"|trans }}"
+                                class="px-3 py-2 bg-green-600 dark:bg-green-500 text-white rounded hover:bg-green-700 dark:hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors flex-shrink-0">
+                            {{ ux_icon('heroicons:clipboard', {class: 'w-4 h-4'}) }}
+                        </button>
+                    </div>
                 </div>
+            {% endif %}
 
-                {% if tokens is empty %}
-                    {% include 'Settings/_empty_state.html.twig' with {
-                        icon: 'heroicons:key',
-                        title_key: 'settings.api.table.empty-title',
-                        description_key: 'settings.api.table.empty-description',
-                    } %}
-                {% else %}
-                    {% embed 'Settings/_table.html.twig' with {
-                        headers: [
-                            {label: 'settings.table.id'},
-                            {label: 'settings.table.name'},
-                            {label: 'settings.api.table.scopes'},
-                            {label: 'settings.table.created'},
-                            {label: 'settings.api.table.last-used'},
-                            {label: 'settings.table.actions', align: 'right'},
-                        ]
-                    } %}
-                        {% block table_body %}
-                            {% for token in tokens %}
-                                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
-                                        {{ token.id }}
-                                    </td>
-                                    <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ token.name|e }}</td>
-                                    <td class="px-6 py-4">
-                                        <div class="flex flex-wrap gap-1">
-                                            {% for scope in token.scopes %}
-                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200">
-                                                    {{ scope|e }}
-                                                </span>
-                                            {% endfor %}
-                                        </div>
-                                    </td>
-                                    <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
-                                        {{ token.creationTime|format_datetime('short', 'short') }}
-                                    </td>
-                                    <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
-                                        {% if token.lastUsedTime %}
-                                            {{ token.lastUsedTime|format_datetime('short', 'short') }}
-                                        {% else %}
-                                            <span class="text-gray-400 dark:text-gray-500 italic">{{ "settings.api.table.never-used"|trans }}</span>
-                                        {% endif %}
-                                    </td>
-                                    <td class="px-6 py-4 text-right">
-                                        <form method="POST"
-                                              action="{{ path('settings_api_delete', {'id': token.id}) }}"
-                                              data-controller="confirm"
-                                              data-confirm-message-value="{{ "settings.api.delete.confirm"|trans({'%name%': token.name}) }}"
-                                              data-action="submit->confirm#prompt">
-                                            <input type="hidden" name="_token" value="{{ csrf_token('delete_api_token_' ~ token.id) }}">
-                                            <button type="submit"
-                                                    title="{{ "settings.api.table.delete"|trans }}"
-                                                    data-controller="tooltip"
-                                                    class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
-                                                {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
-                                                <span class="sr-only">{{ "settings.api.table.delete"|trans }}</span>
-                                            </button>
-                                        </form>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        {% endblock %}
-                    {% endembed %}
-                {% endif %}
+            <div class="mb-6">
+                <a href="{{ path('settings_api_create') }}"
+                   class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                    {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
+                    {{ "settings.api.create.button"|trans }}
+                </a>
             </div>
+
+            {% if tokens is empty %}
+                {% include 'Settings/_empty_state.html.twig' with {
+                    icon: 'heroicons:key',
+                    title_key: 'settings.api.table.empty-title',
+                    description_key: 'settings.api.table.empty-description',
+                } %}
+            {% else %}
+                {% embed 'Settings/_table.html.twig' with {
+                    headers: [
+                        {label: 'settings.table.id'},
+                        {label: 'settings.table.name'},
+                        {label: 'settings.api.table.scopes'},
+                        {label: 'settings.table.created'},
+                        {label: 'settings.api.table.last-used'},
+                        {label: 'settings.table.actions', align: 'right'},
+                    ]
+                } %}
+                    {% block table_body %}
+                        {% for token in tokens %}
+                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+                                    {{ token.id }}
+                                </td>
+                                <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ token.name|e }}</td>
+                                <td class="px-6 py-4">
+                                    <div class="flex flex-wrap gap-1">
+                                        {% for scope in token.scopes %}
+                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200">
+                                                {{ scope|e }}
+                                            </span>
+                                        {% endfor %}
+                                    </div>
+                                </td>
+                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                    {{ token.creationTime|format_datetime('short', 'short') }}
+                                </td>
+                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                    {% if token.lastUsedTime %}
+                                        {{ token.lastUsedTime|format_datetime('short', 'short') }}
+                                    {% else %}
+                                        <span class="text-gray-400 dark:text-gray-500 italic">{{ "settings.api.table.never-used"|trans }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-6 py-4 text-right">
+                                    <form method="POST"
+                                          action="{{ path('settings_api_delete', {'id': token.id}) }}"
+                                          data-controller="confirm"
+                                          data-confirm-message-value="{{ "settings.api.delete.confirm"|trans({'%name%': token.name}) }}"
+                                          data-action="submit->confirm#prompt">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('delete_api_token_' ~ token.id) }}">
+                                        <button type="submit"
+                                                title="{{ "settings.api.table.delete"|trans }}"
+                                                data-controller="tooltip"
+                                                class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                            {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
+                                            <span class="sr-only">{{ "settings.api.table.delete"|trans }}</span>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endblock %}
+                {% endembed %}
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/Domain/index.html.twig
+++ b/templates/Settings/Domain/index.html.twig
@@ -1,93 +1,89 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'domains' %}
+{% extends 'Settings/base_settings.html.twig' %}
 {% block title %}{{ setting('app_name') }} - {{ 'settings.domain.title'|trans }}{% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'domains'} %}
-        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div class="p-6 sm:p-8">
-                {% include 'Settings/_section_header.html.twig' with {
-                    icon: 'heroicons:globe-alt',
-                    icon_color: 'indigo',
-                    heading_key: 'settings.domain.heading',
-                    description_key: 'settings.domain.description',
-                } %}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:globe-alt',
+                icon_color: 'indigo',
+                heading_key: 'settings.domain.heading',
+                description_key: 'settings.domain.description',
+            } %}
 
-                <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                    <div class="flex flex-wrap items-center gap-2">
-                        <a href="{{ path('settings_domain_create') }}"
-                           class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                            {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
-                            {{ 'settings.domain.create.button'|trans }}
-                        </a>
-                    </div>
-
-                    {% include 'Settings/_search_form.html.twig' with {
-                        index_route: 'settings_domain_index',
-                        placeholder_key: 'settings.domain.search.placeholder',
-                        submit_key: 'settings.domain.search.submit',
-                        search: search,
-                    } %}
+            <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                <div class="flex flex-wrap items-center gap-2">
+                    <a href="{{ path('settings_domain_create') }}"
+                       class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.domain.create.button'|trans }}
+                    </a>
                 </div>
 
-                {% if pagination.items is empty %}
-                    {% include 'Settings/_empty_state.html.twig' with {
-                        icon: 'heroicons:globe-alt',
-                        title_key: 'settings.domain.table.empty-title',
-                        description_key: 'settings.domain.table.empty-description',
-                    } %}
-                {% else %}
-                    {% embed 'Settings/_table.html.twig' with {
-                        headers: [
-                            {label: 'settings.table.id'},
-                            {label: 'settings.table.name'},
-                            {label: 'settings.table.created'},
-                            {label: 'settings.table.actions', align: 'right'},
-                        ]
-                    } %}
-                        {% block table_body %}
-                            {% for domain in pagination.items %}
-                                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ domain.id }}</td>
-                                    <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ domain.name }}</td>
-                                    <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
-                                        {{ domain.creationTime|format_datetime('short', 'short') }}
-                                    </td>
-                                    <td class="px-6 py-4 text-right">
-                                        <div class="inline-flex items-center gap-1">
-                                            <a href="{{ path('settings_domain_show', {id: domain.id}) }}"
-                                               title="{{ 'settings.domain.actions.show'|trans }}"
-                                               data-controller="tooltip"
-                                               class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
-                                                {{ ux_icon('heroicons:eye', {class: 'w-4 h-4'}) }}
-                                                <span class="sr-only">{{ 'settings.domain.actions.show'|trans }}</span>
-                                            </a>
-                                            <a href="{{ path('settings_domain_delete', {id: domain.id}) }}"
-                                               title="{{ 'settings.domain.actions.delete'|trans }}"
-                                               data-controller="tooltip"
-                                               class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
-                                                {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
-                                                <span class="sr-only">{{ 'settings.domain.actions.delete'|trans }}</span>
-                                            </a>
-                                        </div>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        {% endblock %}
-                    {% endembed %}
-
-                    {% include 'Settings/_pagination.html.twig' with {
-                        index_route: 'settings_domain_index',
-                        total_key: 'settings.domain.pagination.total',
-                        previous_key: 'settings.domain.pagination.previous',
-                        next_key: 'settings.domain.pagination.next',
-                        page_key: 'settings.domain.pagination.page',
-                        pagination: pagination,
-                        search: search,
-                    } %}
-                {% endif %}
+                {% include 'Settings/_search_form.html.twig' with {
+                    index_route: 'settings_domain_index',
+                    placeholder_key: 'settings.domain.search.placeholder',
+                    submit_key: 'settings.domain.search.submit',
+                    search: search,
+                } %}
             </div>
+
+            {% if pagination.items is empty %}
+                {% include 'Settings/_empty_state.html.twig' with {
+                    icon: 'heroicons:globe-alt',
+                    title_key: 'settings.domain.table.empty-title',
+                    description_key: 'settings.domain.table.empty-description',
+                } %}
+            {% else %}
+                {% embed 'Settings/_table.html.twig' with {
+                    headers: [
+                        {label: 'settings.table.id'},
+                        {label: 'settings.table.name'},
+                        {label: 'settings.table.created'},
+                        {label: 'settings.table.actions', align: 'right'},
+                    ]
+                } %}
+                    {% block table_body %}
+                        {% for domain in pagination.items %}
+                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ domain.id }}</td>
+                                <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ domain.name }}</td>
+                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                    {{ domain.creationTime|format_datetime('short', 'short') }}
+                                </td>
+                                <td class="px-6 py-4 text-right">
+                                    <div class="inline-flex items-center gap-1">
+                                        <a href="{{ path('settings_domain_show', {id: domain.id}) }}"
+                                           title="{{ 'settings.domain.actions.show'|trans }}"
+                                           data-controller="tooltip"
+                                           class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                            {{ ux_icon('heroicons:eye', {class: 'w-4 h-4'}) }}
+                                            <span class="sr-only">{{ 'settings.domain.actions.show'|trans }}</span>
+                                        </a>
+                                        <a href="{{ path('settings_domain_delete', {id: domain.id}) }}"
+                                           title="{{ 'settings.domain.actions.delete'|trans }}"
+                                           data-controller="tooltip"
+                                           class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                            {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
+                                            <span class="sr-only">{{ 'settings.domain.actions.delete'|trans }}</span>
+                                        </a>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endblock %}
+                {% endembed %}
+
+                {% include 'Settings/_pagination.html.twig' with {
+                    index_route: 'settings_domain_index',
+                    total_key: 'settings.domain.pagination.total',
+                    previous_key: 'settings.domain.pagination.previous',
+                    next_key: 'settings.domain.pagination.next',
+                    page_key: 'settings.domain.pagination.page',
+                    pagination: pagination,
+                    search: search,
+                } %}
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/Domain/show.html.twig
+++ b/templates/Settings/Domain/show.html.twig
@@ -1,63 +1,59 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'domains' %}
+{% extends 'Settings/base_settings.html.twig' %}
 {% block title %}{{ setting('app_name') }} - {{ domain.name }}{% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'domains'} %}
-        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-                <div class="p-6 sm:p-8">
-                    <div class="flex items-center mb-6">
-                        <div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/50 rounded-xl flex items-center justify-center mr-4">
-                            {{ ux_icon('heroicons:globe-alt', {class: 'w-6 h-6 text-indigo-600 dark:text-indigo-400'}) }}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+            <div class="p-6 sm:p-8">
+                <div class="flex items-center mb-6">
+                    <div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/50 rounded-xl flex items-center justify-center mr-4">
+                        {{ ux_icon('heroicons:globe-alt', {class: 'w-6 h-6 text-indigo-600 dark:text-indigo-400'}) }}
+                    </div>
+                    <div>
+                        <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ domain.name }}</h3>
+                        <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.domain.show.description'|trans }}</p>
+                    </div>
+                </div>
+
+                <div class="mb-6">
+                    <a href="{{ path('settings_domain_index') }}"
+                       class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.domain.show.back'|trans }}
+                    </a>
+                </div>
+
+                <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
+                    <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600">
+                        <div class="flex items-center mb-2">
+                            {{ ux_icon('heroicons:users', {class: 'w-5 h-5 text-blue-500 dark:text-blue-400 mr-2'}) }}
+                            <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ 'settings.domain.show.users'|trans }}</span>
                         </div>
-                        <div>
-                            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ domain.name }}</h3>
-                            <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.domain.show.description'|trans }}</p>
-                        </div>
+                        <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.users }}</p>
                     </div>
 
-                    <div class="mb-6">
-                        <a href="{{ path('settings_domain_index') }}"
-                           class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
-                            {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.domain.show.back'|trans }}
-                        </a>
+                    <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600">
+                        <div class="flex items-center mb-2">
+                            {{ ux_icon('heroicons:at-symbol', {class: 'w-5 h-5 text-green-500 dark:text-green-400 mr-2'}) }}
+                            <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ 'settings.domain.show.aliases'|trans }}</span>
+                        </div>
+                        <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.aliases }}</p>
                     </div>
 
-                    <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
-                        <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600">
-                            <div class="flex items-center mb-2">
-                                {{ ux_icon('heroicons:users', {class: 'w-5 h-5 text-blue-500 dark:text-blue-400 mr-2'}) }}
-                                <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ 'settings.domain.show.users'|trans }}</span>
-                            </div>
-                            <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.users }}</p>
+                    <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600">
+                        <div class="flex items-center mb-2">
+                            {{ ux_icon('heroicons:shield-check', {class: 'w-5 h-5 text-purple-500 dark:text-purple-400 mr-2'}) }}
+                            <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ 'settings.domain.show.admins'|trans }}</span>
                         </div>
+                        <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.admins }}</p>
+                    </div>
 
-                        <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600">
-                            <div class="flex items-center mb-2">
-                                {{ ux_icon('heroicons:at-symbol', {class: 'w-5 h-5 text-green-500 dark:text-green-400 mr-2'}) }}
-                                <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ 'settings.domain.show.aliases'|trans }}</span>
-                            </div>
-                            <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.aliases }}</p>
+                    <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600">
+                        <div class="flex items-center mb-2">
+                            {{ ux_icon('heroicons:ticket', {class: 'w-5 h-5 text-orange-500 dark:text-orange-400 mr-2'}) }}
+                            <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ 'settings.domain.show.vouchers'|trans }}</span>
                         </div>
-
-                        <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600">
-                            <div class="flex items-center mb-2">
-                                {{ ux_icon('heroicons:shield-check', {class: 'w-5 h-5 text-purple-500 dark:text-purple-400 mr-2'}) }}
-                                <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ 'settings.domain.show.admins'|trans }}</span>
-                            </div>
-                            <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.admins }}</p>
-                        </div>
-
-                        <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600">
-                            <div class="flex items-center mb-2">
-                                {{ ux_icon('heroicons:ticket', {class: 'w-5 h-5 text-orange-500 dark:text-orange-400 mr-2'}) }}
-                                <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ 'settings.domain.show.vouchers'|trans }}</span>
-                            </div>
-                            <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.vouchers }}</p>
-                        </div>
+                        <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.vouchers }}</p>
                     </div>
                 </div>
             </div>
-    </div>
+        </div>
 {% endblock %}

--- a/templates/Settings/Maintenance/show.html.twig
+++ b/templates/Settings/Maintenance/show.html.twig
@@ -1,49 +1,45 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'maintenance' %}
+{% extends 'Settings/base_settings.html.twig' %}
 
 {% block title %}{{ setting('app_name') }} - {{ 'settings.maintenance.title'|trans }}{% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
 {% block page_subtitle %}{{ 'settings.maintenance.subtitle'|trans }}{% endblock %}
 
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with { current_section: 'maintenance' } %}
+{% block settings_content %}
+    <div class="grid gap-8 md:grid-cols-2">
+        {% include 'Settings/_maintenance_card.html.twig' with {
+            icon: 'heroicons:bell-slash',
+            title_key: 'settings.maintenance.pruneUserNotifications.title',
+            description_key: 'settings.maintenance.pruneUserNotifications.description',
+            button_key: 'settings.maintenance.pruneUserNotifications.button',
+            task: 'prune_user_notifications',
+            csrf_token_id: 'maintenance_prune_user_notifications',
+        } %}
 
-        <div class="grid gap-8 md:grid-cols-2">
-            {% include 'Settings/_maintenance_card.html.twig' with {
-                icon: 'heroicons:bell-slash',
-                title_key: 'settings.maintenance.pruneUserNotifications.title',
-                description_key: 'settings.maintenance.pruneUserNotifications.description',
-                button_key: 'settings.maintenance.pruneUserNotifications.button',
-                task: 'prune_user_notifications',
-                csrf_token_id: 'maintenance_prune_user_notifications',
-            } %}
+        {% include 'Settings/_maintenance_card.html.twig' with {
+            icon: 'heroicons:arrow-path-rounded-square',
+            title_key: 'settings.maintenance.pruneWebhookDeliveries.title',
+            description_key: 'settings.maintenance.pruneWebhookDeliveries.description',
+            button_key: 'settings.maintenance.pruneWebhookDeliveries.button',
+            task: 'prune_webhook_deliveries',
+            csrf_token_id: 'maintenance_prune_webhook_deliveries',
+        } %}
 
-            {% include 'Settings/_maintenance_card.html.twig' with {
-                icon: 'heroicons:arrow-path-rounded-square',
-                title_key: 'settings.maintenance.pruneWebhookDeliveries.title',
-                description_key: 'settings.maintenance.pruneWebhookDeliveries.description',
-                button_key: 'settings.maintenance.pruneWebhookDeliveries.button',
-                task: 'prune_webhook_deliveries',
-                csrf_token_id: 'maintenance_prune_webhook_deliveries',
-            } %}
+        {% include 'Settings/_maintenance_card.html.twig' with {
+            icon: 'heroicons:user-minus',
+            title_key: 'settings.maintenance.removeInactiveUsers.title',
+            description_key: 'settings.maintenance.removeInactiveUsers.description',
+            button_key: 'settings.maintenance.removeInactiveUsers.button',
+            task: 'remove_inactive_users',
+            csrf_token_id: 'maintenance_remove_inactive_users',
+        } %}
 
-            {% include 'Settings/_maintenance_card.html.twig' with {
-                icon: 'heroicons:user-minus',
-                title_key: 'settings.maintenance.removeInactiveUsers.title',
-                description_key: 'settings.maintenance.removeInactiveUsers.description',
-                button_key: 'settings.maintenance.removeInactiveUsers.button',
-                task: 'remove_inactive_users',
-                csrf_token_id: 'maintenance_remove_inactive_users',
-            } %}
-
-            {% include 'Settings/_maintenance_card.html.twig' with {
-                icon: 'heroicons:ticket',
-                title_key: 'settings.maintenance.unlinkRedeemedVouchers.title',
-                description_key: 'settings.maintenance.unlinkRedeemedVouchers.description',
-                button_key: 'settings.maintenance.unlinkRedeemedVouchers.button',
-                task: 'unlink_redeemed_vouchers',
-                csrf_token_id: 'maintenance_unlink_redeemed_vouchers',
-            } %}
-        </div>
+        {% include 'Settings/_maintenance_card.html.twig' with {
+            icon: 'heroicons:ticket',
+            title_key: 'settings.maintenance.unlinkRedeemedVouchers.title',
+            description_key: 'settings.maintenance.unlinkRedeemedVouchers.description',
+            button_key: 'settings.maintenance.unlinkRedeemedVouchers.button',
+            task: 'unlink_redeemed_vouchers',
+            csrf_token_id: 'maintenance_unlink_redeemed_vouchers',
+        } %}
     </div>
 {% endblock %}

--- a/templates/Settings/ReservedName/import.html.twig
+++ b/templates/Settings/ReservedName/import.html.twig
@@ -1,64 +1,58 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'reserved-names' %}
+{% extends 'Settings/base_settings.html.twig' %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 
 {% block title %}{{ setting('app_name') }} - {{ 'settings.reserved-name.import.title'|trans }}{% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
 
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'reserved-names'} %}
-        <div class="max-w-2xl mx-auto">
-            <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-                <div class="p-6 sm:p-8">
-                    <div class="flex items-center mb-6">
-                        <div class="w-12 h-12 bg-amber-100 dark:bg-amber-900/50 rounded-xl flex items-center justify-center mr-4">
-                            {{ ux_icon('heroicons:arrow-up-tray', {class: 'w-6 h-6 text-amber-600 dark:text-amber-400'}) }}
-                        </div>
-                        <div>
-                            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
-                                {{ 'settings.reserved-name.import.heading'|trans }}
-                            </h3>
-                            <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.reserved-name.import.description'|trans }}</p>
-                        </div>
-                    </div>
-
-                    {{ form_start(form) }}
-                    {{ form_errors(form) }}
-
-                    <div class="space-y-6">
-                        <div>
-                            {{ form_label(form.file, 'settings.reserved-name.import.form.file.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
-                            {{ form_errors(form.file) }}
-                            {{ form_widget(form.file, {
-                                attr: {
-                                    class: 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 dark:file:bg-blue-900/50 dark:file:text-blue-300',
-                                    accept: '.txt,text/plain'
-                                }
-                            }) }}
-                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
-                                {{ 'settings.reserved-name.import.form.file.help'|trans }}
-                            </p>
-                        </div>
-
-                        <div class="flex items-center justify-between pt-6">
-                            <a href="{{ path('settings_reserved_name_index') }}"
-                               class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                                {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
-                                {{ 'settings.reserved-name.form.cancel'|trans }}
-                            </a>
-                            {{ form_widget(form.submit, {
-                                label: 'settings.reserved-name.import.form.submit',
-                                attr: {
-                                    class: 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
-                                }
-                            }) }}
-                        </div>
-                    </div>
-                    {{ form_end(form) }}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            <div class="flex items-center mb-6">
+                <div class="w-12 h-12 bg-amber-100 dark:bg-amber-900/50 rounded-xl flex items-center justify-center mr-4">
+                    {{ ux_icon('heroicons:arrow-up-tray', {class: 'w-6 h-6 text-amber-600 dark:text-amber-400'}) }}
+                </div>
+                <div>
+                    <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                        {{ 'settings.reserved-name.import.heading'|trans }}
+                    </h3>
+                    <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.reserved-name.import.description'|trans }}</p>
                 </div>
             </div>
+
+            {{ form_start(form) }}
+            {{ form_errors(form) }}
+
+            <div class="space-y-6">
+                <div>
+                    {{ form_label(form.file, 'settings.reserved-name.import.form.file.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.file) }}
+                    {{ form_widget(form.file, {
+                        attr: {
+                            class: 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 dark:file:bg-blue-900/50 dark:file:text-blue-300',
+                            accept: '.txt,text/plain'
+                        }
+                    }) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.reserved-name.import.form.file.help'|trans }}
+                    </p>
+                </div>
+
+                <div class="flex items-center justify-between pt-6">
+                    <a href="{{ path('settings_reserved_name_index') }}"
+                       class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.reserved-name.form.cancel'|trans }}
+                    </a>
+                    {{ form_widget(form.submit, {
+                        label: 'settings.reserved-name.import.form.submit',
+                        attr: {
+                            class: 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
+                        }
+                    }) }}
+                </div>
+            </div>
+            {{ form_end(form) }}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/ReservedName/index.html.twig
+++ b/templates/Settings/ReservedName/index.html.twig
@@ -1,100 +1,96 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'reserved-names' %}
+{% extends 'Settings/base_settings.html.twig' %}
 {% block title %}{{ setting('app_name') }} - {{ 'settings.reserved-name.title'|trans }}{% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'reserved-names'} %}
-        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div class="p-6 sm:p-8">
-                {% include 'Settings/_section_header.html.twig' with {
-                    icon: 'heroicons:shield-exclamation',
-                    icon_color: 'amber',
-                    heading_key: 'settings.reserved-name.heading',
-                    description_key: 'settings.reserved-name.description',
-                } %}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:shield-exclamation',
+                icon_color: 'amber',
+                heading_key: 'settings.reserved-name.heading',
+                description_key: 'settings.reserved-name.description',
+            } %}
 
-                <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                    <div class="flex flex-wrap items-center gap-2">
-                        <a href="{{ path('settings_reserved_name_create') }}"
-                           class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                            {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
-                            {{ 'settings.reserved-name.create.button'|trans }}
-                        </a>
-                        <a href="{{ path('settings_reserved_name_import') }}"
-                           class="inline-flex items-center px-4 py-2 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                            {{ ux_icon('heroicons:arrow-up-tray', {class: 'w-4 h-4 mr-2'}) }}
-                            {{ 'settings.reserved-name.import.button'|trans }}
-                        </a>
-                        <a href="{{ path('settings_reserved_name_export') }}"
-                           class="inline-flex items-center px-4 py-2 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                            {{ ux_icon('heroicons:arrow-down-tray', {class: 'w-4 h-4 mr-2'}) }}
-                            {{ 'settings.reserved-name.export.button'|trans }}
-                        </a>
-                    </div>
-
-                    {% include 'Settings/_search_form.html.twig' with {
-                        index_route: 'settings_reserved_name_index',
-                        placeholder_key: 'settings.reserved-name.search.placeholder',
-                        submit_key: 'settings.reserved-name.search.submit',
-                        search: search,
-                    } %}
+            <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                <div class="flex flex-wrap items-center gap-2">
+                    <a href="{{ path('settings_reserved_name_create') }}"
+                       class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.reserved-name.create.button'|trans }}
+                    </a>
+                    <a href="{{ path('settings_reserved_name_import') }}"
+                       class="inline-flex items-center px-4 py-2 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-up-tray', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.reserved-name.import.button'|trans }}
+                    </a>
+                    <a href="{{ path('settings_reserved_name_export') }}"
+                       class="inline-flex items-center px-4 py-2 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-down-tray', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.reserved-name.export.button'|trans }}
+                    </a>
                 </div>
 
-                {% if pagination.items is empty %}
-                    {% include 'Settings/_empty_state.html.twig' with {
-                        icon: 'heroicons:shield-exclamation',
-                        title_key: 'settings.reserved-name.table.empty-title',
-                        description_key: 'settings.reserved-name.table.empty-description',
-                    } %}
-                {% else %}
-                    {% embed 'Settings/_table.html.twig' with {
-                        headers: [
-                            {label: 'settings.table.id'},
-                            {label: 'settings.table.name'},
-                            {label: 'settings.table.created'},
-                            {label: 'settings.table.actions', align: 'right'},
-                        ]
-                    } %}
-                        {% block table_body %}
-                            {% for reservedName in pagination.items %}
-                                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ reservedName.id }}</td>
-                                    <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ reservedName.name }}</td>
-                                    <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
-                                        {{ reservedName.creationTime|format_datetime('short', 'short') }}
-                                    </td>
-                                    <td class="px-6 py-4 text-right">
-                                        <form method="post"
-                                              action="{{ path('settings_reserved_name_delete', {id: reservedName.id}) }}"
-                                              onsubmit="return confirm('{{ 'settings.reserved-name.delete.confirm'|trans({'%name%': reservedName.name|e('js')}) }}');">
-                                            <input type="hidden" name="_token"
-                                                   value="{{ csrf_token('delete_reserved_name_' ~ reservedName.id) }}">
-                                            <button type="submit"
-                                                    title="{{ 'settings.reserved-name.actions.delete'|trans }}"
-                                                    data-controller="tooltip"
-                                                    class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
-                                                {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
-                                                <span class="sr-only">{{ 'settings.reserved-name.actions.delete'|trans }}</span>
-                                            </button>
-                                        </form>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        {% endblock %}
-                    {% endembed %}
-
-                    {% include 'Settings/_pagination.html.twig' with {
-                        index_route: 'settings_reserved_name_index',
-                        total_key: 'settings.reserved-name.pagination.total',
-                        previous_key: 'settings.reserved-name.pagination.previous',
-                        next_key: 'settings.reserved-name.pagination.next',
-                        page_key: 'settings.reserved-name.pagination.page',
-                        pagination: pagination,
-                        search: search,
-                    } %}
-                {% endif %}
+                {% include 'Settings/_search_form.html.twig' with {
+                    index_route: 'settings_reserved_name_index',
+                    placeholder_key: 'settings.reserved-name.search.placeholder',
+                    submit_key: 'settings.reserved-name.search.submit',
+                    search: search,
+                } %}
             </div>
+
+            {% if pagination.items is empty %}
+                {% include 'Settings/_empty_state.html.twig' with {
+                    icon: 'heroicons:shield-exclamation',
+                    title_key: 'settings.reserved-name.table.empty-title',
+                    description_key: 'settings.reserved-name.table.empty-description',
+                } %}
+            {% else %}
+                {% embed 'Settings/_table.html.twig' with {
+                    headers: [
+                        {label: 'settings.table.id'},
+                        {label: 'settings.table.name'},
+                        {label: 'settings.table.created'},
+                        {label: 'settings.table.actions', align: 'right'},
+                    ]
+                } %}
+                    {% block table_body %}
+                        {% for reservedName in pagination.items %}
+                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ reservedName.id }}</td>
+                                <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ reservedName.name }}</td>
+                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                    {{ reservedName.creationTime|format_datetime('short', 'short') }}
+                                </td>
+                                <td class="px-6 py-4 text-right">
+                                    <form method="post"
+                                          action="{{ path('settings_reserved_name_delete', {id: reservedName.id}) }}"
+                                          onsubmit="return confirm('{{ 'settings.reserved-name.delete.confirm'|trans({'%name%': reservedName.name|e('js')}) }}');">
+                                        <input type="hidden" name="_token"
+                                               value="{{ csrf_token('delete_reserved_name_' ~ reservedName.id) }}">
+                                        <button type="submit"
+                                                title="{{ 'settings.reserved-name.actions.delete'|trans }}"
+                                                data-controller="tooltip"
+                                                class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                            {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
+                                            <span class="sr-only">{{ 'settings.reserved-name.actions.delete'|trans }}</span>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endblock %}
+                {% endembed %}
+
+                {% include 'Settings/_pagination.html.twig' with {
+                    index_route: 'settings_reserved_name_index',
+                    total_key: 'settings.reserved-name.pagination.total',
+                    previous_key: 'settings.reserved-name.pagination.previous',
+                    next_key: 'settings.reserved-name.pagination.next',
+                    page_key: 'settings.reserved-name.pagination.page',
+                    pagination: pagination,
+                    search: search,
+                } %}
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/Webhook/Delivery/index.html.twig
+++ b/templates/Settings/Webhook/Delivery/index.html.twig
@@ -1,139 +1,135 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'webhooks' %}
+{% extends 'Settings/base_settings.html.twig' %}
 {% block title %}{{ setting('app_name') }} - {{ 'settings.webhook.deliveries.title'|trans }}{% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'webhooks'} %}
-        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div class="p-6 sm:p-8">
-                {% include 'Settings/_section_header.html.twig' with {
-                    icon: 'heroicons:paper-airplane',
-                    icon_color: 'indigo',
-                    heading_key: 'settings.webhook.deliveries.heading',
-                    description_key: 'settings.webhook.deliveries.subtitle',
-                } %}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:paper-airplane',
+                icon_color: 'indigo',
+                heading_key: 'settings.webhook.deliveries.heading',
+                description_key: 'settings.webhook.deliveries.subtitle',
+            } %}
 
-                <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                    <a href="{{ path('settings_webhook_endpoint_index') }}"
-                       class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
-                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.actions.back'|trans }}
-                    </a>
-                    <div class="flex flex-wrap items-center gap-4">
-                        <div class="flex items-center gap-2">
-                            <label for="event-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.webhook.deliveries.filter.event'|trans }}:</label>
-                            <select id="event-filter"
-                                    onchange="window.location.href = this.value"
-                                    class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
-                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status}|filter(v => v)) }}"{% if eventType == '' %} selected{% endif %}>{{ 'settings.webhook.deliveries.filter.all'|trans }}</option>
-                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.created'}|filter(v => v)) }}"{% if eventType == 'user.created' %} selected{% endif %}>user.created</option>
-                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.deleted'}|filter(v => v)) }}"{% if eventType == 'user.deleted' %} selected{% endif %}>user.deleted</option>
-                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.reset'}|filter(v => v)) }}"{% if eventType == 'user.reset' %} selected{% endif %}>user.reset</option>
-                            </select>
-                        </div>
-                        <div class="flex items-center gap-2">
-                            <label for="status-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.webhook.deliveries.filter.label'|trans }}:</label>
-                            <select id="status-filter"
-                                    onchange="window.location.href = this.value"
-                                    class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
-                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, eventType: eventType}|filter(v => v)) }}"{% if status == '' %} selected{% endif %}>{{ 'settings.webhook.deliveries.filter.all'|trans }}</option>
-                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'success', eventType: eventType}|filter(v => v)) }}"{% if status == 'success' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.delivered'|trans }}</option>
-                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'failed', eventType: eventType}|filter(v => v)) }}"{% if status == 'failed' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.failed'|trans }}</option>
-                                <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'pending', eventType: eventType}|filter(v => v)) }}"{% if status == 'pending' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.pending'|trans }}</option>
-                            </select>
-                        </div>
+            <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                <a href="{{ path('settings_webhook_endpoint_index') }}"
+                   class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                    {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.actions.back'|trans }}
+                </a>
+                <div class="flex flex-wrap items-center gap-4">
+                    <div class="flex items-center gap-2">
+                        <label for="event-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.webhook.deliveries.filter.event'|trans }}:</label>
+                        <select id="event-filter"
+                                onchange="window.location.href = this.value"
+                                class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status}|filter(v => v)) }}"{% if eventType == '' %} selected{% endif %}>{{ 'settings.webhook.deliveries.filter.all'|trans }}</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.created'}|filter(v => v)) }}"{% if eventType == 'user.created' %} selected{% endif %}>user.created</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.deleted'}|filter(v => v)) }}"{% if eventType == 'user.deleted' %} selected{% endif %}>user.deleted</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.reset'}|filter(v => v)) }}"{% if eventType == 'user.reset' %} selected{% endif %}>user.reset</option>
+                        </select>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <label for="status-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.webhook.deliveries.filter.label'|trans }}:</label>
+                        <select id="status-filter"
+                                onchange="window.location.href = this.value"
+                                class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, eventType: eventType}|filter(v => v)) }}"{% if status == '' %} selected{% endif %}>{{ 'settings.webhook.deliveries.filter.all'|trans }}</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'success', eventType: eventType}|filter(v => v)) }}"{% if status == 'success' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.delivered'|trans }}</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'failed', eventType: eventType}|filter(v => v)) }}"{% if status == 'failed' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.failed'|trans }}</option>
+                            <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'pending', eventType: eventType}|filter(v => v)) }}"{% if status == 'pending' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.pending'|trans }}</option>
+                        </select>
                     </div>
                 </div>
-
-                {% embed 'Settings/_table.html.twig' with {
-                    headers: [
-                        {label: 'settings.table.id'},
-                        {label: 'settings.webhook.deliveries.table.event'},
-                        {label: 'settings.webhook.deliveries.table.status'},
-                        {label: 'settings.webhook.deliveries.table.dispatched'},
-                        {label: 'settings.table.actions', align: 'right'},
-                    ]
-                } %}
-                    {% block table_body %}
-                        {% for delivery in deliveries %}
-                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ delivery.id }}</td>
-                                <td class="px-6 py-4">
-                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-200">{{ delivery.type }}</span>
-                                </td>
-                                <td class="px-6 py-4">
-                                    {% if delivery.success %}
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.webhook.deliveries.status.delivered'|trans }}</span>
-                                    {% elseif delivery.error %}
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ 'settings.webhook.deliveries.status.failed'|trans }}</span>
-                                    {% else %}
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200">{{ 'settings.webhook.deliveries.status.pending'|trans }}</span>
-                                    {% endif %}
-                                </td>
-                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
-                                    {{ delivery.dispatchedTime|format_datetime('none', 'medium') }}
-                                </td>
-                                <td class="px-6 py-4 text-right">
-                                    <span class="inline-flex items-center rounded-lg border border-gray-200 dark:border-gray-600 divide-x divide-gray-200 dark:divide-gray-600">
-                                        <a href="{{ path('settings_webhook_delivery_show', {id: delivery.id}) }}"
-                                           title="{{ 'settings.webhook.deliveries.detail.action'|trans }}"
-                                           data-controller="tooltip"
-                                           class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
-                                            {{ ux_icon('heroicons:eye', {class: 'w-4 h-4'}) }}
-                                            <span class="sr-only">{{ 'settings.webhook.deliveries.detail.action'|trans }}</span>
-                                        </a>
-                                        {% if delivery.error and not delivery.success %}
-                                            <form method="post"
-                                                  action="{{ path('settings_webhook_delivery_retry', {id: delivery.id}) }}"
-                                                  onsubmit="return confirm('{{ 'settings.webhook.deliveries.retry.confirm'|trans }}')">
-                                                <input type="hidden" name="_token"
-                                                       value="{{ csrf_token('retry_delivery_' ~ delivery.id) }}">
-                                                <button type="submit"
-                                                        title="{{ 'settings.webhook.deliveries.retry.action'|trans }}"
-                                                        data-controller="tooltip"
-                                                        class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
-                                                    {{ ux_icon('heroicons:arrow-path', {class: 'w-4 h-4'}) }}
-                                                    <span class="sr-only">{{ 'settings.webhook.deliveries.retry.action'|trans }}</span>
-                                                </button>
-                                            </form>
-                                        {% endif %}
-                                    </span>
-                                </td>
-                            </tr>
-                        {% else %}
-                            <tr>
-                                <td colspan="5"
-                                    class="px-6 py-6 text-center text-sm text-gray-500 dark:text-gray-300">{{ 'settings.webhook.deliveries.empty'|trans }}</td>
-                            </tr>
-                        {% endfor %}
-                    {% endblock %}
-                {% endembed %}
-
-                {% if totalPages > 1 %}
-                    <div class="mt-6 flex items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-4">
-                        <div class="text-sm text-gray-500 dark:text-gray-400">
-                            {{ 'settings.webhook.deliveries.pagination.total'|trans({'%count%': total}) }}
-                        </div>
-                        <div class="flex gap-2">
-                            {% if page > 1 %}
-                                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page - 1, status: status, eventType: eventType}|filter(v => v)) }}"
-                                   class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
-                                    {{ ux_icon('heroicons:chevron-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.deliveries.pagination.newer'|trans }}
-                                </a>
-                            {% endif %}
-                            <span class="inline-flex items-center px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400">
-                                {{ 'settings.webhook.deliveries.pagination.page'|trans({'%page%': page, '%totalPages%': totalPages}) }}
-                            </span>
-                            {% if page < totalPages %}
-                                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page + 1, status: status, eventType: eventType}|filter(v => v)) }}"
-                                   class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
-                                    {{ 'settings.webhook.deliveries.pagination.older'|trans }} {{ ux_icon('heroicons:chevron-right', {class: 'w-4 h-4 ml-1'}) }}
-                                </a>
-                            {% endif %}
-                        </div>
-                    </div>
-                {% endif %}
             </div>
+
+            {% embed 'Settings/_table.html.twig' with {
+                headers: [
+                    {label: 'settings.table.id'},
+                    {label: 'settings.webhook.deliveries.table.event'},
+                    {label: 'settings.webhook.deliveries.table.status'},
+                    {label: 'settings.webhook.deliveries.table.dispatched'},
+                    {label: 'settings.table.actions', align: 'right'},
+                ]
+            } %}
+                {% block table_body %}
+                    {% for delivery in deliveries %}
+                        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ delivery.id }}</td>
+                            <td class="px-6 py-4">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-200">{{ delivery.type }}</span>
+                            </td>
+                            <td class="px-6 py-4">
+                                {% if delivery.success %}
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.webhook.deliveries.status.delivered'|trans }}</span>
+                                {% elseif delivery.error %}
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ 'settings.webhook.deliveries.status.failed'|trans }}</span>
+                                {% else %}
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200">{{ 'settings.webhook.deliveries.status.pending'|trans }}</span>
+                                {% endif %}
+                            </td>
+                            <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                {{ delivery.dispatchedTime|format_datetime('none', 'medium') }}
+                            </td>
+                            <td class="px-6 py-4 text-right">
+                                <span class="inline-flex items-center rounded-lg border border-gray-200 dark:border-gray-600 divide-x divide-gray-200 dark:divide-gray-600">
+                                    <a href="{{ path('settings_webhook_delivery_show', {id: delivery.id}) }}"
+                                       title="{{ 'settings.webhook.deliveries.detail.action'|trans }}"
+                                       data-controller="tooltip"
+                                       class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
+                                        {{ ux_icon('heroicons:eye', {class: 'w-4 h-4'}) }}
+                                        <span class="sr-only">{{ 'settings.webhook.deliveries.detail.action'|trans }}</span>
+                                    </a>
+                                    {% if delivery.error and not delivery.success %}
+                                        <form method="post"
+                                              action="{{ path('settings_webhook_delivery_retry', {id: delivery.id}) }}"
+                                              onsubmit="return confirm('{{ 'settings.webhook.deliveries.retry.confirm'|trans }}')">
+                                            <input type="hidden" name="_token"
+                                                   value="{{ csrf_token('retry_delivery_' ~ delivery.id) }}">
+                                            <button type="submit"
+                                                    title="{{ 'settings.webhook.deliveries.retry.action'|trans }}"
+                                                    data-controller="tooltip"
+                                                    class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
+                                                {{ ux_icon('heroicons:arrow-path', {class: 'w-4 h-4'}) }}
+                                                <span class="sr-only">{{ 'settings.webhook.deliveries.retry.action'|trans }}</span>
+                                            </button>
+                                        </form>
+                                    {% endif %}
+                                </span>
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr>
+                            <td colspan="5"
+                                class="px-6 py-6 text-center text-sm text-gray-500 dark:text-gray-300">{{ 'settings.webhook.deliveries.empty'|trans }}</td>
+                        </tr>
+                    {% endfor %}
+                {% endblock %}
+            {% endembed %}
+
+            {% if totalPages > 1 %}
+                <div class="mt-6 flex items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-4">
+                    <div class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ 'settings.webhook.deliveries.pagination.total'|trans({'%count%': total}) }}
+                    </div>
+                    <div class="flex gap-2">
+                        {% if page > 1 %}
+                            <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page - 1, status: status, eventType: eventType}|filter(v => v)) }}"
+                               class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                                {{ ux_icon('heroicons:chevron-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.deliveries.pagination.newer'|trans }}
+                            </a>
+                        {% endif %}
+                        <span class="inline-flex items-center px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400">
+                            {{ 'settings.webhook.deliveries.pagination.page'|trans({'%page%': page, '%totalPages%': totalPages}) }}
+                        </span>
+                        {% if page < totalPages %}
+                            <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id, page: page + 1, status: status, eventType: eventType}|filter(v => v)) }}"
+                               class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                                {{ 'settings.webhook.deliveries.pagination.older'|trans }} {{ ux_icon('heroicons:chevron-right', {class: 'w-4 h-4 ml-1'}) }}
+                            </a>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/Webhook/Delivery/show.html.twig
+++ b/templates/Settings/Webhook/Delivery/show.html.twig
@@ -1,114 +1,110 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'webhooks' %}
+{% extends 'Settings/base_settings.html.twig' %}
 {% block title %}{{ setting('app_name') }} - {{ 'settings.webhook.delivery.title'|trans({'%id%': delivery.id}) }}{% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'webhooks'} %}
-        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div class="p-6 sm:p-8 space-y-8">
-                <div class="flex items-start justify-between">
-                    <div class="flex items-center">
-                        <div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/50 rounded-xl flex items-center justify-center mr-4">
-                            {{ ux_icon('heroicons:paper-airplane', {class: 'w-6 h-6 text-indigo-600 dark:text-indigo-400'}) }}
-                        </div>
-                        <div>
-                            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ 'settings.webhook.delivery.heading'|trans({'%id%': delivery.id}) }}</h3>
-                            <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.webhook.delivery.subtitle'|trans({'%endpoint%': endpoint.url}) }}</p>
-                        </div>
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8 space-y-8">
+            <div class="flex items-start justify-between">
+                <div class="flex items-center">
+                    <div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/50 rounded-xl flex items-center justify-center mr-4">
+                        {{ ux_icon('heroicons:paper-airplane', {class: 'w-6 h-6 text-indigo-600 dark:text-indigo-400'}) }}
+                    </div>
+                    <div>
+                        <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ 'settings.webhook.delivery.heading'|trans({'%id%': delivery.id}) }}</h3>
+                        <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.webhook.delivery.subtitle'|trans({'%endpoint%': endpoint.url}) }}</p>
                     </div>
                 </div>
+            </div>
 
-                <div class="flex items-center gap-2 pt-2">
-                    <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id}) }}"
-                       class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
-                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.delivery.actions.back'|trans }}
-                    </a>
-                    {% if delivery.error and not delivery.success %}
-                        <form method="post"
-                              action="{{ path('settings_webhook_delivery_retry', {id: delivery.id}) }}"
-                              onsubmit="return confirm('{{ 'settings.webhook.deliveries.retry.confirm'|trans }}')">
-                            <input type="hidden" name="_token"
-                                   value="{{ csrf_token('retry_delivery_' ~ delivery.id) }}">
-                            <button class="inline-flex items-center px-3 py-2 bg-blue-600 dark:bg-blue-500 text-white text-sm font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors">
-                                {{ ux_icon('heroicons:arrow-path', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.deliveries.retry.action'|trans }}
-                            </button>
-                        </form>
-                    {% endif %}
-                </div>
-
-                <div class="grid gap-8 md:grid-cols-2">
-                    <div class="space-y-6">
-                        <div>
-                            <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ 'settings.webhook.delivery.meta'|trans }}</h4>
-                            <dl class="text-sm divide-y divide-gray-100 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-                                <div class="flex justify-between gap-4 px-4 py-2 bg-gray-50 dark:bg-gray-700">
-                                    <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.event'|trans }}</dt>
-                                    <dd class="text-gray-900 dark:text-gray-100"><span
-                                                class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-200">{{ delivery.type }}</span>
-                                    </dd>
-                                </div>
-                                <div class="flex justify-between gap-4 px-4 py-2 dark:bg-gray-800">
-                                    <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.status'|trans }}</dt>
-                                    <dd>
-                                        {% if delivery.success %}
-                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.webhook.deliveries.status.delivered'|trans }}</span>
-                                        {% elseif delivery.error %}
-                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ 'settings.webhook.deliveries.status.failed'|trans }}</span>
-                                        {% else %}
-                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200">{{ 'settings.webhook.deliveries.status.pending'|trans }}</span>
-                                        {% endif %}
-                                    </dd>
-                                </div>
-                                <div class="flex justify-between gap-4 px-4 py-2 bg-gray-50 dark:bg-gray-700">
-                                    <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.attempt'|trans }}</dt>
-                                    <dd class="text-gray-900 dark:text-gray-100">{{ delivery.attempts }}</dd>
-                                </div>
-                                <div class="flex justify-between gap-4 px-4 py-2 dark:bg-gray-800">
-                                    <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.dispatched'|trans }}</dt>
-                                    <dd class="text-gray-900 dark:text-gray-100">{{ delivery.dispatchedTime|format_datetime('short', 'medium') }}</dd>
-                                </div>
-                                <div class="flex justify-between gap-4 px-4 py-2 bg-gray-50 dark:bg-gray-700">
-                                    <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.delivered'|trans }}</dt>
-                                    <dd class="text-gray-900 dark:text-gray-100">{{ delivery.deliveredTime ? delivery.deliveredTime|format_datetime('short', 'medium') : '—' }}</dd>
-                                </div>
-                                <div class="flex justify-between gap-4 px-4 py-2 bg-gray-50 dark:bg-gray-700">
-                                    <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.response_status'|trans }}</dt>
-                                    <dd class="text-gray-900 dark:text-gray-100">{{ delivery.responseCode ?? '—' }}</dd>
-                                </div>
-                            </dl>
-                        </div>
-
-                    </div>
-                    <div class="space-y-6">
-                        <div>
-                            <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ 'settings.webhook.delivery.request_headers'|trans }}</h4>
-                            <pre class="p-3 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-xs overflow-x-auto text-gray-900 dark:text-gray-100">{{ delivery.requestHeaders|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
-                        </div>
-                        <div>
-                            <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ 'settings.webhook.delivery.request_body'|trans }}</h4>
-                            <pre class="p-3 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-xs overflow-x-auto text-gray-900 dark:text-gray-100">{{ delivery.requestBody|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
-                        </div>
-                    </div>
-                </div>
-
-                {% if delivery.responseBody or delivery.error %}
-                    <div class="mt-8 space-y-6">
-                        {% if delivery.responseBody %}
-                            <div>
-                                <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ 'settings.webhook.delivery.response_body'|trans }}</h4>
-                                <pre class="p-3 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-xs overflow-x-auto text-gray-900 dark:text-gray-100">{{ delivery.responseBody }}</pre>
-                            </div>
-                        {% endif %}
-                        {% if delivery.error %}
-                            <div>
-                                <h4 class="text-sm font-medium text-red-700 dark:text-red-400 mb-2">{{ 'settings.webhook.delivery.error'|trans }}</h4>
-                                <pre class="p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg text-xs overflow-x-auto text-red-900 dark:text-red-200">{{ delivery.error }}</pre>
-                            </div>
-                        {% endif %}
-                    </div>
+            <div class="flex items-center gap-2 pt-2">
+                <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id}) }}"
+                   class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                    {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.delivery.actions.back'|trans }}
+                </a>
+                {% if delivery.error and not delivery.success %}
+                    <form method="post"
+                          action="{{ path('settings_webhook_delivery_retry', {id: delivery.id}) }}"
+                          onsubmit="return confirm('{{ 'settings.webhook.deliveries.retry.confirm'|trans }}')">
+                        <input type="hidden" name="_token"
+                               value="{{ csrf_token('retry_delivery_' ~ delivery.id) }}">
+                        <button class="inline-flex items-center px-3 py-2 bg-blue-600 dark:bg-blue-500 text-white text-sm font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors">
+                            {{ ux_icon('heroicons:arrow-path', {class: 'w-4 h-4 mr-1'}) }} {{ 'settings.webhook.deliveries.retry.action'|trans }}
+                        </button>
+                    </form>
                 {% endif %}
             </div>
+
+            <div class="grid gap-8 md:grid-cols-2">
+                <div class="space-y-6">
+                    <div>
+                        <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ 'settings.webhook.delivery.meta'|trans }}</h4>
+                        <dl class="text-sm divide-y divide-gray-100 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+                            <div class="flex justify-between gap-4 px-4 py-2 bg-gray-50 dark:bg-gray-700">
+                                <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.event'|trans }}</dt>
+                                <dd class="text-gray-900 dark:text-gray-100"><span
+                                            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-200">{{ delivery.type }}</span>
+                                </dd>
+                            </div>
+                            <div class="flex justify-between gap-4 px-4 py-2 dark:bg-gray-800">
+                                <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.status'|trans }}</dt>
+                                <dd>
+                                    {% if delivery.success %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.webhook.deliveries.status.delivered'|trans }}</span>
+                                    {% elseif delivery.error %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ 'settings.webhook.deliveries.status.failed'|trans }}</span>
+                                    {% else %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200">{{ 'settings.webhook.deliveries.status.pending'|trans }}</span>
+                                    {% endif %}
+                                </dd>
+                            </div>
+                            <div class="flex justify-between gap-4 px-4 py-2 bg-gray-50 dark:bg-gray-700">
+                                <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.attempt'|trans }}</dt>
+                                <dd class="text-gray-900 dark:text-gray-100">{{ delivery.attempts }}</dd>
+                            </div>
+                            <div class="flex justify-between gap-4 px-4 py-2 dark:bg-gray-800">
+                                <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.dispatched'|trans }}</dt>
+                                <dd class="text-gray-900 dark:text-gray-100">{{ delivery.dispatchedTime|format_datetime('short', 'medium') }}</dd>
+                            </div>
+                            <div class="flex justify-between gap-4 px-4 py-2 bg-gray-50 dark:bg-gray-700">
+                                <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.delivered'|trans }}</dt>
+                                <dd class="text-gray-900 dark:text-gray-100">{{ delivery.deliveredTime ? delivery.deliveredTime|format_datetime('short', 'medium') : '---' }}</dd>
+                            </div>
+                            <div class="flex justify-between gap-4 px-4 py-2 bg-gray-50 dark:bg-gray-700">
+                                <dt class="font-medium text-gray-600 dark:text-gray-300">{{ 'settings.webhook.delivery.response_status'|trans }}</dt>
+                                <dd class="text-gray-900 dark:text-gray-100">{{ delivery.responseCode ?? '---' }}</dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                </div>
+                <div class="space-y-6">
+                    <div>
+                        <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ 'settings.webhook.delivery.request_headers'|trans }}</h4>
+                        <pre class="p-3 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-xs overflow-x-auto text-gray-900 dark:text-gray-100">{{ delivery.requestHeaders|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
+                    </div>
+                    <div>
+                        <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ 'settings.webhook.delivery.request_body'|trans }}</h4>
+                        <pre class="p-3 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-xs overflow-x-auto text-gray-900 dark:text-gray-100">{{ delivery.requestBody|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
+                    </div>
+                </div>
+            </div>
+
+            {% if delivery.responseBody or delivery.error %}
+                <div class="mt-8 space-y-6">
+                    {% if delivery.responseBody %}
+                        <div>
+                            <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ 'settings.webhook.delivery.response_body'|trans }}</h4>
+                            <pre class="p-3 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-xs overflow-x-auto text-gray-900 dark:text-gray-100">{{ delivery.responseBody }}</pre>
+                        </div>
+                    {% endif %}
+                    {% if delivery.error %}
+                        <div>
+                            <h4 class="text-sm font-medium text-red-700 dark:text-red-400 mb-2">{{ 'settings.webhook.delivery.error'|trans }}</h4>
+                            <pre class="p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg text-xs overflow-x-auto text-red-900 dark:text-red-200">{{ delivery.error }}</pre>
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/Webhook/Endpoint/form.html.twig
+++ b/templates/Settings/Webhook/Endpoint/form.html.twig
@@ -1,4 +1,5 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'webhooks' %}
+{% extends 'Settings/base_settings.html.twig' %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 {% set is_edit = endpoint is defined %}
@@ -7,110 +8,103 @@
 {% block title %}
     {{ setting('app_name') }} - {{ is_edit ? 'settings.webhook.edit.title'|trans : 'settings.webhook.create.title'|trans }}
 {% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
 
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'webhooks'} %}
-        <div class="max-w-2xl mx-auto">
-            <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-                <div class="p-6 sm:p-8">
-                    <div class="flex items-center mb-6">
-                        <div class="w-12 h-12 {{ is_edit ? 'bg-indigo-100 dark:bg-indigo-900/50' : 'bg-blue-100 dark:bg-blue-900/50' }} rounded-xl flex items-center justify-center mr-4">
-                            {% if is_edit %}
-                                {{ ux_icon('heroicons:pencil-square', {class: 'w-6 h-6 text-indigo-600 dark:text-indigo-400'}) }}
-                            {% else %}
-                                {{ ux_icon('heroicons:plus', {class: 'w-6 h-6 text-blue-600 dark:text-blue-400'}) }}
-                            {% endif %}
-                        </div>
-                        <div>
-                            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
-                                {% if is_edit %}
-                                    {{ 'settings.webhook.form.title.edit'|trans }}
-                                {% else %}
-                                    {{ 'settings.webhook.form.title.create'|trans }}
-                                {% endif %}
-                            </h3>
-                            {% if not is_edit %}
-                                <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.webhook.form.description.create'|trans }}</p>
-                            {% endif %}
-                        </div>
-                    </div>
-
-                    {{ form_start(form) }}
-                    {{ form_errors(form) }}
-
-                    <div class="space-y-6">
-                        <div>
-                            {{ form_label(form.url, 'settings.webhook.form.url.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
-                            {{ form_errors(form.url) }}
-                            {{ form_widget(form.url, {
-                                attr: {
-                                    placeholder: 'settings.webhook.form.url.placeholder',
-                                    class: 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors'
-                                }
-                            }) }}
-                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
-                                {{ 'settings.webhook.form.url.help'|trans }}
-                            </p>
-                        </div>
-
-                        <div>
-                            {{ form_label(form.secret, 'settings.webhook.form.secret.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
-                            {{ form_errors(form.secret) }}
-                            {{ form_widget(form.secret, {
-                                attr: {
-                                    placeholder: 'settings.webhook.form.secret.placeholder',
-                                    class: 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors'
-                                }
-                            }) }}
-                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
-                                {{ 'settings.webhook.form.secret.help'|trans }}
-                            </p>
-                        </div>
-
-                        <div>
-                            {{ form_label(form.events, 'settings.webhook.form.events.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
-                            {{ form_errors(form.events) }}
-                            {{ form_widget(form.events, { attr: { class: 'w-full' } }) }}
-                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
-                                {{ 'settings.webhook.form.events.help'|trans }}
-                            </p>
-                        </div>
-
-                        <div>
-                            {{ form_label(form.domains, 'settings.webhook.form.domains.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
-                            {{ form_errors(form.domains) }}
-                            {{ form_widget(form.domains) }}
-                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
-                                {{ 'settings.webhook.form.domains.help'|trans }}
-                            </p>
-                        </div>
-
-                        <div class="flex items-center gap-3">
-                            {{ form_widget(form.enabled, { attr: { class: 'h-4 w-4 text-blue-600 dark:text-blue-500 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500 dark:focus:ring-blue-400 bg-white dark:bg-gray-700' } }) }}
-                            {{ form_label(form.enabled, 'settings.webhook.form.enabled.label', {'label_attr': {'class': 'text-sm font-medium text-gray-700 dark:text-gray-300'}}) }}
-                            {{ form_errors(form.enabled) }}
-                        </div>
-
-                        <div class="flex items-center justify-between pt-6">
-                            <a href="{{ path('settings_webhook_endpoint_index') }}"
-                               class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                                {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
-                                {{ 'settings.webhook.form.cancel'|trans }}
-                            </a>
-                            {{ form_widget(form.submit, {
-                                label: is_edit ? 'settings.webhook.form.submit.save' : 'settings.webhook.form.submit.create',
-                                attr: {
-                                    class: 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
-                                }
-                            }) }}
-                        </div>
-                    </div>
-                    {{ form_end(form) }}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            <div class="flex items-center mb-6">
+                <div class="w-12 h-12 {{ is_edit ? 'bg-indigo-100 dark:bg-indigo-900/50' : 'bg-blue-100 dark:bg-blue-900/50' }} rounded-xl flex items-center justify-center mr-4">
+                    {% if is_edit %}
+                        {{ ux_icon('heroicons:pencil-square', {class: 'w-6 h-6 text-indigo-600 dark:text-indigo-400'}) }}
+                    {% else %}
+                        {{ ux_icon('heroicons:plus', {class: 'w-6 h-6 text-blue-600 dark:text-blue-400'}) }}
+                    {% endif %}
+                </div>
+                <div>
+                    <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                        {% if is_edit %}
+                            {{ 'settings.webhook.form.title.edit'|trans }}
+                        {% else %}
+                            {{ 'settings.webhook.form.title.create'|trans }}
+                        {% endif %}
+                    </h3>
+                    {% if not is_edit %}
+                        <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.webhook.form.description.create'|trans }}</p>
+                    {% endif %}
                 </div>
             </div>
+
+            {{ form_start(form) }}
+            {{ form_errors(form) }}
+
+            <div class="space-y-6">
+                <div>
+                    {{ form_label(form.url, 'settings.webhook.form.url.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.url) }}
+                    {{ form_widget(form.url, {
+                        attr: {
+                            placeholder: 'settings.webhook.form.url.placeholder',
+                            class: 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors'
+                        }
+                    }) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.webhook.form.url.help'|trans }}
+                    </p>
+                </div>
+
+                <div>
+                    {{ form_label(form.secret, 'settings.webhook.form.secret.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.secret) }}
+                    {{ form_widget(form.secret, {
+                        attr: {
+                            placeholder: 'settings.webhook.form.secret.placeholder',
+                            class: 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors'
+                        }
+                    }) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.webhook.form.secret.help'|trans }}
+                    </p>
+                </div>
+
+                <div>
+                    {{ form_label(form.events, 'settings.webhook.form.events.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.events) }}
+                    {{ form_widget(form.events, { attr: { class: 'w-full' } }) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.webhook.form.events.help'|trans }}
+                    </p>
+                </div>
+
+                <div>
+                    {{ form_label(form.domains, 'settings.webhook.form.domains.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.domains) }}
+                    {{ form_widget(form.domains) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.webhook.form.domains.help'|trans }}
+                    </p>
+                </div>
+
+                <div class="flex items-center gap-3">
+                    {{ form_widget(form.enabled, { attr: { class: 'h-4 w-4 text-blue-600 dark:text-blue-500 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500 dark:focus:ring-blue-400 bg-white dark:bg-gray-700' } }) }}
+                    {{ form_label(form.enabled, 'settings.webhook.form.enabled.label', {'label_attr': {'class': 'text-sm font-medium text-gray-700 dark:text-gray-300'}}) }}
+                    {{ form_errors(form.enabled) }}
+                </div>
+
+                <div class="flex items-center justify-between pt-6">
+                    <a href="{{ path('settings_webhook_endpoint_index') }}"
+                       class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.webhook.form.cancel'|trans }}
+                    </a>
+                    {{ form_widget(form.submit, {
+                        label: is_edit ? 'settings.webhook.form.submit.save' : 'settings.webhook.form.submit.create',
+                        attr: {
+                            class: 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
+                        }
+                    }) }}
+                </div>
+            </div>
+            {{ form_end(form) }}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/Webhook/Endpoint/index.html.twig
+++ b/templates/Settings/Webhook/Endpoint/index.html.twig
@@ -1,108 +1,104 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'webhooks' %}
+{% extends 'Settings/base_settings.html.twig' %}
 {% block title %}{{ setting('app_name') }} - {{ 'settings.webhook.title'|trans }}{% endblock %}
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'webhooks'} %}
-        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div class="p-6 sm:p-8">
-                {% include 'Settings/_section_header.html.twig' with {
-                    icon: 'heroicons:cursor-arrow-rays',
-                    icon_color: 'blue',
-                    heading_key: 'settings.webhook.table.title',
-                    description_key: 'settings.webhook.table.description',
-                } %}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:cursor-arrow-rays',
+                icon_color: 'blue',
+                heading_key: 'settings.webhook.table.title',
+                description_key: 'settings.webhook.table.description',
+            } %}
 
-                <div class="mb-6">
-                    <a href="{{ path('settings_webhook_endpoint_create') }}"
-                       class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                        {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
-                        {{ 'settings.webhook.create.button'|trans }}
-                    </a>
-                </div>
-
-                {% if endpoints is empty %}
-                    {% include 'Settings/_empty_state.html.twig' with {
-                        icon: 'heroicons:cursor-arrow-rays',
-                        title_key: 'settings.webhook.table.empty-title',
-                        description_key: 'settings.webhook.table.empty-description',
-                    } %}
-                {% else %}
-                    {% embed 'Settings/_table.html.twig' with {
-                        headers: [
-                            {label: 'settings.table.id'},
-                            {label: 'settings.webhook.table.url'},
-                            {label: 'settings.webhook.table.events'},
-                            {label: 'settings.webhook.table.domains'},
-                            {label: 'settings.webhook.table.enabled'},
-                            {label: 'settings.table.actions', align: 'right'},
-                        ]
-                    } %}
-                        {% block table_body %}
-                            {% for endpoint in endpoints %}
-                                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ endpoint.id }}</td>
-                                    <td class="px-6 py-4 text-sm font-mono break-all text-gray-900 dark:text-gray-100">{{ endpoint.url|e }}</td>
-                                    <td class="px-6 py-4">
-                                        <div class="flex flex-wrap gap-1">
-                                            {% for event in endpoint.events %}
-                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-200">{{ event }}</span>
-                                            {% endfor %}
-                                        </div>
-                                    </td>
-                                    <td class="px-6 py-4">
-                                        <div class="flex flex-wrap gap-1">
-                                            {% if endpoint.domains is empty %}
-                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 whitespace-nowrap">{{ 'settings.webhook.all_domains'|trans }}</span>
-                                            {% else %}
-                                                {% for domain in endpoint.domains %}
-                                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">{{ domain.name }}</span>
-                                                {% endfor %}
-                                            {% endif %}
-                                        </div>
-                                    </td>
-                                    <td class="px-6 py-4">{% if endpoint.enabled %}<span
-                                                class="text-green-600 dark:text-green-400 font-medium">{{ 'settings.webhook.enabled'|trans }}</span>{% else %}
-                                            <span class="text-gray-400 dark:text-gray-500">{{ 'settings.webhook.disabled'|trans }}</span>{% endif %}
-                                    </td>
-                                    <td class="px-6 py-4 text-right">
-                                        <span class="inline-flex items-center rounded-lg border border-gray-200 dark:border-gray-600 divide-x divide-gray-200 dark:divide-gray-600">
-                                            <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id}) }}"
-                                               title="{{ 'settings.webhook.actions.deliveries'|trans }}"
-                                               data-controller="tooltip"
-                                               class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
-                                                {{ ux_icon('heroicons:paper-airplane', {class: 'w-4 h-4'}) }}
-                                                <span class="sr-only">{{ 'settings.webhook.actions.deliveries'|trans }}</span>
-                                            </a>
-                                            <a href="{{ path('settings_webhook_endpoint_edit', {id: endpoint.id}) }}"
-                                               title="{{ 'settings.webhook.actions.edit'|trans }}"
-                                               data-controller="tooltip"
-                                               class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
-                                                {{ ux_icon('heroicons:pencil-square', {class: 'w-4 h-4'}) }}
-                                                <span class="sr-only">{{ 'settings.webhook.actions.edit'|trans }}</span>
-                                            </a>
-                                            <form method="post"
-                                                  action="{{ path('settings_webhook_endpoint_delete', {id: endpoint.id}) }}"
-                                                  onsubmit="return confirm('{{ 'settings.webhook.delete.confirm'|trans({'%url%': endpoint.url|e('js')}) }}');">
-                                                <input type="hidden" name="_token"
-                                                       value="{{ csrf_token('delete_webhook_endpoint_' ~ endpoint.id) }}">
-                                                <button type="submit"
-                                                        title="{{ 'settings.webhook.actions.delete'|trans }}"
-                                                        data-controller="tooltip"
-                                                        class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
-                                                    {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
-                                                    <span class="sr-only">{{ 'settings.webhook.actions.delete'|trans }}</span>
-                                                </button>
-                                            </form>
-                                        </span>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        {% endblock %}
-                    {% endembed %}
-                {% endif %}
+            <div class="mb-6">
+                <a href="{{ path('settings_webhook_endpoint_create') }}"
+                   class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                    {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
+                    {{ 'settings.webhook.create.button'|trans }}
+                </a>
             </div>
+
+            {% if endpoints is empty %}
+                {% include 'Settings/_empty_state.html.twig' with {
+                    icon: 'heroicons:cursor-arrow-rays',
+                    title_key: 'settings.webhook.table.empty-title',
+                    description_key: 'settings.webhook.table.empty-description',
+                } %}
+            {% else %}
+                {% embed 'Settings/_table.html.twig' with {
+                    headers: [
+                        {label: 'settings.table.id'},
+                        {label: 'settings.webhook.table.url'},
+                        {label: 'settings.webhook.table.events'},
+                        {label: 'settings.webhook.table.domains'},
+                        {label: 'settings.webhook.table.enabled'},
+                        {label: 'settings.table.actions', align: 'right'},
+                    ]
+                } %}
+                    {% block table_body %}
+                        {% for endpoint in endpoints %}
+                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ endpoint.id }}</td>
+                                <td class="px-6 py-4 text-sm font-mono break-all text-gray-900 dark:text-gray-100">{{ endpoint.url|e }}</td>
+                                <td class="px-6 py-4">
+                                    <div class="flex flex-wrap gap-1">
+                                        {% for event in endpoint.events %}
+                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-200">{{ event }}</span>
+                                        {% endfor %}
+                                    </div>
+                                </td>
+                                <td class="px-6 py-4">
+                                    <div class="flex flex-wrap gap-1">
+                                        {% if endpoint.domains is empty %}
+                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 whitespace-nowrap">{{ 'settings.webhook.all_domains'|trans }}</span>
+                                        {% else %}
+                                            {% for domain in endpoint.domains %}
+                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">{{ domain.name }}</span>
+                                            {% endfor %}
+                                        {% endif %}
+                                    </div>
+                                </td>
+                                <td class="px-6 py-4">{% if endpoint.enabled %}<span
+                                            class="text-green-600 dark:text-green-400 font-medium">{{ 'settings.webhook.enabled'|trans }}</span>{% else %}
+                                        <span class="text-gray-400 dark:text-gray-500">{{ 'settings.webhook.disabled'|trans }}</span>{% endif %}
+                                </td>
+                                <td class="px-6 py-4 text-right">
+                                    <span class="inline-flex items-center rounded-lg border border-gray-200 dark:border-gray-600 divide-x divide-gray-200 dark:divide-gray-600">
+                                        <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id}) }}"
+                                           title="{{ 'settings.webhook.actions.deliveries'|trans }}"
+                                           data-controller="tooltip"
+                                           class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
+                                            {{ ux_icon('heroicons:paper-airplane', {class: 'w-4 h-4'}) }}
+                                            <span class="sr-only">{{ 'settings.webhook.actions.deliveries'|trans }}</span>
+                                        </a>
+                                        <a href="{{ path('settings_webhook_endpoint_edit', {id: endpoint.id}) }}"
+                                           title="{{ 'settings.webhook.actions.edit'|trans }}"
+                                           data-controller="tooltip"
+                                           class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
+                                            {{ ux_icon('heroicons:pencil-square', {class: 'w-4 h-4'}) }}
+                                            <span class="sr-only">{{ 'settings.webhook.actions.edit'|trans }}</span>
+                                        </a>
+                                        <form method="post"
+                                              action="{{ path('settings_webhook_endpoint_delete', {id: endpoint.id}) }}"
+                                              onsubmit="return confirm('{{ 'settings.webhook.delete.confirm'|trans({'%url%': endpoint.url|e('js')}) }}');">
+                                            <input type="hidden" name="_token"
+                                                   value="{{ csrf_token('delete_webhook_endpoint_' ~ endpoint.id) }}">
+                                            <button type="submit"
+                                                    title="{{ 'settings.webhook.actions.delete'|trans }}"
+                                                    data-controller="tooltip"
+                                                    class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors first:rounded-l-[7px] last:rounded-r-[7px]">
+                                                {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
+                                                <span class="sr-only">{{ 'settings.webhook.actions.delete'|trans }}</span>
+                                            </button>
+                                        </form>
+                                    </span>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endblock %}
+                {% endembed %}
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/_create_form.html.twig
+++ b/templates/Settings/_create_form.html.twig
@@ -1,59 +1,51 @@
 {# Parameters: form, current_section, heading_key, description_key, label_key, placeholder_key, help_key, cancel_key, submit_key, cancel_route #}
-{% extends 'base_page.html.twig' %}
+{% extends 'Settings/base_settings.html.twig' %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 
-{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
-{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:plus',
+                icon_color: 'blue',
+                heading_key: heading_key,
+                description_key: description_key,
+            } %}
 
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {% include 'Settings/_navigation.html.twig' with {'current_section': current_section} %}
-        <div class="max-w-2xl mx-auto">
-            <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-                <div class="p-6 sm:p-8">
-                    {% include 'Settings/_section_header.html.twig' with {
-                        icon: 'heroicons:plus',
-                        icon_color: 'blue',
-                        heading_key: heading_key,
-                        description_key: description_key,
-                    } %}
+            {{ form_start(form) }}
+            {{ form_errors(form) }}
 
-                    {{ form_start(form) }}
-                    {{ form_errors(form) }}
+            <div class="space-y-6">
+                <div>
+                    {{ form_label(form.name, label_key, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.name) }}
+                    {{ form_widget(form.name, {
+                        attr: {
+                            placeholder: placeholder_key,
+                            class: 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors'
+                        }
+                    }) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ help_key|trans }}
+                    </p>
+                </div>
 
-                    <div class="space-y-6">
-                        <div>
-                            {{ form_label(form.name, label_key, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
-                            {{ form_errors(form.name) }}
-                            {{ form_widget(form.name, {
-                                attr: {
-                                    placeholder: placeholder_key,
-                                    class: 'w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 transition-colors'
-                                }
-                            }) }}
-                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
-                                {{ help_key|trans }}
-                            </p>
-                        </div>
-
-                        <div class="flex items-center justify-between pt-6">
-                            <a href="{{ path(cancel_route) }}"
-                               class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
-                                {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
-                                {{ cancel_key|trans }}
-                            </a>
-                            {{ form_widget(form.submit, {
-                                label: submit_key,
-                                attr: {
-                                    class: 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
-                                }
-                            }) }}
-                        </div>
-                    </div>
-                    {{ form_end(form) }}
+                <div class="flex items-center justify-between pt-6">
+                    <a href="{{ path(cancel_route) }}"
+                       class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ cancel_key|trans }}
+                    </a>
+                    {{ form_widget(form.submit, {
+                        label: submit_key,
+                        attr: {
+                            class: 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
+                        }
+                    }) }}
                 </div>
             </div>
+            {{ form_end(form) }}
         </div>
     </div>
 {% endblock %}

--- a/templates/Settings/_navigation.html.twig
+++ b/templates/Settings/_navigation.html.twig
@@ -1,60 +1,43 @@
-{# Settings Navigation Component #}
-{# Parameters: current_section (string) - The current active section #}
+{# Settings Navigation Component (vertical list) #}
+{# Parameters:
+   - current_section (string) - The current active section
+   - summary_only (bool, optional) - If true, only render the active item's icon + label (for mobile <summary>)
+#}
 
 {% set current_section = current_section|default('general') %}
+{% set summary_only = summary_only|default(false) %}
 
-<div class="mb-8">
-    {# Floating navigation bar style - inspired by the main navbar #}
-    <nav class="bg-gray-50/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200/60 dark:border-gray-700/60 rounded-2xl shadow-sm p-1"
-         aria-label="{{ 'settings.navigation.aria-label'|trans }}">
-        <div class="flex space-x-1">
-            {# General/Home Link #}
-            <a href="{{ path('settings_show') }}"
-               class="flex items-center px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 {{ current_section == 'general' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50' }}">
-                <!-- heroicons:cog-8-tooth -->
-                {{ ux_icon('heroicons:cog-8-tooth', {class: 'w-4 h-4 mr-2'}) }}
-                {{ "settings.navigation.general"|trans }}
-            </a>
+{% set nav_items = [
+    {route: 'settings_show', section: 'general', icon: 'heroicons:cog-8-tooth', label: 'settings.navigation.general'},
+    {route: 'settings_api_show', section: 'api', icon: 'heroicons:key', label: 'settings.navigation.api'},
+    {route: 'settings_webhook_endpoint_index', section: 'webhooks', icon: 'heroicons:cursor-arrow-rays', label: 'settings.navigation.webhooks'},
+    {route: 'settings_maintenance_show', section: 'maintenance', icon: 'heroicons:building-library', label: 'settings.navigation.maintenance'},
+    {route: 'settings_domain_index', section: 'domains', icon: 'heroicons:globe-alt', label: 'settings.navigation.domains'},
+    {route: 'settings_reserved_name_index', section: 'reserved-names', icon: 'heroicons:shield-exclamation', label: 'settings.navigation.reserved-names'},
+    {route: 'sonata_admin_dashboard', section: 'admin', icon: 'heroicons:shield-check', label: 'Admin'},
+] %}
 
-            {# API Tokens Link #}
-            <a href="{{ path('settings_api_show') }}"
-               class="flex items-center px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 {{ current_section == 'api' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50' }}">
-                <!-- heroicons:key -->
-                {{ ux_icon('heroicons:key', {class: 'w-4 h-4 mr-2'}) }}
-                {{ "settings.navigation.api"|trans }}
+{% if summary_only %}
+    {# Render only the active item's icon and label (used inside <summary>) #}
+    {% for item in nav_items %}
+        {% if item.section == current_section %}
+            <span class="flex items-center text-sm font-medium text-gray-900 dark:text-gray-100">
+                {{ ux_icon(item.icon, {class: 'w-4 h-4 mr-2 text-gray-600 dark:text-gray-300'}) }}
+                {{ item.label|trans }}
+            </span>
+        {% endif %}
+    {% endfor %}
+{% else %}
+    {# Full vertical navigation list #}
+    <div class="flex flex-col space-y-1">
+        {% for item in nav_items %}
+            {% set is_active = item.section == current_section %}
+            <a href="{{ path(item.route) }}"
+               {% if is_active %}aria-current="page"{% endif %}
+               class="flex items-center px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 {{ is_active ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50' }}">
+                {{ ux_icon(item.icon, {class: 'w-4 h-4 mr-2.5 flex-shrink-0'}) }}
+                {{ item.section == 'admin' ? item.label : item.label|trans }}
             </a>
-
-            <a href="{{ path('settings_webhook_endpoint_index') }}"
-               class="flex items-center px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 {{ current_section == 'webhooks' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50' }}">
-                {{ ux_icon('heroicons:cursor-arrow-rays', {class: 'w-4 h-4 mr-2'}) }}
-                {{ 'settings.navigation.webhooks'|trans }}
-            </a>
-
-            <a href="{{ path('settings_maintenance_show') }}"
-               class="flex items-center px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 {{ current_section == 'maintenance' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50' }}">
-                {# heroicons:building-library chosen per request #}
-                {{ ux_icon('heroicons:building-library', {class: 'w-4 h-4 mr-2'}) }}
-                {{ 'settings.navigation.maintenance'|trans }}
-            </a>
-
-            <a href="{{ path('settings_domain_index') }}"
-               class="flex items-center px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 {{ current_section == 'domains' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50' }}">
-                {{ ux_icon('heroicons:globe-alt', {class: 'w-4 h-4 mr-2'}) }}
-                {{ 'settings.navigation.domains'|trans }}
-            </a>
-
-            <a href="{{ path('settings_reserved_name_index') }}"
-               class="flex items-center px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 {{ current_section == 'reserved-names' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50' }}">
-                {{ ux_icon('heroicons:shield-exclamation', {class: 'w-4 h-4 mr-2'}) }}
-                {{ 'settings.navigation.reserved-names'|trans }}
-            </a>
-
-            <a href="{{ path('sonata_admin_dashboard') }}"
-                class="flex items-center px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 {{ current_section == 'admin' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50' }}">
-                <!-- heroicons:shield-check -->
-                {{ ux_icon('heroicons:shield-check', {class: 'w-4 h-4 mr-2'}) }}
-                Admin
-            </a>
-        </div>
-    </nav>
-</div>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/templates/Settings/base_settings.html.twig
+++ b/templates/Settings/base_settings.html.twig
@@ -1,0 +1,40 @@
+{# Base template for all settings pages. Provides sidebar navigation (desktop) and disclosure menu (mobile). #}
+{# Parameters: current_section (string) - set via {% set %} in child templates before {% extends %} #}
+{% extends 'base_page.html.twig' %}
+
+{% block page_title %}{{ 'settings.title'|trans }}{% endblock %}
+{% block page_subtitle %}{{ 'settings.subtitle'|trans }}{% endblock %}
+
+{% block page_content %}
+    {% set current_section = current_section|default('general') %}
+
+    <div class="max-w-6xl mx-auto">
+        <div class="lg:grid lg:grid-cols-[15rem_1fr] lg:gap-8">
+            {# Desktop sidebar (hidden on mobile) #}
+            <aside class="hidden lg:block">
+                <nav class="sticky top-20 bg-gray-50/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200/60 dark:border-gray-700/60 rounded-2xl shadow-sm p-2"
+                     aria-label="{{ 'settings.navigation.aria-label'|trans }}">
+                    {% include 'Settings/_navigation.html.twig' with {'current_section': current_section} %}
+                </nav>
+            </aside>
+
+            {# Mobile navigation (hidden on desktop) #}
+            <div class="lg:hidden mb-6">
+                <details class="group bg-gray-50/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200/60 dark:border-gray-700/60 rounded-2xl shadow-sm">
+                    <summary class="flex items-center justify-between px-4 py-3 cursor-pointer list-none rounded-2xl hover:bg-white/50 dark:hover:bg-gray-700/50 transition-colors [&::-webkit-details-marker]:hidden">
+                        {% include 'Settings/_navigation.html.twig' with {'current_section': current_section, 'summary_only': true} %}
+                        {{ ux_icon('heroicons:chevron-down', {class: 'w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform duration-200 group-open:rotate-180'}) }}
+                    </summary>
+                    <nav class="px-2 pb-2" aria-label="{{ 'settings.navigation.aria-label'|trans }}">
+                        {% include 'Settings/_navigation.html.twig' with {'current_section': current_section} %}
+                    </nav>
+                </details>
+            </div>
+
+            {# Content area #}
+            <div class="min-w-0">
+                {% block settings_content %}{% endblock %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/Settings/show.html.twig
+++ b/templates/Settings/show.html.twig
@@ -1,102 +1,96 @@
-{% extends 'base_page.html.twig' %}
+{% set current_section = 'general' %}
+{% extends 'Settings/base_settings.html.twig' %}
 
 {% form_theme form 'Form/fields.html.twig' %}
 
 {% block title %}{{ setting('app_name') }} - {{ "settings.title"|trans }}{% endblock %}
-{% block page_title %}{{ "settings.title"|trans }}{% endblock %}
-{% block page_subtitle %}{{ "settings.subtitle"|trans }}{% endblock %}
 
-{% block page_content %}
-    <div class="max-w-5xl mx-auto">
-        {# Settings Navigation #}
-        {% include 'Settings/_navigation.html.twig' with {'current_section': 'general'} %}
+{% block settings_content %}
+    {# Main content area #}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:cog-6-tooth',
+                icon_color: 'blue',
+                heading_key: 'settings.form.title',
+                description_key: 'settings.form.description',
+            } %}
+            {{ form_start(form, {'attr': {'class': 'space-y-6', 'action': path('settings_update')}}) }}
+                {{ form_errors(form) }}
 
-        {# Main content area #}
-        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div class="p-6 sm:p-8">
-                {% include 'Settings/_section_header.html.twig' with {
-                    icon: 'heroicons:cog-6-tooth',
-                    icon_color: 'blue',
-                    heading_key: 'settings.form.title',
-                    description_key: 'settings.form.description',
+                {# Group settings by category #}
+                {% set categories = {
+                    'app': ['app_name', 'app_url', 'webmail_url'],
+                    'project': ['project_name', 'project_url'],
+                    'email': ['email_sender_address', 'email_notification_address'],
+                    'mail_crypt': ['mail_crypt'],
+                    'reports': ['weekly_report_enabled'],
+                    'smtp_quota': ['smtp_quota_limit_per_hour', 'smtp_quota_limit_per_day'],
+                    'mta_sts': ['mta_sts_mode', 'mta_sts_mx', 'mta_sts_max_age'],
                 } %}
-                {{ form_start(form, {'attr': {'class': 'space-y-6', 'action': path('settings_update')}}) }}
-                    {{ form_errors(form) }}
 
-                    {# Group settings by category #}
-                    {% set categories = {
-                        'app': ['app_name', 'app_url', 'webmail_url'],
-                        'project': ['project_name', 'project_url'],
-                        'email': ['email_sender_address', 'email_notification_address'],
-                        'mail_crypt': ['mail_crypt'],
-                        'reports': ['weekly_report_enabled'],
-                        'smtp_quota': ['smtp_quota_limit_per_hour', 'smtp_quota_limit_per_day'],
-                        'mta_sts': ['mta_sts_mode', 'mta_sts_mx', 'mta_sts_max_age'],
-                    } %}
+                {% for category, fields in categories %}
+                    <div class="space-y-6 border-b border-gray-200 dark:border-gray-700 pb-8">
+                        <div class="flex items-center mb-6">
+                            {% set category_icon = {
+                                'app': 'heroicons:computer-desktop',
+                                'project': 'heroicons:building-office',
+                                'email': 'heroicons:envelope',
+                                'mail_crypt': 'heroicons:lock-closed',
+                                'reports': 'heroicons:document-chart-bar',
+                                'smtp_quota': 'heroicons:arrow-up-tray',
+                                'mta_sts': 'heroicons:shield-check',
+                            }[category] %}
 
-                    {% for category, fields in categories %}
-                        <div class="space-y-6 border-b border-gray-200 dark:border-gray-700 pb-8">
-                            <div class="flex items-center mb-6">
-                                {% set category_icon = {
-                                    'app': 'heroicons:computer-desktop',
-                                    'project': 'heroicons:building-office',
-                                    'email': 'heroicons:envelope',
-                                    'mail_crypt': 'heroicons:lock-closed',
-                                    'reports': 'heroicons:document-chart-bar',
-                                    'smtp_quota': 'heroicons:arrow-up-tray',
-                                    'mta_sts': 'heroicons:shield-check',
-                                }[category] %}
-
-                                <div class="w-8 h-8 bg-gray-100 dark:bg-gray-700 rounded-lg flex items-center justify-center mr-3">
-                                    {{ ux_icon(category_icon, {class: 'w-4 h-4 text-gray-600 dark:text-gray-300'}) }}
-                                </div>
-                                <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-                                    {{ ("settings.form.category." ~ category)|trans }}
-                                </h4>
+                            <div class="w-8 h-8 bg-gray-100 dark:bg-gray-700 rounded-lg flex items-center justify-center mr-3">
+                                {{ ux_icon(category_icon, {class: 'w-4 h-4 text-gray-600 dark:text-gray-300'}) }}
                             </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {% for fieldName in fields %}
-                                    {% if form[fieldName] is defined %}
-                                        {% if form[fieldName].vars.block_prefixes[1] == 'checkbox' %}
-                                            <div class="flex items-start md:col-span-2">
-                                                <label for="{{ form[fieldName].vars.id }}" class="relative inline-flex items-center cursor-pointer flex-shrink-0 mt-0.5 mr-4">
-                                                    {{ form_widget(form[fieldName], {'attr': {'class': 'sr-only peer'}}) }}
-                                                    <div class="w-11 h-6 bg-gray-200 dark:bg-gray-600 rounded-full peer peer-checked:bg-blue-600 dark:peer-checked:bg-blue-500 peer-focus:ring-2 peer-focus:ring-blue-500 dark:peer-focus:ring-blue-400 peer-focus:ring-offset-2 dark:peer-focus:ring-offset-gray-800 transition-colors duration-200 after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all after:duration-200 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full"></div>
-                                                </label>
-                                                <div>
-                                                    {{ form_label(form[fieldName], null, {
-                                                        'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer', 'for': form[fieldName].vars.id}
-                                                    }) }}
-                                                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-300">{{ ("settings.form." ~ fieldName ~ ".help")|trans }}</p>
-                                                </div>
-                                                {{ form_errors(form[fieldName]) }}
-                                            </div>
-                                        {% else %}
-                                            <div class="space-y-2">
-                                                {{ form_label(form[fieldName], null, {
-                                                    'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}
-                                                }) }}
-                                                {{ form_errors(form[fieldName]) }}
-                                                {{ form_widget(form[fieldName]) }}
-                                                <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">{{ ("settings.form." ~ fieldName ~ ".help")|trans }}</p>
-                                            </div>
-                                        {% endif %}
-                                    {% endif %}
-                                {% endfor %}
-                            </div>
+                            <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                                {{ ("settings.form.category." ~ category)|trans }}
+                            </h4>
                         </div>
-                    {% endfor %}
 
-                    {# Submit Button #}
-                    <div class="flex justify-end pt-6">
-                        {{ form_widget(form.save, {
-                            'attr': {'class': 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors duration-200'}
-                        }) }}
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            {% for fieldName in fields %}
+                                {% if form[fieldName] is defined %}
+                                    {% if form[fieldName].vars.block_prefixes[1] == 'checkbox' %}
+                                        <div class="flex items-start md:col-span-2">
+                                            <label for="{{ form[fieldName].vars.id }}" class="relative inline-flex items-center cursor-pointer flex-shrink-0 mt-0.5 mr-4">
+                                                {{ form_widget(form[fieldName], {'attr': {'class': 'sr-only peer'}}) }}
+                                                <div class="w-11 h-6 bg-gray-200 dark:bg-gray-600 rounded-full peer peer-checked:bg-blue-600 dark:peer-checked:bg-blue-500 peer-focus:ring-2 peer-focus:ring-blue-500 dark:peer-focus:ring-blue-400 peer-focus:ring-offset-2 dark:peer-focus:ring-offset-gray-800 transition-colors duration-200 after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all after:duration-200 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full"></div>
+                                            </label>
+                                            <div>
+                                                {{ form_label(form[fieldName], null, {
+                                                    'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer', 'for': form[fieldName].vars.id}
+                                                }) }}
+                                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-300">{{ ("settings.form." ~ fieldName ~ ".help")|trans }}</p>
+                                            </div>
+                                            {{ form_errors(form[fieldName]) }}
+                                        </div>
+                                    {% else %}
+                                        <div class="space-y-2">
+                                            {{ form_label(form[fieldName], null, {
+                                                'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}
+                                            }) }}
+                                            {{ form_errors(form[fieldName]) }}
+                                            {{ form_widget(form[fieldName]) }}
+                                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">{{ ("settings.form." ~ fieldName ~ ".help")|trans }}</p>
+                                        </div>
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        </div>
                     </div>
+                {% endfor %}
 
-                {{ form_end(form) }}
-            </div>
+                {# Submit Button #}
+                <div class="flex justify-end pt-6">
+                    {{ form_widget(form.save, {
+                        'attr': {'class': 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors duration-200'}
+                    }) }}
+                </div>
+
+            {{ form_end(form) }}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Replace the horizontal tab bar in settings pages with a **vertical sidebar** (desktop, `lg:` breakpoint) and a **collapsible `<details>` disclosure menu** (mobile)
- Introduce a new shared `base_settings.html.twig` intermediate template that centralizes the 2-column grid layout and navigation, eliminating per-page navigation boilerplate
- Migrate all 14 settings page templates from `extends 'base_page.html.twig'` to `extends 'Settings/base_settings.html.twig'`

<img width="300" alt="Bildschirmfoto am 2026-03-07 um 12 14 34" src="https://github.com/user-attachments/assets/eab7af8d-2434-423a-ac92-6eaee49decf0" />
<img width="300" alt="Bildschirmfoto am 2026-03-07 um 12 14 38" src="https://github.com/user-attachments/assets/4ad3188c-ab4a-4b65-bc91-594dbc503163" />

<img width="2880" height="1800" alt="Bildschirmfoto am 2026-03-07 um 12 14 57" src="https://github.com/user-attachments/assets/b7d8fe28-0c54-4261-bab2-13caea45e10d" />


## Details

**New template:** `templates/Settings/base_settings.html.twig`
- Template chain: `base.html.twig` → `base_page.html.twig` → `base_settings.html.twig` → individual pages
- Desktop: `lg:grid lg:grid-cols-[15rem_1fr] lg:gap-8` with a sticky sidebar (`sticky top-20`)
- Mobile: `<details>` element showing the active section label, expanding to the full nav list
- No JavaScript required — pure CSS + semantic HTML

**Rewritten navigation partial:** `templates/Settings/_navigation.html.twig`
- Changed from horizontal flex row to vertical link list
- Supports `summary_only=true` mode for the `<details>` summary (renders only the active item icon+label)
- DRY: navigation items defined once as a Twig array and iterated in both mobile and desktop contexts

**Updated settings pages** (all use `settings_content` block instead of `page_content`):
- `Settings/show.html.twig`, `Api/show.html.twig`, `Api/create.html.twig`
- `Domain/index.html.twig`, `Domain/show.html.twig`
- `Webhook/Endpoint/index.html.twig`, `Webhook/Endpoint/form.html.twig`
- `Webhook/Delivery/index.html.twig`, `Webhook/Delivery/show.html.twig`
- `Maintenance/show.html.twig`
- `ReservedName/index.html.twig`, `ReservedName/import.html.twig`
- `_create_form.html.twig` (shared by `Domain/create` and `ReservedName/create`)

**Not modified** (no changes needed):
- `Domain/create.html.twig` and `ReservedName/create.html.twig` — inherit changes from `_create_form.html.twig`
- `Domain/delete.html.twig` — extends `base_step.html.twig`, out of scope

Closes #1090

---
<sub>The changes and the PR were generated by OpenCode.</sub>