### PR TITLE
♻️ Organize controllers into Account, Settings, and Api subdirectories

### DIFF
--- a/src/Controller/Account/AccountController.php
+++ b/src/Controller/Account/AccountController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Account;
 
 use App\Entity\User;
 use App\Enum\Roles;

--- a/src/Controller/Account/AliasController.php
+++ b/src/Controller/Account/AliasController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Account;
 
 use App\Entity\Alias;
 use App\Entity\User;

--- a/src/Controller/Account/OpenPGPController.php
+++ b/src/Controller/Account/OpenPGPController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Account;
 
 use App\Entity\User;
 use App\Exception\MultipleGpgKeysForUserException;

--- a/src/Controller/Account/TwofactorController.php
+++ b/src/Controller/Account/TwofactorController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Account;
 
 use App\Entity\User;
 use App\Form\Model\PasswordConfirmation;

--- a/src/Controller/Account/VoucherController.php
+++ b/src/Controller/Account/VoucherController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Account;
 
 use App\Entity\User;
 use App\Enum\Roles;

--- a/src/Controller/Api/DovecotController.php
+++ b/src/Controller/Api/DovecotController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Dto\DovecotPassdbDto;
 use App\Entity\User;

--- a/src/Controller/Api/KeycloakController.php
+++ b/src/Controller/Api/KeycloakController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Dto\KeycloakUserValidateDto;
 use App\Entity\Domain;

--- a/src/Controller/Api/MtaStsController.php
+++ b/src/Controller/Api/MtaStsController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Service\MtaStsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/src/Controller/Api/PostfixController.php
+++ b/src/Controller/Api/PostfixController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Enum\AliasCacheKey;
 use App\Enum\ApiScope;

--- a/src/Controller/Api/RetentionController.php
+++ b/src/Controller/Api/RetentionController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Dto\RetentionTouchUserDto;
 use App\Entity\User;

--- a/src/Controller/Api/RoundcubeController.php
+++ b/src/Controller/Api/RoundcubeController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Dto\RoundcubeUserAliasesDto;
 use App\Entity\Alias;

--- a/src/Controller/Api/WkdController.php
+++ b/src/Controller/Api/WkdController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Enum\OpenPgpKeyCacheKey;
 use App\Repository\OpenPgpKeyRepository;

--- a/src/Controller/Settings/ApiTokenController.php
+++ b/src/Controller/Settings/ApiTokenController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Entity\ApiToken;
 use App\Form\ApiTokenType;

--- a/src/Controller/Settings/DomainController.php
+++ b/src/Controller/Settings/DomainController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Entity\Domain;
 use App\Entity\User;

--- a/src/Controller/Settings/DomainSearchController.php
+++ b/src/Controller/Settings/DomainSearchController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Entity\Domain;
 use Doctrine\ORM\EntityManagerInterface;

--- a/src/Controller/Settings/MaintenanceController.php
+++ b/src/Controller/Settings/MaintenanceController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Message\PruneUserNotifications;
 use App\Message\PruneWebhookDeliveries;

--- a/src/Controller/Settings/ReservedNameController.php
+++ b/src/Controller/Settings/ReservedNameController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Entity\ReservedName;
 use App\Exception\ValidationException;

--- a/src/Controller/Settings/SettingsController.php
+++ b/src/Controller/Settings/SettingsController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Form\SettingsType;
 use App\Service\SettingsService;

--- a/src/Controller/Settings/UserNotificationController.php
+++ b/src/Controller/Settings/UserNotificationController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Enum\UserNotificationType;
 use App\Service\UserNotificationManager;

--- a/src/Controller/Settings/UserSearchController.php
+++ b/src/Controller/Settings/UserSearchController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Entity\User;
 use App\Enum\Roles;

--- a/src/Controller/Settings/VoucherController.php
+++ b/src/Controller/Settings/VoucherController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Entity\Domain;
 use App\Entity\User;
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-final class VoucherSettingsController extends AbstractController
+final class VoucherController extends AbstractController
 {
     public function __construct(
         private readonly VoucherManager $manager,

--- a/src/Controller/Settings/WebhookDeliveryController.php
+++ b/src/Controller/Settings/WebhookDeliveryController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Entity\WebhookDelivery;
 use App\Entity\WebhookEndpoint;

--- a/src/Controller/Settings/WebhookEndpointController.php
+++ b/src/Controller/Settings/WebhookEndpointController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Settings;
 
 use App\Entity\WebhookEndpoint;
 use App\Form\Model\WebhookEndpointModel;


### PR DESCRIPTION
## Summary

Reorganizes the flat `src/Controller/` directory (30 files) into logical subdirectories to improve codebase navigation and maintainability:

- **`Account/`** (5 files): User self-service controllers — account management, aliases, OpenPGP, 2FA, vouchers
- **`Settings/`** (11 files): Admin management controllers — global settings, domains, API tokens, reserved names, webhooks, voucher admin, user notifications, maintenance
- **`Api/`** (7 files): External integration endpoints — Dovecot, Postfix, Keycloak, Roundcube, Retention, WKD, MTA-STS
- **Root** (7 files): Auth, registration, recovery, init, and Sonata CRUD controllers

### Additional change

- `VoucherSettingsController` is renamed to `Settings\VoucherController` since the namespace collision with `Account\VoucherController` no longer exists.

### What is NOT changed

- Route names and URL paths remain identical
- Templates, Behat features, security config, and all other references are unaffected
- `config/services.yaml` requires no changes (Symfony auto-discovers controllers recursively)

### Verification

- PHP CS Fixer: 0 issues
- Rector: OK
- Psalm: No errors
- PHPUnit: 839 tests passed
- Behat: 226 scenarios, 2148 steps passed

---
<sub>The changes and the PR were generated by OpenCode.</sub>