### PR TITLE
♻️ Replace Sonata Alias admin with native settings view

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -481,6 +481,7 @@ settings:
     general: Allgemein
     maintenance: Wartung
     reserved-names: Reservierte Namen
+    aliases: Aliase
     vouchers: Einladungen
     domains: Domains
     user-notifications: Benachrichtigungen
@@ -692,6 +693,73 @@ settings:
       button: Exportieren
     pagination:
       total: "%count% reservierte Namen insgesamt"
+      previous: Zurück
+      next: Weiter
+      page: "Seite %page% von %totalPages%"
+
+  alias:
+    title: Aliase
+    heading: Aliase
+    description: Verwalte E-Mail-Aliase für deine Benutzer:innen
+    table:
+      source: Quelle
+      destination: Ziel
+      status: Status
+      empty-title: Keine Aliase
+      empty-description: Es sind noch keine Aliase vorhanden. Erstelle einen Alias, um E-Mails weiterzuleiten.
+    filter:
+      status: Status
+      active: Aktiv
+      deleted: Gelöscht
+      all: Alle
+    status:
+      active: Aktiv
+      deleted: Gelöscht
+    create:
+      button: Alias erstellen
+      title: Alias erstellen
+      heading: Alias erstellen
+      description: Erstelle einen neuen E-Mail-Alias.
+      success: Alias wurde erfolgreich erstellt.
+      error: Alias konnte nicht erstellt werden.
+    edit:
+      title: Alias bearbeiten
+      success: Alias wurde erfolgreich aktualisiert.
+    delete:
+      confirm: "Möchtest du den Alias \"%source%\" wirklich löschen?"
+      success: Alias wurde erfolgreich gelöscht.
+    actions:
+      edit: Bearbeiten
+      delete: Löschen
+    form:
+      title:
+        create: Neuen Alias erstellen
+        edit: Alias bearbeiten
+      description:
+        create: Gib die Quell-E-Mail-Adresse, optional einen Benutzer und ein Ziel für den Alias an.
+      source:
+        label: Quelle
+        help:
+          create: Die Quell-E-Mail-Adresse, die weitergeleitet wird.
+          edit: Die Quell-E-Mail-Adresse kann nicht geändert werden. Erstelle stattdessen einen neuen Alias.
+      user:
+        label: Benutzer
+        help: Wähle den Benutzer, dem dieser Alias gehört. Wenn leer, wird der aktuelle Benutzer verwendet.
+      destination:
+        label: Ziel
+        help: Die Ziel-E-Mail-Adresse. Wenn leer, wird die E-Mail-Adresse des ausgewählten Benutzers verwendet.
+      smtp_quota_limits:
+        label: SMTP-Quota Limits
+        help: Überschreibe die Standard-SMTP-Quota-Limits für diesen Alias.
+      submit:
+        create: Erstellen
+        save: Speichern
+      cancel: Abbrechen
+    search:
+      placeholder: Nach Quelle, Ziel oder Benutzer suchen...
+      submit: Suchen
+    pagination:
+      total: "%count% Aliase insgesamt"
       previous: Zurück
       next: Weiter
       page: "Seite %page% von %totalPages%"

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -501,6 +501,7 @@ settings:
     maintenance: Maintenance
     general: General
     reserved-names: Reserved Names
+    aliases: Aliases
     vouchers: Vouchers
     domains: Domains
     user-notifications: Notifications
@@ -694,6 +695,73 @@ settings:
       button: Export
     pagination:
       total: "%count% reserved names total"
+      previous: Previous
+      next: Next
+      page: "Page %page% of %totalPages%"
+
+  alias:
+    title: Aliases
+    heading: Aliases
+    description: Manage email aliases for your users
+    table:
+      source: Source
+      destination: Destination
+      status: Status
+      empty-title: No aliases
+      empty-description: There are no aliases yet. Create an alias to forward emails.
+    filter:
+      status: Status
+      active: Active
+      deleted: Deleted
+      all: All
+    status:
+      active: Active
+      deleted: Deleted
+    create:
+      button: Create Alias
+      title: Create Alias
+      heading: Create Alias
+      description: Create a new email alias.
+      success: Alias has been created successfully.
+      error: Failed to create alias.
+    edit:
+      title: Edit Alias
+      success: Alias has been updated successfully.
+    delete:
+      confirm: "Are you sure you want to delete the alias \"%source%\"?"
+      success: Alias has been deleted successfully.
+    actions:
+      edit: Edit
+      delete: Delete
+    form:
+      title:
+        create: Create new Alias
+        edit: Edit Alias
+      description:
+        create: Provide the source email, optional user and destination for the alias.
+      source:
+        label: Source
+        help:
+          create: The source email address that will be aliased.
+          edit: The source email address cannot be changed. Create a new alias instead.
+      user:
+        label: User
+        help: Select the user who owns this alias. If left empty, defaults to the current user.
+      destination:
+        label: Destination
+        help: The destination email address. If left empty, defaults to the selected user's email.
+      smtp_quota_limits:
+        label: SMTP Quota Limits
+        help: Override the default SMTP quota limits for this alias.
+      submit:
+        create: Create
+        save: Save
+      cancel: Cancel
+    search:
+      placeholder: Search by source, destination or user...
+      submit: Search
+    pagination:
+      total: "%count% aliases total"
       previous: Previous
       next: Next
       page: "Page %page% of %totalPages%"

