### PR TITLE
🔒 Add missing CSRF validation and fix null-safety in settings controllers

### DIFF
--- a/src/Controller/Settings/ApiTokenController.php
+++ b/src/Controller/Settings/ApiTokenController.php
@@ -76,7 +76,7 @@ final class ApiTokenController extends AbstractController
 
     #[Route('/settings/api/delete/{id}', name: 'settings_api_delete', methods: ['POST'])]
     public function delete(
-        #[MapEntity(class: ApiToken::class, mapping: ['id' => 'id'])] ?ApiToken $apiToken,
+        #[MapEntity] ApiToken $apiToken,
         Request $request,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('delete_api_token_'.$apiToken->getId(), $request->request->get('_token'))) {

--- a/src/Controller/Settings/WebhookEndpointController.php
+++ b/src/Controller/Settings/WebhookEndpointController.php
@@ -104,8 +104,12 @@ final class WebhookEndpointController extends AbstractController
     }
 
     #[Route('/settings/webhooks/delete/{id}', name: 'settings_webhook_endpoint_delete', methods: ['POST'])]
-    public function delete(#[MapEntity] WebhookEndpoint $endpoint): RedirectResponse
+    public function delete(#[MapEntity] WebhookEndpoint $endpoint, Request $request): RedirectResponse
     {
+        if (!$this->isCsrfTokenValid('delete_webhook_endpoint_'.$endpoint->getId(), $request->request->get('_token'))) {
+            return $this->redirectToRoute('settings_webhook_endpoint_index');
+        }
+
         $this->manager->delete($endpoint);
         $this->addFlash('success', 'settings.webhook.delete.success');
 


### PR DESCRIPTION
## Summary

- **Add CSRF token validation to `WebhookEndpointController::delete()`**: The template already generated a CSRF token (`csrf_token('delete_webhook_endpoint_' ~ endpoint.id)`), but the controller never validated it — unlike all other settings delete endpoints (`AliasController`, `VoucherController`, `ReservedNameController`, `ApiTokenController`). This left the endpoint vulnerable to cross-site request forgery.
- **Fix null-safety in `ApiTokenController::delete()`**: The `$apiToken` parameter was typed as `?ApiToken` (nullable), but `$apiToken->getId()` was called unconditionally on line 82. A request with a non-existent ID would cause a `TypeError` instead of a proper 404 response. Changed to non-nullable `ApiToken` so Symfony's entity resolver returns a 404 automatically, consistent with all other settings delete endpoints.

Both issues were identified during a systematic IDOR (Insecure Direct Object Reference) security audit of the codebase. No IDOR vulnerabilities were found — these are the only two issues discovered.

---
<sub>The changes and the PR were generated by OpenCode.</sub>