### PR TITLE
🔒 Add CSP nonces to inline dark mode scripts

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -14,7 +14,7 @@
     {% endblock %}
 
     {# Dark mode initialization - respects system preference and saved preference #}
-    <script>
+    <script nonce="{{ csp_nonce('script') }}">
         (function() {
             const savedTheme = localStorage.getItem('theme');
             if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ setting('app_name') }} - {{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
     <link rel="stylesheet" href="{{ asset('build/app.css') }}">
-    <script>
+    <script nonce="{{ csp_nonce('script') }}">
         (function() {
             const savedTheme = localStorage.getItem('theme');
             if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ setting('app_name') }} - {{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
     <link rel="stylesheet" href="{{ asset('build/app.css') }}">
-    <script>
+    <script nonce="{{ csp_nonce('script') }}">
         (function() {
             const savedTheme = localStorage.getItem('theme');
             if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ setting('app_name') }} - {{ "error.title"|trans|default("Oops, an error occurred.") }}</title>
     <link rel="stylesheet" href="{{ asset('build/app.css') }}">
-    <script>
+    <script nonce="{{ csp_nonce('script') }}">
         (function() {
             const savedTheme = localStorage.getItem('theme');
             if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {


### PR DESCRIPTION
## Summary

- Add `csp_nonce('script')` to all 4 inline dark mode initialization scripts (`base.html.twig` + 3 error templates)
- NelmioSecurityBundle automatically generates a per-request nonce and adds it to the CSP response header
- Per CSP Level 2 spec, browsers that support nonces ignore `unsafe-inline` when a nonce is present, effectively hardening CSP for our own templates

### Why not remove `unsafe-inline` entirely?

Sonata Admin still requires `unsafe-inline` for its extensive inline scripts and styles. Once Sonata Admin is replaced (Phase 2), `unsafe-inline` can be fully removed from the CSP config.

### Templates changed
- `templates/base.html.twig`
- `templates/bundles/TwigBundle/Exception/error.html.twig`
- `templates/bundles/TwigBundle/Exception/error403.html.twig`
- `templates/bundles/TwigBundle/Exception/error404.html.twig`

---
<sub>The changes and the PR were generated by OpenCode.</sub>