--- a/features/settings_aliases.feature
+++ b/features/settings_aliases.feature
@@ -1,0 +1,96 @@
+Feature: Settings (Aliases)
+
+  Background:
+    Given the database is clean
+    And the following Domain exists:
+      | name        |
+      | example.org |
+    And the following User exists:
+      | email             | password | roles      |
+      | louis@example.org | asdasd   | ROLE_ADMIN |
+      | user@example.org  | asdasd   | ROLE_USER  |
+
+  @aliases
+  Scenario: Normal user cannot access aliases page
+    Given I am authenticated as "user@example.org"
+    When I am on "/settings/aliases/"
+
+    Then I should see "Access Denied"
+    And the response status code should be 403
+
+  @aliases
+  Scenario: Admin can list aliases
+    Given I am authenticated as "louis@example.org"
+    When I am on "/settings/aliases/"
+
+    Then the response status code should be 200
+    And I should see "Aliases"
+
+  @aliases
+  Scenario: Admin can access create alias page
+    Given I am authenticated as "louis@example.org"
+    When I am on "/settings/aliases/create"
+
+    Then the response status code should be 200
+    And I should see "Create new Alias"
+
+  @aliases
+  Scenario: Admin can filter aliases by status
+    Given I am authenticated as "louis@example.org"
+    When I am on "/settings/aliases/?deleted=deleted"
+
+    Then the response status code should be 200
+    And I should see "Aliases"
+
+  @aliases
+  Scenario: Admin can create an alias
+    Given I am authenticated as "louis@example.org"
+    When I am on "/settings/aliases/create"
+    Then the response status code should be 200
+
+    When I fill in "alias_admin_source" with "newalias@example.org"
+    And I press "Create"
+
+    Then I should see "Alias has been created successfully"
+
+  @aliases
+  Scenario: Admin can list existing aliases
+    Given the following Alias exists:
+      | source              | destination       |
+      | alias1@example.org  | louis@example.org |
+      | alias2@example.org  | user@example.org  |
+    And I am authenticated as "louis@example.org"
+    When I am on "/settings/aliases/"
+
+    Then the response status code should be 200
+    And I should see "alias1@example.org"
+    And I should see "alias2@example.org"
+
+  @aliases
+  Scenario: Admin can delete an alias
+    Given the following Alias exists:
+      | source              | destination       |
+      | todelete@example.org | louis@example.org |
+    And I am authenticated as "louis@example.org"
+    When I am on "/settings/aliases/"
+
+    Then I should see "todelete@example.org"
+
+    When I press "Delete"
+
+    Then I should see "Alias has been deleted successfully"
+
+  @aliases
+  Scenario: Admin can access edit alias page
+    Given the following Alias exists:
+      | source              | destination       |
+      | editalias@example.org | louis@example.org |
+    And I am authenticated as "louis@example.org"
+    When I am on "/settings/aliases/"
+
+    Then I should see "editalias@example.org"
+
+    When I follow "Edit"
+
+    Then the response status code should be 200
+    And I should see "Edit Alias"

