### PR TITLE
♻️ Add missing readonly keywords to stateless classes

### DIFF
--- a/src/EventListener/ApiScopeListener.php
+++ b/src/EventListener/ApiScopeListener.php
@@ -12,7 +12,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
-final class ApiScopeListener implements EventSubscriberInterface
+final readonly class ApiScopeListener implements EventSubscriberInterface
 {
     #[Override]
     public static function getSubscribedEvents(): array

--- a/src/EventListener/LogoutListener.php
+++ b/src/EventListener/LogoutListener.php
@@ -9,7 +9,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 
-final class LogoutListener implements EventSubscriberInterface
+final readonly class LogoutListener implements EventSubscriberInterface
 {
     public function onLogoutSuccess(LogoutEvent $event): void
     {

--- a/src/Service/SettingsConfigService.php
+++ b/src/Service/SettingsConfigService.php
@@ -9,21 +9,18 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Yaml\Yaml;
 
-final class SettingsConfigService
+final readonly class SettingsConfigService
 {
-    private array $settings = [];
+    private array $settings;
 
     public function __construct(
-        #[Autowire(param: 'kernel.project_dir')] private readonly string $projectDir,
+        #[Autowire(param: 'kernel.project_dir')] string $projectDir,
     ) {
-        $this->loadDefaults();
-    }
-
-    private function loadDefaults(): void
-    {
-        $configFile = $this->projectDir.'/config/settings.yaml';
+        $configFile = $projectDir.'/config/settings.yaml';
 
         if (!file_exists($configFile)) {
+            $this->settings = [];
+
             return;
         }
 
@@ -31,7 +28,6 @@ final class SettingsConfigService
         $processor = new Processor();
         $configuration = new SettingsConfiguration();
 
-        // Pass the 'settings' part of the config to the processor
         $settingsConfig = $config['settings'] ?? [];
         $this->settings = $processor->processConfiguration($configuration, [$settingsConfig]);
     }


### PR DESCRIPTION
## Summary

- Add `readonly` modifier to `LogoutListener`, `ApiScopeListener`, and `SettingsConfigService` for consistency with the rest of the codebase
- Inline `loadDefaults()` into `SettingsConfigService` constructor to enable `readonly` declaration and remove the unused `$projectDir` property

No behavior changes. All 853 tests pass.

---
<sub>The changes and the PR were generated by OpenCode.</sub>