### PR TITLE
🔒 Enable cryptographic signing for all Messenger handlers

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,31 @@
 # Upgrade documentation
 
+## Unreleased
+
+### Messenger message signing enabled
+
+All Messenger message handlers now use cryptographic signing (`sign: true`) via
+Symfony's `SigningSerializer`. Messages are signed with an HMAC-SHA256 signature
+using `APP_SECRET` when dispatched and verified when consumed.
+
+**Deployment impact:** Messages already in the queue at the time of deployment
+will lack a valid signature and will be **rejected** by the consumer with an
+`InvalidMessageSignatureException`. To avoid message loss:
+
+1. **Before deploying**, drain the message queue by running the consumer until
+   all pending messages are processed:
+   ```shell
+   bin/console messenger:consume async --limit=0
+   ```
+2. **Deploy** the new version.
+3. **Start** the consumer as usual.
+
+Alternatively, if draining is not possible, you can purge the queue (messages
+will be lost):
+```shell
+bin/console doctrine:query:sql "DELETE FROM messenger_messages"
+```
+
 ## Upgrade to 6.3.0
 
 ### MAIL_CRYPT environment variable removed

--- a/src/MessageHandler/ClearCacheHandler.php
+++ b/src/MessageHandler/ClearCacheHandler.php
@@ -8,7 +8,7 @@ use App\Message\ClearCache;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class ClearCacheHandler
 {
     public function __construct(private CacheItemPoolInterface $cache)

--- a/src/MessageHandler/CreatePostmasterAliasHandler.php
+++ b/src/MessageHandler/CreatePostmasterAliasHandler.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class CreatePostmasterAliasHandler
 {
     public function __construct(

--- a/src/MessageHandler/DeleteUserHandler.php
+++ b/src/MessageHandler/DeleteUserHandler.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class DeleteUserHandler
 {
     public function __construct(

--- a/src/MessageHandler/InvalidateAliasCacheHandler.php
+++ b/src/MessageHandler/InvalidateAliasCacheHandler.php
@@ -11,7 +11,7 @@ use App\Repository\AliasRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\Cache\CacheInterface;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class InvalidateAliasCacheHandler
 {
     public function __construct(private CacheInterface $cache, private AliasRepository $aliasRepository)

--- a/src/MessageHandler/InvalidateDomainCacheHandler.php
+++ b/src/MessageHandler/InvalidateDomainCacheHandler.php
@@ -9,7 +9,7 @@ use App\Message\InvalidateDomainCache;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\Cache\CacheInterface;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class InvalidateDomainCacheHandler
 {
     public function __construct(private CacheInterface $cache)

--- a/src/MessageHandler/InvalidateOpenPgpKeyCacheHandler.php
+++ b/src/MessageHandler/InvalidateOpenPgpKeyCacheHandler.php
@@ -9,7 +9,7 @@ use App\Message\InvalidateOpenPgpKeyCache;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\Cache\CacheInterface;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class InvalidateOpenPgpKeyCacheHandler
 {
     public function __construct(private CacheInterface $cache)

--- a/src/MessageHandler/InvalidateUserCacheHandler.php
+++ b/src/MessageHandler/InvalidateUserCacheHandler.php
@@ -9,7 +9,7 @@ use App\Message\InvalidateUserCache;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\Cache\CacheInterface;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class InvalidateUserCacheHandler
 {
     public function __construct(private CacheInterface $cache)

--- a/src/MessageHandler/PruneUserNotificationsHandler.php
+++ b/src/MessageHandler/PruneUserNotificationsHandler.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class PruneUserNotificationsHandler
 {
     public function __construct(

--- a/src/MessageHandler/PruneWebhookDeliveriesHandler.php
+++ b/src/MessageHandler/PruneWebhookDeliveriesHandler.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class PruneWebhookDeliveriesHandler
 {
     public function __construct(

--- a/src/MessageHandler/RemoveInactiveUsersHandler.php
+++ b/src/MessageHandler/RemoveInactiveUsersHandler.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class RemoveInactiveUsersHandler
 {
     public function __construct(

--- a/src/MessageHandler/ReportSuspiciousChildrenHandler.php
+++ b/src/MessageHandler/ReportSuspiciousChildrenHandler.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class ReportSuspiciousChildrenHandler
 {
     public function __construct(

--- a/src/MessageHandler/SendWebhookHandler.php
+++ b/src/MessageHandler/SendWebhookHandler.php
@@ -13,7 +13,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Throwable;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class SendWebhookHandler
 {
     public function __construct(

--- a/src/MessageHandler/SendWeeklyReportHandler.php
+++ b/src/MessageHandler/SendWeeklyReportHandler.php
@@ -10,7 +10,7 @@ use App\Service\SettingsService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class SendWeeklyReportHandler
 {
     public function __construct(

--- a/src/MessageHandler/UnlinkRedeemedVouchersHandler.php
+++ b/src/MessageHandler/UnlinkRedeemedVouchersHandler.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class UnlinkRedeemedVouchersHandler
 {
     public function __construct(

--- a/src/MessageHandler/WelcomeMailHandler.php
+++ b/src/MessageHandler/WelcomeMailHandler.php
@@ -10,7 +10,7 @@ use App\Sender\WelcomeMessageSender;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(sign: true)]
 final readonly class WelcomeMailHandler
 {
     public function __construct(


### PR DESCRIPTION
## Summary

- Enable HMAC-SHA256 message signing (`sign: true`) on all 15 Messenger handlers via Symfony 7.4's `SigningSerializer`
- Prevents processing of forged or tampered messages if an attacker gains write access to the Doctrine message queue
- Add deployment guidance to UPGRADE.md (queue must be drained before deployment)

## Context

Symfony 7.4 introduced [per-handler message signing](https://symfony.com/blog/new-in-symfony-7-4-signing-messages) as a defense-in-depth measure. Messages are signed with `APP_SECRET` when dispatched and the signature is verified before consumption. Invalid or missing signatures cause an `InvalidMessageSignatureException`.

This is particularly important for destructive handlers like `DeleteUserHandler` and `RemoveInactiveUsersHandler`, which perform irreversible operations (permanent user deletion including cryptographic keys).

## Deployment

⚠️ Messages already in the queue will be rejected after deployment. See UPGRADE.md for details on draining the queue before deploying.

---
<sub>The changes and the PR were generated by OpenCode.</sub>