--- a/src/Controller/Settings/AliasController.php
+++ b/src/Controller/Settings/AliasController.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Settings;
+
+use App\Entity\Alias;
+use App\Enum\Roles;
+use App\Exception\ValidationException;
+use App\Form\AliasAdminType;
+use App\Form\Model\AliasAdminModel;
+use App\Service\AliasManager;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class AliasController extends AbstractController
+{
+    public function __construct(
+        private readonly AliasManager $manager,
+    ) {
+    }
+
+    #[Route('/settings/aliases/', name: 'settings_alias_index', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $search = $request->query->getString('search', '');
+        $deleted = $request->query->getString('deleted', 'active');
+
+        return $this->render('Settings/Alias/index.html.twig', [
+            'pagination' => $this->manager->findPaginated($request->query->getInt('page', 1), $search, $deleted),
+            'search' => $search,
+            'deleted' => $deleted,
+        ]);
+    }
+
+    #[Route('/settings/aliases/create', name: 'settings_alias_create', methods: ['GET'])]
+    public function create(): Response
+    {
+        $isAdmin = $this->isGranted(Roles::ADMIN);
+        $form = $this->createForm(AliasAdminType::class, new AliasAdminModel(), [
+            'action' => $this->generateUrl('settings_alias_create_post'),
+            'method' => 'POST',
+            'is_admin' => $isAdmin,
+        ]);
+
+        return $this->render('Settings/Alias/form.html.twig', [
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/settings/aliases/create', name: 'settings_alias_create_post', methods: ['POST'])]
+    public function createSubmit(Request $request): Response
+    {
+        $isAdmin = $this->isGranted(Roles::ADMIN);
+        $model = new AliasAdminModel();
+        $form = $this->createForm(AliasAdminType::class, $model, [
+            'is_admin' => $isAdmin,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $this->manager->create($model);
+                $this->addFlash('success', 'settings.alias.create.success');
+
+                return $this->redirectToRoute('settings_alias_index');
+            } catch (ValidationException) {
+                $this->addFlash('error', 'settings.alias.create.error');
+            }
+        }
+
+        return $this->render('Settings/Alias/form.html.twig', [
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/settings/aliases/edit/{id}', name: 'settings_alias_edit', methods: ['GET'])]
+    public function edit(#[MapEntity] Alias $alias): Response
+    {
+        if ($alias->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
+        $isAdmin = $this->isGranted(Roles::ADMIN);
+        $model = AliasAdminModel::fromAlias($alias);
+
+        $form = $this->createForm(AliasAdminType::class, $model, [
+            'action' => $this->generateUrl('settings_alias_edit_post', ['id' => $alias->getId()]),
+            'method' => 'POST',
+            'is_admin' => $isAdmin,
+            'is_edit' => true,
+        ]);
+
+        return $this->render('Settings/Alias/form.html.twig', [
+            'form' => $form,
+            'alias' => $alias,
+        ]);
+    }
+
+    #[Route('/settings/aliases/edit/{id}', name: 'settings_alias_edit_post', methods: ['POST'])]
+    public function editSubmit(#[MapEntity] Alias $alias, Request $request): Response
+    {
+        if ($alias->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
+        $isAdmin = $this->isGranted(Roles::ADMIN);
+        $model = new AliasAdminModel();
+        $form = $this->createForm(AliasAdminType::class, $model, [
+            'is_admin' => $isAdmin,
+            'is_edit' => true,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->manager->update($alias, $model);
+            $this->addFlash('success', 'settings.alias.edit.success');
+
+            return $this->redirectToRoute('settings_alias_index');
+        }
+
+        return $this->render('Settings/Alias/form.html.twig', [
+            'form' => $form,
+            'alias' => $alias,
+        ]);
+    }
+
+    #[Route('/settings/aliases/delete/{id}', name: 'settings_alias_delete', methods: ['POST'])]
+    public function delete(#[MapEntity] Alias $alias, Request $request): RedirectResponse
+    {
+        if ($alias->isDeleted()) {
+            return $this->redirectToRoute('settings_alias_index');
+        }
+
+        if (!$this->isCsrfTokenValid('delete_alias_'.$alias->getId(), $request->request->get('_token'))) {
+            return $this->redirectToRoute('settings_alias_index');
+        }
+
+        $this->manager->delete($alias);
+        $this->addFlash('success', 'settings.alias.delete.success');
+
+        return $this->redirectToRoute('settings_alias_index');
+    }
+}

--- a/src/Form/AliasAdminType.php
+++ b/src/Form/AliasAdminType.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Form\Model\AliasAdminModel;
+use App\Validator\EmailAllowedSymbols;
+use App\Validator\EmailDomain;
+use App\Validator\Lowercase;
+use Override;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @extends AbstractType<AliasAdminModel>
+ */
+final class AliasAdminType extends AbstractType
+{
+    #[Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ($options['is_edit']) {
+            $builder->add('source', EmailType::class, [
+                'disabled' => true,
+            ]);
+        } else {
+            $builder->add('source', EmailType::class, [
+                'constraints' => [
+                    new Assert\NotNull(),
+                    new Assert\Email(mode: 'strict'),
+                    new Lowercase(),
+                    new EmailAllowedSymbols(),
+                    new EmailDomain(),
+                ],
+            ]);
+        }
+
+        $builder->add('user', UserAutocompleteType::class, [
+            'required' => false,
+        ]);
+
+        if ($options['is_admin']) {
+            $builder
+                ->add('destination', EmailType::class, [
+                    'required' => false,
+                ])
+                ->add('smtpQuotaLimits', SmtpQuotaLimitsType::class, [
+                    'required' => false,
+                ]);
+        }
+
+        $builder->add('submit', SubmitType::class);
+    }
+
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => AliasAdminModel::class,
+            'is_admin' => false,
+            'is_edit' => false,
+        ]);
+
+        $resolver->setAllowedTypes('is_admin', 'bool');
+        $resolver->setAllowedTypes('is_edit', 'bool');
+    }
+}

--- a/src/Form/Model/AliasAdminModel.php
+++ b/src/Form/Model/AliasAdminModel.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Model;
+
+use App\Entity\Alias;
+use App\Entity\User;
+
+final class AliasAdminModel
+{
+    private ?string $source = null;
+
+    private ?User $user = null;
+
+    private ?string $destination = null;
+
+    /** @var array<string, int>|null */
+    private ?array $smtpQuotaLimits = null;
+
+    public static function fromAlias(Alias $alias): self
+    {
+        $model = new self();
+        $model->source = $alias->getSource();
+        $model->user = $alias->getUser();
+        $model->destination = $alias->getDestination();
+        $model->smtpQuotaLimits = $alias->getSmtpQuotaLimits();
+
+        return $model;
+    }
+
+    public function getSource(): ?string
+    {
+        return $this->source;
+    }
+
+    public function setSource(?string $source): void
+    {
+        $this->source = $source;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getDestination(): ?string
+    {
+        return $this->destination;
+    }
+
+    public function setDestination(?string $destination): void
+    {
+        $this->destination = $destination;
+    }
+
+    /**
+     * @return array<string, int>|null
+     */
+    public function getSmtpQuotaLimits(): ?array
+    {
+        return $this->smtpQuotaLimits;
+    }
+
+    /**
+     * @param array<string, int>|null $smtpQuotaLimits
+     */
+    public function setSmtpQuotaLimits(?array $smtpQuotaLimits): void
+    {
+        $this->smtpQuotaLimits = $smtpQuotaLimits;
+    }
+}

--- a/src/Repository/AliasRepository.php
+++ b/src/Repository/AliasRepository.php
@@ -8,6 +8,7 @@ use App\Entity\Alias;
 use App\Entity\Domain;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -85,6 +86,53 @@ final class AliasRepository extends ServiceEntityRepository
         }
 
         return $result['smtpQuotaLimits'] ?? [];
+    }
+
+    public function countByFilters(string $search = '', ?Domain $domain = null, string $deleted = 'active'): int
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->select('COUNT(a.id)');
+
+        $this->applyFilters($qb, $search, $domain, $deleted);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @return Alias[]
+     */
+    public function findPaginatedByFilters(string $search = '', ?Domain $domain = null, string $deleted = 'active', int $limit = 20, int $offset = 0): array
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->orderBy('a.id', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset);
+
+        $this->applyFilters($qb, $search, $domain, $deleted);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    private function applyFilters(QueryBuilder $qb, string $search, ?Domain $domain, string $deleted): void
+    {
+        if ('' !== $search) {
+            $qb->leftJoin('a.user', 'u')
+                ->andWhere('a.source LIKE :search OR a.destination LIKE :search OR u.email LIKE :search')
+                ->setParameter('search', '%'.$search.'%');
+        }
+
+        if (null !== $domain) {
+            $qb->andWhere('a.domain = :domain')
+                ->setParameter('domain', $domain);
+        }
+
+        if ('active' === $deleted) {
+            $qb->andWhere('a.deleted = :deleted')
+                ->setParameter('deleted', false);
+        } elseif ('deleted' === $deleted) {
+            $qb->andWhere('a.deleted = :deleted')
+                ->setParameter('deleted', true);
+        }
     }
 
     /**

--- a/src/Service/AliasManager.php
+++ b/src/Service/AliasManager.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Dto\PaginatedResult;
+use App\Entity\Alias;
+use App\Entity\User;
+use App\Enum\Roles;
+use App\Exception\ValidationException;
+use App\Form\Model\AliasAdminModel;
+use App\Guesser\DomainGuesser;
+use App\Handler\DeleteHandler;
+use App\Repository\AliasRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final readonly class AliasManager
+{
+    private const int PAGE_SIZE = 20;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private AliasRepository $repository,
+        private DomainGuesser $domainGuesser,
+        private DeleteHandler $deleteHandler,
+        private Security $security,
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    /**
+     * Find aliases with offset-based pagination and optional filters.
+     *
+     * @return PaginatedResult<Alias>
+     */
+    public function findPaginated(int $page = 1, string $search = '', string $deleted = 'active'): PaginatedResult
+    {
+        $page = max(1, $page);
+        $offset = ($page - 1) * self::PAGE_SIZE;
+        $total = $this->repository->countByFilters($search, null, $deleted);
+        $totalPages = max(1, (int) ceil($total / self::PAGE_SIZE));
+        $items = $this->repository->findPaginatedByFilters($search, null, $deleted, self::PAGE_SIZE, $offset);
+
+        return new PaginatedResult($items, $page, $totalPages, $total);
+    }
+
+    /**
+     * Create a new alias from the admin form model.
+     *
+     * @throws ValidationException
+     */
+    public function create(AliasAdminModel $model): Alias
+    {
+        $alias = new Alias();
+        $alias->setSource($model->getSource());
+        if (null !== $model->getUser()) {
+            $alias->setUser($model->getUser());
+        }
+
+        $alias->setDestination($model->getDestination());
+        $alias->setSmtpQuotaLimits($model->getSmtpQuotaLimits());
+
+        $this->applyDefaults($alias);
+
+        $violations = $this->validator->validate($alias);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+
+        $this->em->persist($alias);
+        $this->em->flush();
+
+        return $alias;
+    }
+
+    /**
+     * Update an existing alias from the admin form model.
+     */
+    public function update(Alias $alias, AliasAdminModel $model): void
+    {
+        if (null !== $model->getUser()) {
+            $alias->setUser($model->getUser());
+        }
+
+        $alias->setDestination($model->getDestination());
+        $alias->setSmtpQuotaLimits($model->getSmtpQuotaLimits());
+
+        $this->applyDefaults($alias);
+
+        $this->em->flush();
+    }
+
+    /**
+     * Soft-delete an alias.
+     */
+    public function delete(Alias $alias): void
+    {
+        $this->deleteHandler->deleteAlias($alias);
+    }
+
+    /**
+     * Apply default values for user, destination, and domain.
+     *
+     * Mirrors the prePersist/preUpdate logic from the Sonata AliasAdmin:
+     * - If no destination and no user: set user to current user
+     * - If user set but no destination: set destination to user's email
+     * - Guess domain from source email
+     * - Domain admins (non-ROLE_ADMIN) are forced to use the user's email as destination
+     */
+    private function applyDefaults(Alias $alias): void
+    {
+        if (null === $alias->getDestination() && null === $alias->getUser()) {
+            $user = $this->security->getUser();
+            if ($user instanceof User) {
+                $alias->setUser($user);
+            }
+        }
+
+        if (null === $alias->getDestination()) {
+            $alias->setDestination($alias->getUser()?->getEmail());
+        }
+
+        if (null !== $alias->getSource()) {
+            $domain = $this->domainGuesser->guess($alias->getSource());
+            if (null !== $domain) {
+                $alias->setDomain($domain);
+            }
+        }
+
+        // Domain admins are only allowed to set alias destination to existing user's email
+        if (!$this->security->isGranted(Roles::ADMIN)) {
+            $alias->setDestination($alias->getUser()?->getEmail());
+        }
+    }
+}

--- a/templates/Settings/Alias/form.html.twig
+++ b/templates/Settings/Alias/form.html.twig
@@ -1,0 +1,97 @@
+{% set current_section = 'aliases' %}
+{% extends 'Settings/base_settings.html.twig' %}
+
+{% form_theme form 'Form/fields.html.twig' %}
+{% set is_edit = alias is defined %}
+
+{% block title %}
+    {{ setting('app_name') }} - {{ is_edit ? 'settings.alias.edit.title'|trans : 'settings.alias.create.title'|trans }}
+{% endblock %}
+
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            <div class="flex items-center mb-6">
+                <div class="w-12 h-12 {{ is_edit ? 'bg-indigo-100 dark:bg-indigo-900/50' : 'bg-blue-100 dark:bg-blue-900/50' }} rounded-xl flex items-center justify-center mr-4">
+                    {% if is_edit %}
+                        {{ ux_icon('heroicons:pencil-square', {class: 'w-6 h-6 text-indigo-600 dark:text-indigo-400'}) }}
+                    {% else %}
+                        {{ ux_icon('heroicons:plus', {class: 'w-6 h-6 text-blue-600 dark:text-blue-400'}) }}
+                    {% endif %}
+                </div>
+                <div>
+                    <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                        {% if is_edit %}
+                            {{ 'settings.alias.form.title.edit'|trans }}
+                        {% else %}
+                            {{ 'settings.alias.form.title.create'|trans }}
+                        {% endif %}
+                    </h3>
+                    {% if not is_edit %}
+                        <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.alias.form.description.create'|trans }}</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            {{ form_start(form) }}
+            {{ form_errors(form) }}
+
+            <div class="space-y-6">
+                <div>
+                    {{ form_label(form.source, 'settings.alias.form.source.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.source) }}
+                    {{ form_widget(form.source) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ is_edit ? 'settings.alias.form.source.help.edit'|trans : 'settings.alias.form.source.help.create'|trans }}
+                    </p>
+                </div>
+
+                <div>
+                    {{ form_label(form.user, 'settings.alias.form.user.label') }}
+                    {{ form_errors(form.user) }}
+                    {{ form_widget(form.user) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.alias.form.user.help'|trans }}
+                    </p>
+                </div>
+
+                {% if form.destination is defined %}
+                    <div>
+                        {{ form_label(form.destination, 'settings.alias.form.destination.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                        {{ form_errors(form.destination) }}
+                        {{ form_widget(form.destination) }}
+                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                            {{ 'settings.alias.form.destination.help'|trans }}
+                        </p>
+                    </div>
+                {% endif %}
+
+                {% if form.smtpQuotaLimits is defined %}
+                    <div>
+                        {{ form_label(form.smtpQuotaLimits, 'settings.alias.form.smtp_quota_limits.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                        {{ form_errors(form.smtpQuotaLimits) }}
+                        {{ form_widget(form.smtpQuotaLimits) }}
+                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                            {{ 'settings.alias.form.smtp_quota_limits.help'|trans }}
+                        </p>
+                    </div>
+                {% endif %}
+
+                <div class="flex items-center justify-between pt-6">
+                    <a href="{{ path('settings_alias_index') }}"
+                       class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.alias.form.cancel'|trans }}
+                    </a>
+                    {{ form_widget(form.submit, {
+                        label: is_edit ? 'settings.alias.form.submit.save' : 'settings.alias.form.submit.create',
+                        attr: {
+                            class: 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
+                        }
+                    }) }}
+                </div>
+            </div>
+            {{ form_end(form) }}
+        </div>
+    </div>
+{% endblock %}

--- a/templates/Settings/Alias/index.html.twig
+++ b/templates/Settings/Alias/index.html.twig
@@ -1,0 +1,122 @@
+{% set current_section = 'aliases' %}
+{% extends 'Settings/base_settings.html.twig' %}
+{% block title %}{{ setting('app_name') }} - {{ 'settings.alias.title'|trans }}{% endblock %}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:at-symbol',
+                icon_color: 'blue',
+                heading_key: 'settings.alias.heading',
+                description_key: 'settings.alias.description',
+            } %}
+
+            <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                <div class="flex flex-wrap items-center gap-2">
+                    <a href="{{ path('settings_alias_create') }}"
+                       class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.alias.create.button'|trans }}
+                    </a>
+                </div>
+
+                {% include 'Settings/_search_form.html.twig' with {
+                    index_route: 'settings_alias_index',
+                    placeholder_key: 'settings.alias.search.placeholder',
+                    submit_key: 'settings.alias.search.submit',
+                    search: search,
+                    extra_params: {deleted: deleted}|filter(v => v and v != 'active'),
+                } %}
+            </div>
+
+            <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
+                <div class="flex items-center gap-2">
+                    <label for="deleted-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.alias.filter.status'|trans }}:</label>
+                    <select id="deleted-filter"
+                            onchange="window.location.href = this.value"
+                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('settings_alias_index', {search: search, deleted: 'active'}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'settings.alias.filter.active'|trans }}</option>
+                        <option value="{{ path('settings_alias_index', {search: search, deleted: 'deleted'}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'settings.alias.filter.deleted'|trans }}</option>
+                        <option value="{{ path('settings_alias_index', {search: search}|filter(v => v)) }}"{% if deleted == '' %} selected{% endif %}>{{ 'settings.alias.filter.all'|trans }}</option>
+                    </select>
+                </div>
+            </div>
+
+            {% if pagination.items is empty %}
+                {% include 'Settings/_empty_state.html.twig' with {
+                    icon: 'heroicons:at-symbol',
+                    title_key: 'settings.alias.table.empty-title',
+                    description_key: 'settings.alias.table.empty-description',
+                } %}
+            {% else %}
+                {% embed 'Settings/_table.html.twig' with {
+                    headers: [
+                        {label: 'settings.table.id', class: 'hidden xl:table-cell'},
+                        {label: 'settings.alias.table.source'},
+                        {label: 'settings.alias.table.destination'},
+                        {label: 'settings.table.created', class: 'hidden xl:table-cell'},
+                        {label: 'settings.alias.table.status'},
+                        {label: 'settings.table.actions', align: 'right'},
+                    ]
+                } %}
+                    {% block table_body %}
+                        {% for alias in pagination.items %}
+                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                <td class="hidden xl:table-cell px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ alias.id }}</td>
+                                <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 max-w-xs truncate" title="{{ alias.source }}">{{ alias.source }}</td>
+                                <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 max-w-xs truncate" title="{{ alias.destination ?? '' }}">{{ alias.destination ?? '—' }}</td>
+                                <td class="hidden xl:table-cell px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
+                                    {{ alias.creationTime|format_datetime('short', 'short') }}
+                                </td>
+                                <td class="px-4 py-3">
+                                    {% if alias.deleted %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ 'settings.alias.status.deleted'|trans }}</span>
+                                    {% else %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.alias.status.active'|trans }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-4 py-3 text-right">
+                                    <div class="inline-flex items-center gap-1">
+                                        {% if not alias.deleted %}
+                                            <a href="{{ path('settings_alias_edit', {id: alias.id}) }}"
+                                               title="{{ 'settings.alias.actions.edit'|trans }}"
+                                               data-controller="tooltip"
+                                               class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                                {{ ux_icon('heroicons:pencil-square', {class: 'w-4 h-4'}) }}
+                                                <span class="sr-only">{{ 'settings.alias.actions.edit'|trans }}</span>
+                                            </a>
+                                            <form method="post"
+                                                  action="{{ path('settings_alias_delete', {id: alias.id}) }}"
+                                                  onsubmit="return confirm('{{ 'settings.alias.delete.confirm'|trans({'%source%': alias.source|e('js')}) }}');">
+                                                <input type="hidden" name="_token"
+                                                       value="{{ csrf_token('delete_alias_' ~ alias.id) }}">
+                                                <button type="submit"
+                                                        title="{{ 'settings.alias.actions.delete'|trans }}"
+                                                        data-controller="tooltip"
+                                                        class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                                    {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
+                                                    <span class="sr-only">{{ 'settings.alias.actions.delete'|trans }}</span>
+                                                </button>
+                                            </form>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endblock %}
+                {% endembed %}
+
+                {% include 'Settings/_pagination.html.twig' with {
+                    index_route: 'settings_alias_index',
+                    total_key: 'settings.alias.pagination.total',
+                    previous_key: 'settings.alias.pagination.previous',
+                    next_key: 'settings.alias.pagination.next',
+                    page_key: 'settings.alias.pagination.page',
+                    pagination: pagination,
+                    search: search,
+                    extra_params: {deleted: deleted}|filter(v => v and v != 'active'),
+                } %}
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/templates/Settings/_navigation.html.twig
+++ b/templates/Settings/_navigation.html.twig
@@ -14,6 +14,7 @@
     {route: 'settings_maintenance_show', section: 'maintenance', icon: 'heroicons:building-library', label: 'settings.navigation.maintenance'},
     {route: 'settings_domain_index', section: 'domains', icon: 'heroicons:globe-alt', label: 'settings.navigation.domains'},
     {route: 'settings_reserved_name_index', section: 'reserved-names', icon: 'heroicons:shield-exclamation', label: 'settings.navigation.reserved-names'},
+    {route: 'settings_alias_index', section: 'aliases', icon: 'heroicons:at-symbol', label: 'settings.navigation.aliases'},
     {route: 'settings_voucher_index', section: 'vouchers', icon: 'heroicons:ticket', label: 'settings.navigation.vouchers'},
     {route: 'settings_user_notification_index', section: 'user-notifications', icon: 'heroicons:bell-alert', label: 'settings.navigation.user-notifications'},
     {route: 'sonata_admin_dashboard', section: 'admin', icon: 'heroicons:shield-check', label: 'Admin'},

--- a/tests/Form/AliasAdminTypeTest.php
+++ b/tests/Form/AliasAdminTypeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form;
+
+use App\Form\AliasAdminType;
+use App\Form\DataTransformer\UserToIdTransformer;
+use App\Form\Model\AliasAdminModel;
+use App\Form\SmtpQuotaLimitsType;
+use App\Form\UserAutocompleteType;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Validator\Validation;
+
+class AliasAdminTypeTest extends TypeTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private UrlGeneratorInterface $urlGenerator;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $this->urlGenerator->method('generate')->willReturn('/settings/users/search');
+        parent::setUp();
+    }
+
+    protected function getExtensions(): array
+    {
+        $userAutocomplete = new UserAutocompleteType(
+            new UserToIdTransformer($this->entityManager),
+            $this->urlGenerator,
+        );
+
+        $validator = Validation::createValidator();
+
+        return [
+            new PreloadedExtension([$userAutocomplete, new SmtpQuotaLimitsType()], []),
+            new ValidatorExtension($validator),
+        ];
+    }
+
+    public function testCreateFormHasExpectedFields(): void
+    {
+        $form = $this->factory->create(AliasAdminType::class, null, [
+            'is_admin' => true,
+            'is_edit' => false,
+        ]);
+        $view = $form->createView();
+
+        self::assertArrayHasKey('source', $view->children);
+        self::assertArrayHasKey('user', $view->children);
+        self::assertArrayHasKey('destination', $view->children);
+        self::assertArrayHasKey('smtpQuotaLimits', $view->children);
+        self::assertArrayHasKey('submit', $view->children);
+    }
+
+    public function testNonAdminFormHidesAdminFields(): void
+    {
+        $form = $this->factory->create(AliasAdminType::class, null, [
+            'is_admin' => false,
+            'is_edit' => false,
+        ]);
+        $view = $form->createView();
+
+        self::assertArrayHasKey('source', $view->children);
+        self::assertArrayHasKey('user', $view->children);
+        self::assertArrayNotHasKey('destination', $view->children);
+        self::assertArrayNotHasKey('smtpQuotaLimits', $view->children);
+        self::assertArrayHasKey('submit', $view->children);
+    }
+
+    public function testEditFormHasDisabledSource(): void
+    {
+        $form = $this->factory->create(AliasAdminType::class, null, [
+            'is_admin' => true,
+            'is_edit' => true,
+        ]);
+
+        $sourceConfig = $form->get('source')->getConfig();
+        self::assertTrue($sourceConfig->getOption('disabled'));
+    }
+
+    public function testSubmitValidData(): void
+    {
+        $formData = [
+            'source' => 'alias@example.org',
+            'user' => '',
+            'destination' => 'dest@example.org',
+            'smtpQuotaLimits' => ['per_hour' => 100, 'per_day' => 1000],
+        ];
+
+        $model = new AliasAdminModel();
+        $form = $this->factory->create(AliasAdminType::class, $model, [
+            'is_admin' => true,
+            'is_edit' => true,
+        ]);
+
+        $form->submit($formData);
+
+        self::assertTrue($form->isSynchronized());
+        // Source is disabled in edit mode, so it won't be submitted
+        self::assertSame('dest@example.org', $model->getDestination());
+        self::assertSame(['per_hour' => 100, 'per_day' => 1000], $model->getSmtpQuotaLimits());
+    }
+}

--- a/tests/Service/AliasManagerTest.php
+++ b/tests/Service/AliasManagerTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Dto\PaginatedResult;
+use App\Entity\Alias;
+use App\Entity\Domain;
+use App\Entity\User;
+use App\Exception\ValidationException;
+use App\Form\Model\AliasAdminModel;
+use App\Guesser\DomainGuesser;
+use App\Handler\DeleteHandler;
+use App\Repository\AliasRepository;
+use App\Service\AliasManager;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class AliasManagerTest extends TestCase
+{
+    private AliasRepository&Stub $repository;
+    private EntityManagerInterface&Stub $entityManager;
+    private DomainGuesser&Stub $domainGuesser;
+    private DeleteHandler&Stub $deleteHandler;
+    private Security&Stub $security;
+    private ValidatorInterface&Stub $validator;
+    private AliasManager $manager;
+    private Domain $domain;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createStub(AliasRepository::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->domainGuesser = $this->createStub(DomainGuesser::class);
+        $this->deleteHandler = $this->createStub(DeleteHandler::class);
+        $this->security = $this->createStub(Security::class);
+        $this->validator = $this->createStub(ValidatorInterface::class);
+        $this->validator->method('validate')->willReturn(new ConstraintViolationList());
+
+        $this->domain = new Domain();
+        $this->domain->setName('example.org');
+
+        $this->security->method('isGranted')->willReturn(true);
+        $this->security->method('getUser')->willReturn(new User('admin@example.org'));
+        $this->domainGuesser->method('guess')->willReturn($this->domain);
+
+        $this->manager = new AliasManager(
+            $this->entityManager,
+            $this->repository,
+            $this->domainGuesser,
+            $this->deleteHandler,
+            $this->security,
+            $this->validator,
+        );
+    }
+
+    public function testFindPaginated(): void
+    {
+        $this->repository->method('countByFilters')->willReturn(25);
+        $this->repository->method('findPaginatedByFilters')->willReturn([
+            new Alias(),
+            new Alias(),
+        ]);
+
+        $result = $this->manager->findPaginated(1, '', 'active');
+
+        self::assertInstanceOf(PaginatedResult::class, $result);
+        self::assertSame(1, $result->page);
+        self::assertSame(2, $result->totalPages);
+        self::assertSame(25, $result->total);
+        self::assertCount(2, $result->items);
+    }
+
+    public function testFindPaginatedWithFilters(): void
+    {
+        $this->repository->method('countByFilters')->willReturn(5);
+        $this->repository->method('findPaginatedByFilters')->willReturn([
+            new Alias(),
+        ]);
+
+        $result = $this->manager->findPaginated(1, 'test', 'deleted');
+
+        self::assertSame(1, $result->page);
+        self::assertSame(1, $result->totalPages);
+        self::assertSame(5, $result->total);
+        self::assertCount(1, $result->items);
+    }
+
+    public function testFindPaginatedClampsPageToMin1(): void
+    {
+        $this->repository->method('countByFilters')->willReturn(0);
+        $this->repository->method('findPaginatedByFilters')->willReturn([]);
+
+        $result = $this->manager->findPaginated(0);
+
+        self::assertSame(1, $result->page);
+        self::assertSame(1, $result->totalPages);
+    }
+
+    public function testCreate(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects($this->once())
+            ->method('persist')
+            ->with($this->isInstanceOf(Alias::class));
+        $entityManager
+            ->expects($this->once())
+            ->method('flush');
+
+        $manager = new AliasManager(
+            $entityManager,
+            $this->repository,
+            $this->domainGuesser,
+            $this->deleteHandler,
+            $this->security,
+            $this->validator,
+        );
+
+        $model = new AliasAdminModel();
+        $model->setSource('alias@example.org');
+        $model->setDestination('user@example.org');
+
+        $alias = $manager->create($model);
+
+        self::assertInstanceOf(Alias::class, $alias);
+        self::assertSame('alias@example.org', $alias->getSource());
+        self::assertSame('user@example.org', $alias->getDestination());
+        self::assertSame($this->domain, $alias->getDomain());
+    }
+
+    public function testCreateWithValidationException(): void
+    {
+        $violation = new ConstraintViolation('message', 'messageTemplate', [], null, null, 'someValue');
+
+        $validator = $this->createStub(ValidatorInterface::class);
+        $validator->method('validate')->willReturn(new ConstraintViolationList([$violation]));
+
+        $manager = new AliasManager(
+            $this->entityManager,
+            $this->repository,
+            $this->domainGuesser,
+            $this->deleteHandler,
+            $this->security,
+            $validator,
+        );
+
+        $model = new AliasAdminModel();
+        $model->setSource('alias@example.org');
+
+        $this->expectException(ValidationException::class);
+
+        $manager->create($model);
+    }
+
+    public function testCreateSetsDefaultUserWhenNoUserAndNoDestination(): void
+    {
+        $currentUser = new User('admin@example.org');
+        $security = $this->createStub(Security::class);
+        $security->method('isGranted')->willReturn(true);
+        $security->method('getUser')->willReturn($currentUser);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new AliasManager(
+            $entityManager,
+            $this->repository,
+            $this->domainGuesser,
+            $this->deleteHandler,
+            $security,
+            $this->validator,
+        );
+
+        $model = new AliasAdminModel();
+        $model->setSource('alias@example.org');
+
+        $alias = $manager->create($model);
+
+        self::assertSame($currentUser, $alias->getUser());
+        self::assertSame('admin@example.org', $alias->getDestination());
+    }
+
+    public function testCreateSetsDestinationFromUser(): void
+    {
+        $user = new User('target@example.org');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new AliasManager(
+            $entityManager,
+            $this->repository,
+            $this->domainGuesser,
+            $this->deleteHandler,
+            $this->security,
+            $this->validator,
+        );
+
+        $model = new AliasAdminModel();
+        $model->setSource('alias@example.org');
+        $model->setUser($user);
+
+        $alias = $manager->create($model);
+
+        self::assertSame($user, $alias->getUser());
+        self::assertSame('target@example.org', $alias->getDestination());
+    }
+
+    public function testUpdate(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects($this->once())
+            ->method('flush');
+
+        $manager = new AliasManager(
+            $entityManager,
+            $this->repository,
+            $this->domainGuesser,
+            $this->deleteHandler,
+            $this->security,
+            $this->validator,
+        );
+
+        $alias = new Alias();
+        $alias->setSource('alias@example.org');
+
+        $user = new User('user@example.org');
+        $model = AliasAdminModel::fromAlias($alias);
+        $model->setUser($user);
+        $model->setDestination('dest@example.org');
+
+        $manager->update($alias, $model);
+
+        self::assertSame($user, $alias->getUser());
+        self::assertSame('dest@example.org', $alias->getDestination());
+    }
+
+    public function testDelete(): void
+    {
+        $alias = new Alias();
+
+        /** @var DeleteHandler&MockObject $deleteHandler */
+        $deleteHandler = $this->createMock(DeleteHandler::class);
+        $deleteHandler
+            ->expects($this->once())
+            ->method('deleteAlias')
+            ->with($alias);
+
+        $manager = new AliasManager(
+            $this->entityManager,
+            $this->repository,
+            $this->domainGuesser,
+            $deleteHandler,
+            $this->security,
+            $this->validator,
+        );
+
+        $manager->delete($alias);
+    }
+
+    public function testDomainAdminForcesDestinationToUserEmail(): void
+    {
+        $user = new User('user@example.org');
+
+        $security = $this->createStub(Security::class);
+        $security->method('isGranted')->willReturn(false); // Not ROLE_ADMIN
+        $security->method('getUser')->willReturn($user);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new AliasManager(
+            $entityManager,
+            $this->repository,
+            $this->domainGuesser,
+            $this->deleteHandler,
+            $security,
+            $this->validator,
+        );
+
+        $model = new AliasAdminModel();
+        $model->setSource('alias@example.org');
+        $model->setUser($user);
+        $model->setDestination('other@example.org');
+
+        $alias = $manager->create($model);
+
+        // Domain admin should have destination forced to user's email
+        self::assertSame('user@example.org', $alias->getDestination());
+    }
+}


### PR DESCRIPTION
## Summary

- Implements a native Symfony admin interface for Alias management, replacing the existing Sonata Admin implementation (both coexist temporarily)
- Adds `AliasController` with full CRUD (index, create, edit, delete), `AliasManager` service, `AliasAdminType` form with role-dependent fields, and `AliasAdminModel`
- Extends `AliasRepository` with paginated filter queries (search, status), adds search/status-filter/pagination to the index template, and a shared create/edit form template
- Includes 10 unit tests (AliasManager), 4 form type tests (AliasAdminType), and 8 Behat scenarios

<img width="2880" height="1800" alt="Bildschirmfoto am 2026-03-07 um 20 33 05" src="https://github.com/user-attachments/assets/479bac3e-ea8d-487c-b3ab-966409fe9c02" />
<img width="2880" height="1800" alt="Bildschirmfoto am 2026-03-07 um 20 33 12" src="https://github.com/user-attachments/assets/e379a984-4468-4385-bd7c-eeb1deb36113" />
<img width="2880" height="1800" alt="Bildschirmfoto am 2026-03-07 um 20 33 56" src="https://github.com/user-attachments/assets/31ff85d0-f9df-4966-831a-d66da0147302" />


Closes #1084

---
<sub>The changes and the PR were generated by OpenCode.</sub>