### PR TITLE
🔥 Remove incorrect copy-paste docblocks from MailCryptKeyHandler

### DIFF
--- a/src/Handler/MailCryptKeyHandler.php
+++ b/src/Handler/MailCryptKeyHandler.php
@@ -14,9 +14,6 @@ use Symfony\Component\Process\Process;
 
 use const OPENSSL_KEYTYPE_EC;
 
-/**
- * Class AliasHandler.
- */
 final readonly class MailCryptKeyHandler
 {
     // Use elliptic curve type 'secp521r1' for MailCrypt keys
@@ -32,9 +29,6 @@ final readonly class MailCryptKeyHandler
 
     public const string MESSAGE_DECRYPTION_FAILED = 'decryption of mailCryptSecretBox failed';
 
-    /**
-     * MailCryptPrivateKeyHandler constructor.
-     */
     public function __construct(private EntityManagerInterface $manager)
     {
     }


### PR DESCRIPTION
## Summary

- Remove `/** Class AliasHandler. */` docblock from `MailCryptKeyHandler` — a copy-paste artifact referencing the wrong class
- Remove redundant `/** MailCryptPrivateKeyHandler constructor. */` docblock that adds no information beyond what the code already communicates

Pure documentation cleanup, no behavior changes.

---
<sub>The changes and the PR were generated by OpenCode.</sub>