### PR TITLE
💄 Improve responsive table layout in settings pages

### DIFF
--- a/templates/Settings/Api/show.html.twig
+++ b/templates/Settings/Api/show.html.twig
@@ -52,22 +52,22 @@
             {% else %}
                 {% embed 'Settings/_table.html.twig' with {
                     headers: [
-                        {label: 'settings.table.id'},
+                        {label: 'settings.table.id', class: 'hidden xl:table-cell'},
                         {label: 'settings.table.name'},
                         {label: 'settings.api.table.scopes'},
                         {label: 'settings.table.created'},
-                        {label: 'settings.api.table.last-used'},
+                        {label: 'settings.api.table.last-used', class: 'hidden xl:table-cell'},
                         {label: 'settings.table.actions', align: 'right'},
                     ]
                 } %}
                     {% block table_body %}
                         {% for token in tokens %}
                             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+                                <td class="hidden xl:table-cell px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
                                     {{ token.id }}
                                 </td>
-                                <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ token.name|e }}</td>
-                                <td class="px-6 py-4">
+                                <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-gray-100 max-w-xs truncate" title="{{ token.name|e }}">{{ token.name|e }}</td>
+                                <td class="px-4 py-3">
                                     <div class="flex flex-wrap gap-1">
                                         {% for scope in token.scopes %}
                                             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200">
@@ -76,17 +76,17 @@
                                         {% endfor %}
                                     </div>
                                 </td>
-                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
                                     {{ token.creationTime|format_datetime('short', 'short') }}
                                 </td>
-                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                <td class="hidden xl:table-cell px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
                                     {% if token.lastUsedTime %}
                                         {{ token.lastUsedTime|format_datetime('short', 'short') }}
                                     {% else %}
                                         <span class="text-gray-400 dark:text-gray-500 italic">{{ "settings.api.table.never-used"|trans }}</span>
                                     {% endif %}
                                 </td>
-                                <td class="px-6 py-4 text-right">
+                                <td class="px-4 py-3 text-right">
                                     <form method="POST"
                                           action="{{ path('settings_api_delete', {'id': token.id}) }}"
                                           data-controller="confirm"

--- a/templates/Settings/Domain/index.html.twig
+++ b/templates/Settings/Domain/index.html.twig
@@ -46,12 +46,12 @@
                     {% block table_body %}
                         {% for domain in pagination.items %}
                             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ domain.id }}</td>
-                                <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ domain.name }}</td>
-                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ domain.id }}</td>
+                                <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-gray-100">{{ domain.name }}</td>
+                                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
                                     {{ domain.creationTime|format_datetime('short', 'short') }}
                                 </td>
-                                <td class="px-6 py-4 text-right">
+                                <td class="px-4 py-3 text-right">
                                     <div class="inline-flex items-center gap-1">
                                         <a href="{{ path('settings_domain_show', {id: domain.id}) }}"
                                            title="{{ 'settings.domain.actions.show'|trans }}"

--- a/templates/Settings/ReservedName/index.html.twig
+++ b/templates/Settings/ReservedName/index.html.twig
@@ -56,12 +56,12 @@
                     {% block table_body %}
                         {% for reservedName in pagination.items %}
                             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ reservedName.id }}</td>
-                                <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ reservedName.name }}</td>
-                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ reservedName.id }}</td>
+                                <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-gray-100">{{ reservedName.name }}</td>
+                                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
                                     {{ reservedName.creationTime|format_datetime('short', 'short') }}
                                 </td>
-                                <td class="px-6 py-4 text-right">
+                                <td class="px-4 py-3 text-right">
                                     <form method="post"
                                           action="{{ path('settings_reserved_name_delete', {id: reservedName.id}) }}"
                                           onsubmit="return confirm('{{ 'settings.reserved-name.delete.confirm'|trans({'%name%': reservedName.name|e('js')}) }}');">

--- a/templates/Settings/UserNotification/index.html.twig
+++ b/templates/Settings/UserNotification/index.html.twig
@@ -67,12 +67,12 @@
                     {% block table_body %}
                         {% for notification in pagination.items %}
                             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ notification.id }}</td>
-                                <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ notification.user }}</td>
-                                <td class="px-6 py-4">
+                                <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ notification.id }}</td>
+                                <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-gray-100">{{ notification.user }}</td>
+                                <td class="px-4 py-3">
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-200">{{ notification.type.value }}</span>
                                 </td>
-                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
                                     {{ notification.creationTime|format_datetime('short', 'short') }}
                                 </td>
                             </tr>

