### PR TITLE
♻️ Simplify locale parameters in services.yaml

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -2,7 +2,7 @@ twig:
   default_path: '%kernel.project_dir%/templates'
   form_themes: ['Form/fields.html.twig']
   globals:
-    locales: '%supported_locales%'
+    locales: '%locales%'
   file_name_pattern: '*.twig'
 
 when@test:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,9 +7,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-    locale: "en"
-    locales: "en|de|es|fr|it|pt|nb|gsw"
-    supported_locales: ["en", "de", "es", "fr", "it", "pt", "nb", "gsw"]
+    locales: ["en", "de", "es", "fr", "it", "pt", "nb", "gsw"]
 
 services:
     # default configuration for services in *this* file

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -13,9 +13,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
 final readonly class LocaleListener implements EventSubscriberInterface
 {
     public function __construct(
-        #[Autowire(param: 'locale')]
+        #[Autowire('kernel.default_locale')]
         private string $defaultLocale,
-        #[Autowire(param: 'supported_locales')]
+        #[Autowire(param: 'locales')]
         private array $supportedLocales,
     ) {
     }


### PR DESCRIPTION
## Summary

- Remove the unused `locales` parameter (pipe-separated string, no consumers)
- Remove the redundant `locale` parameter (duplicated Symfony's `kernel.default_locale`)
- Rename `supported_locales` to `locales` (cleaner name, now that the old `locales` is gone)
- Switch `LocaleListener` to use `kernel.default_locale` for consistency with `AliasCreationListener`, `RecoveryProcessListener`, and `UsersRegistrationMailCommand`

### Before (3 parameters, 1 unused)

```yaml
parameters:
    locale: "en"
    locales: "en|de|es|fr|it|pt|nb|gsw"
    supported_locales: ["en", "de", "es", "fr", "it", "pt", "nb", "gsw"]
```

### After (1 custom parameter + Symfony built-in)

```yaml
parameters:
    locales: ["en", "de", "es", "fr", "it", "pt", "nb", "gsw"]
```

---
<sub>The changes and the PR were generated by OpenCode.</sub>