### PR TITLE
🔧 Remove redundant kernel.event_subscriber tag from services.yaml

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,11 +35,6 @@ services:
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 
-    App\EventListener\:
-        resource: "../src/EventListener/*"
-        tags:
-            - { name: kernel.event_subscriber }
-
     # Custom TOTP Authenticator that uses settings instead of environment variables
     App\Service\SettingsAwareTotpAuthenticator:
         decorates: "scheb_two_factor.security.totp_authenticator"


### PR DESCRIPTION
## Summary

- Remove redundant `kernel.event_subscriber` tag for `App\EventListener\` classes in `config/services.yaml`
- The tag is unnecessary because `autoconfigure: true` already registers all classes implementing `EventSubscriberInterface` as event subscribers automatically
- The classes are also already registered as services by the `App\` resource block, so the separate resource registration was a duplicate

Verified via `bin/console debug:event-dispatcher` — all 15 event listeners remain properly registered.

---
<sub>The changes and the PR were generated by OpenCode.</sub>