### PR TITLE
♻️ Replace fluent setters with void setters in OpenPgpKey form model

### DIFF
--- a/src/Form/Model/OpenPgpKey.php
+++ b/src/Form/Model/OpenPgpKey.php
@@ -15,14 +15,9 @@ final class OpenPgpKey
         return $this->keyFile;
     }
 
-    /**
-     * @return $this
-     */
-    public function setKeyFile(string $keyFile): self
+    public function setKeyFile(string $keyFile): void
     {
         $this->keyFile = $keyFile;
-
-        return $this;
     }
 
     public function getKeyText(): ?string
@@ -30,13 +25,8 @@ final class OpenPgpKey
         return $this->keyText;
     }
 
-    /**
-     * @return $this
-     */
-    public function setKeyText(string $keyText): self
+    public function setKeyText(string $keyText): void
     {
         $this->keyText = $keyText;
-
-        return $this;
     }
 }


### PR DESCRIPTION
## Summary

- Replace fluent setters (`return $this`) with void setters in `OpenPgpKey` form model for consistency with all other 16 form models in the codebase
- Remove redundant `@return $this` docblocks
- Symfony Forms call setters via PropertyAccess which ignores return values, so this change is safe

---
<sub>The changes and the PR were generated by OpenCode.</sub>