### PR TITLE
♻️ Use Command::SUCCESS/FAILURE constants instead of literal integers

### DIFF
--- a/src/Command/AliasDeleteCommand.php
+++ b/src/Command/AliasDeleteCommand.php
@@ -42,13 +42,13 @@ final class AliasDeleteCommand extends Command
         if ($email && null === $user = $this->manager->getRepository(User::class)->findByEmail($email)) {
             $output->writeln(sprintf("<error>User with email '%s' not found!</error>", $email));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (empty($source) || null === $alias = $this->manager->getRepository(Alias::class)->findOneBySource($source)) {
             $output->writeln(sprintf("<error>Alias with address '%s' not found!</error>", $source));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if ($input->getOption('dry-run')) {
@@ -67,6 +67,6 @@ final class AliasDeleteCommand extends Command
             }
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/OpenPgpDeleteKeyCommand.php
+++ b/src/Command/OpenPgpDeleteKeyCommand.php
@@ -52,6 +52,6 @@ final class OpenPgpDeleteKeyCommand extends Command
             $output->writeln(sprintf('Deleted OpenPGP key for email %s: %s', $openPgpKey->getEmail(), $openPgpKey->getKeyFingerprint()));
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/OpenPgpImportKeyCommand.php
+++ b/src/Command/OpenPgpImportKeyCommand.php
@@ -57,11 +57,11 @@ final class OpenPgpImportKeyCommand extends Command
         } catch (NoGpgKeyForUserException|MultipleGpgKeysForUserException $e) {
             $output->writeln(sprintf('Error: %s in %s', $e->getMessage(), $file));
 
-            return 0;
+            return Command::FAILURE;
         }
 
         $output->writeln(sprintf('Imported OpenPGP key for email %s: %s', $email, $openPgpKey->getKeyFingerprint()));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/OpenPgpShowKeyCommand.php
+++ b/src/Command/OpenPgpShowKeyCommand.php
@@ -49,6 +49,6 @@ final class OpenPgpShowKeyCommand extends Command
             $output->writeln(sprintf('OpenPGP key for email %s: %s', $openPgpKey->getEmail(), $openPgpKey->getKeyFingerprint()));
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/UsersRegistrationMailCommand.php
+++ b/src/Command/UsersRegistrationMailCommand.php
@@ -52,6 +52,6 @@ final class UsersRegistrationMailCommand extends Command
 
         $this->welcomeMessageSender->send($user, $locale);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
## Summary

- Replace literal `0` and `1` return values with `Command::SUCCESS` and `Command::FAILURE` constants in 5 command classes for consistency with the rest of the codebase
- Also fixes a bug in `OpenPgpImportKeyCommand` where the error path (catch block for `NoGpgKeyForUserException`/`MultipleGpgKeysForUserException`) incorrectly returned `0` (success) instead of `1` (failure), making it impossible for scripts to detect import failures

### Affected commands
- `OpenPgpShowKeyCommand`
- `OpenPgpDeleteKeyCommand`
- `OpenPgpImportKeyCommand` (includes bug fix)
- `UsersRegistrationMailCommand`
- `AliasDeleteCommand`

---
<sub>The changes and the PR were generated by OpenCode.</sub>