### PR TITLE
🐛 Fix TotpSecretValidator return type to match Symfony's void signature

### DIFF
--- a/src/Validator/TotpSecretValidator.php
+++ b/src/Validator/TotpSecretValidator.php
@@ -20,14 +20,14 @@ final class TotpSecretValidator extends ConstraintValidator
     }
 
     #[Override]
-    public function validate($value, Constraint $constraint): bool
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof TotpSecret) {
             throw new UnexpectedTypeException($constraint, TotpSecret::class);
         }
 
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_string($value)) {
@@ -40,10 +40,6 @@ final class TotpSecretValidator extends ConstraintValidator
         if (!$this->totpAuthenticator->checkCode($user, $value)) {
             $this->context->buildViolation('form.twofactor-secret-invalid')
                 ->addViolation();
-
-            return false;
         }
-
-        return true;
     }
 }


### PR DESCRIPTION
## Summary

- Fix `TotpSecretValidator::validate()` return type from `bool` to `void` to match Symfony's `ConstraintValidator::validate()` signature
- Add missing `mixed` type hint for the `$value` parameter
- Remove unused `return true`/`return false` statements — Symfony's validation system communicates errors exclusively via `$this->context->buildViolation()`

---
<sub>The changes and the PR were generated by OpenCode.</sub>