--- a/templates/Settings/Voucher/index.html.twig
+++ b/templates/Settings/Voucher/index.html.twig
@@ -75,11 +75,11 @@
             {% else %}
                 {% embed 'Settings/_table.html.twig' with {
                     headers: [
-                        {label: 'settings.table.id'},
+                        {label: 'settings.table.id', class: 'hidden xl:table-cell'},
                         {label: 'settings.voucher.table.code'},
                         {label: 'settings.voucher.table.user'},
                         {label: 'settings.voucher.table.domain'},
-                        {label: 'settings.table.created'},
+                        {label: 'settings.table.created', class: 'hidden xl:table-cell'},
                         {label: 'settings.voucher.table.status'},
                         {label: 'settings.table.actions', align: 'right'},
                     ]
@@ -87,21 +87,21 @@
                     {% block table_body %}
                         {% for voucher in pagination.items %}
                             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ voucher.id }}</td>
-                                <td class="px-6 py-4 text-sm font-mono text-gray-900 dark:text-gray-100">{{ voucher.code }}</td>
-                                <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100">{{ voucher.user ? voucher.user.email : '—' }}</td>
-                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">{{ voucher.domain ? voucher.domain.name : '—' }}</td>
-                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                <td class="hidden xl:table-cell px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ voucher.id }}</td>
+                                <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-gray-100 max-w-[10rem] truncate" title="{{ voucher.code }}">{{ voucher.code }}</td>
+                                <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 max-w-xs truncate" title="{{ voucher.user ? voucher.user.email : '' }}">{{ voucher.user ? voucher.user.email : '—' }}</td>
+                                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-300">{{ voucher.domain ? voucher.domain.name : '—' }}</td>
+                                <td class="hidden xl:table-cell px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
                                     {{ voucher.creationTime|format_datetime('short', 'short') }}
                                 </td>
-                                <td class="px-6 py-4">
+                                <td class="px-4 py-3">
                                     {% if voucher.redeemed %}
                                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.voucher.status.redeemed'|trans }}</span>
                                     {% else %}
                                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200">{{ 'settings.voucher.status.unredeemed'|trans }}</span>
                                     {% endif %}
                                 </td>
-                                <td class="px-6 py-4 text-right">
+                                <td class="px-4 py-3 text-right">
                                     <form method="post"
                                           action="{{ path('settings_voucher_delete', {id: voucher.id}) }}"
                                           onsubmit="return confirm('{{ 'settings.voucher.delete.confirm'|trans({'%code%': voucher.code|e('js')}) }}');">

--- a/templates/Settings/Webhook/Delivery/index.html.twig
+++ b/templates/Settings/Webhook/Delivery/index.html.twig
@@ -44,7 +44,7 @@
 
             {% embed 'Settings/_table.html.twig' with {
                 headers: [
-                    {label: 'settings.table.id'},
+                    {label: 'settings.table.id', class: 'hidden xl:table-cell'},
                     {label: 'settings.webhook.deliveries.table.event'},
                     {label: 'settings.webhook.deliveries.table.status'},
                     {label: 'settings.webhook.deliveries.table.dispatched'},
@@ -54,11 +54,11 @@
                 {% block table_body %}
                     {% for delivery in deliveries %}
                         <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ delivery.id }}</td>
-                            <td class="px-6 py-4">
+                            <td class="hidden xl:table-cell px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ delivery.id }}</td>
+                            <td class="px-4 py-3">
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-200">{{ delivery.type }}</span>
                             </td>
-                            <td class="px-6 py-4">
+                            <td class="px-4 py-3">
                                 {% if delivery.success %}
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.webhook.deliveries.status.delivered'|trans }}</span>
                                 {% elseif delivery.error %}
@@ -67,10 +67,10 @@
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200">{{ 'settings.webhook.deliveries.status.pending'|trans }}</span>
                                 {% endif %}
                             </td>
-                            <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300">
+                            <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
                                 {{ delivery.dispatchedTime|format_datetime('none', 'medium') }}
                             </td>
-                            <td class="px-6 py-4 text-right">
+                            <td class="px-4 py-3 text-right">
                                 <span class="inline-flex items-center rounded-lg border border-gray-200 dark:border-gray-600 divide-x divide-gray-200 dark:divide-gray-600">
                                     <a href="{{ path('settings_webhook_delivery_show', {id: delivery.id}) }}"
                                        title="{{ 'settings.webhook.deliveries.detail.action'|trans }}"
@@ -100,7 +100,7 @@
                     {% else %}
                         <tr>
                             <td colspan="5"
-                                class="px-6 py-6 text-center text-sm text-gray-500 dark:text-gray-300">{{ 'settings.webhook.deliveries.empty'|trans }}</td>
+                                class="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-300">{{ 'settings.webhook.deliveries.empty'|trans }}</td>
                         </tr>
                     {% endfor %}
                 {% endblock %}

--- a/templates/Settings/Webhook/Endpoint/index.html.twig
+++ b/templates/Settings/Webhook/Endpoint/index.html.twig
@@ -28,7 +28,7 @@
             {% else %}
                 {% embed 'Settings/_table.html.twig' with {
                     headers: [
-                        {label: 'settings.table.id'},
+                        {label: 'settings.table.id', class: 'hidden xl:table-cell'},
                         {label: 'settings.webhook.table.url'},
                         {label: 'settings.webhook.table.events'},
                         {label: 'settings.webhook.table.domains'},
@@ -39,16 +39,16 @@
                     {% block table_body %}
                         {% for endpoint in endpoints %}
                             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ endpoint.id }}</td>
-                                <td class="px-6 py-4 text-sm font-mono break-all text-gray-900 dark:text-gray-100">{{ endpoint.url|e }}</td>
-                                <td class="px-6 py-4">
+                                <td class="hidden xl:table-cell px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ endpoint.id }}</td>
+                                <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-gray-100 max-w-xs truncate" title="{{ endpoint.url|e }}">{{ endpoint.url|e }}</td>
+                                <td class="px-4 py-3">
                                     <div class="flex flex-wrap gap-1">
                                         {% for event in endpoint.events %}
                                             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-200">{{ event }}</span>
                                         {% endfor %}
                                     </div>
                                 </td>
-                                <td class="px-6 py-4">
+                                <td class="px-4 py-3">
                                     <div class="flex flex-wrap gap-1">
                                         {% if endpoint.domains is empty %}
                                             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 whitespace-nowrap">{{ 'settings.webhook.all_domains'|trans }}</span>
@@ -59,11 +59,11 @@
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="px-6 py-4">{% if endpoint.enabled %}<span
+                                <td class="px-4 py-3">{% if endpoint.enabled %}<span
                                             class="text-green-600 dark:text-green-400 font-medium">{{ 'settings.webhook.enabled'|trans }}</span>{% else %}
                                         <span class="text-gray-400 dark:text-gray-500">{{ 'settings.webhook.disabled'|trans }}</span>{% endif %}
                                 </td>
-                                <td class="px-6 py-4 text-right">
+                                <td class="px-4 py-3 text-right">
                                     <span class="inline-flex items-center rounded-lg border border-gray-200 dark:border-gray-600 divide-x divide-gray-200 dark:divide-gray-600">
                                         <a href="{{ path('settings_webhook_delivery_index', {id: endpoint.id}) }}"
                                            title="{{ 'settings.webhook.actions.deliveries'|trans }}"

--- a/templates/Settings/_table.html.twig
+++ b/templates/Settings/_table.html.twig
@@ -1,4 +1,4 @@
-{# Parameters: headers (array of {label, align (default: 'left')}) #}
+{# Parameters: headers (array of {label, align (default: 'left'), class (optional extra CSS classes)}) #}
 {# Usage: {% embed 'Settings/_table.html.twig' with {headers: [...]} %} {% block table_body %}...{% endblock %} {% endembed %} #}
 <div class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
     <div class="overflow-x-auto">
@@ -6,7 +6,7 @@
             <thead class="bg-gray-50 dark:bg-gray-700">
                 <tr>
                     {% for header in headers %}
-                        <th scope="col" class="px-6 py-3 text-{{ header.align|default('left') }} text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider whitespace-nowrap">
+                        <th scope="col" class="px-4 py-3 text-{{ header.align|default('left') }} text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider whitespace-nowrap {{ header.class|default('') }}">
                             {{ header.label|trans }}
                         </th>
                     {% endfor %}


### PR DESCRIPTION
## Summary

- Reduce table cell padding (`px-6 py-4` → `px-4 py-3`) across all settings tables to reclaim horizontal space after the sidebar navigation refactoring
- Hide less important columns (ID, Created, Last Used) below the `xl` breakpoint on tables with 5+ columns to prevent horizontal scrolling
- Add truncation with native title tooltips for long content (URLs, voucher codes, email addresses)
- Extend the `_table.html.twig` component with an optional `class` attribute per header for responsive visibility control

### Affected tables

| Table | Columns | Hidden below xl | Truncated |
|-------|---------|-----------------|-----------|
| Vouchers | 7 → 5 | ID, Created | Code, User email |
| API Tokens | 6 → 4 | ID, Last Used | Name |
| Webhook Endpoints | 6 → 5 | ID | URL |
| Webhook Deliveries | 5 → 4 | ID | — |
| Domains | 4 (unchanged) | — | — |
| Reserved Names | 4 (unchanged) | — | — |
| User Notifications | 4 (unchanged) | — | — |

---
<sub>The changes and the PR were generated by OpenCode.</sub>