### PR TITLE
♻️ Replace inline onchange handlers with Stimulus navigate controller

### DIFF
--- a/assets/controllers/navigate_controller.ts
+++ b/assets/controllers/navigate_controller.ts
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus";
+
+/**
+ * Navigate controller — redirects the browser when a select value changes.
+ *
+ * Usage:
+ *   <select data-controller="navigate"
+ *           data-action="change->navigate#go">
+ *     <option value="/path/to/page">Page</option>
+ *   </select>
+ */
+export default class extends Controller {
+  go(event: Event): void {
+    const target = event.target as HTMLSelectElement;
+
+    try {
+      const parsed = new URL(target.value, window.location.origin);
+      if (parsed.origin === window.location.origin) {
+        window.location.assign(parsed.href);
+      }
+    } catch {
+      // ignore invalid URLs
+    }
+  }
+}

--- a/templates/Settings/Alias/index.html.twig
+++ b/templates/Settings/Alias/index.html.twig
@@ -33,7 +33,8 @@
                 <div class="flex items-center gap-2">
                     <label for="deleted-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.alias.filter.status'|trans }}:</label>
                     <select id="deleted-filter"
-                            onchange="window.location.href = this.value"
+                            data-controller="navigate"
+                            data-action="change->navigate#go"
                             class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                         <option value="{{ path('settings_alias_index', {search: search, deleted: 'active'}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'settings.alias.filter.active'|trans }}</option>
                         <option value="{{ path('settings_alias_index', {search: search, deleted: 'deleted'}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'settings.alias.filter.deleted'|trans }}</option>

--- a/templates/Settings/UserNotification/index.html.twig
+++ b/templates/Settings/UserNotification/index.html.twig
@@ -15,7 +15,8 @@
                 <div class="flex items-center gap-2">
                     <label for="type-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.user-notification.filter.type'|trans }}:</label>
                     <select id="type-filter"
-                            onchange="window.location.href = this.value"
+                            data-controller="navigate"
+                            data-action="change->navigate#go"
                             class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
                         <option value="{{ path('settings_user_notification_index', {search: search}|filter(v => v)) }}"{% if type == '' %} selected{% endif %}>{{ 'settings.user-notification.filter.all'|trans }}</option>
                         {% for notificationType in notificationTypes %}

--- a/templates/Settings/Voucher/index.html.twig
+++ b/templates/Settings/Voucher/index.html.twig
@@ -56,7 +56,8 @@
                     <div class="flex items-center gap-2">
                         <label for="status-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.voucher.filter.status'|trans }}:</label>
                         <select id="status-filter"
-                                onchange="window.location.href = this.value"
+                                data-controller="navigate"
+                                data-action="change->navigate#go"
                                 class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
                             <option value="{{ path('settings_voucher_index', {search: search, domain: selectedDomain}|filter(v => v)) }}"{% if status == '' %} selected{% endif %}>{{ 'settings.voucher.filter.all'|trans }}</option>
                             <option value="{{ path('settings_voucher_index', {search: search, domain: selectedDomain, status: 'redeemed'}|filter(v => v)) }}"{% if status == 'redeemed' %} selected{% endif %}>{{ 'settings.voucher.filter.redeemed'|trans }}</option>

--- a/templates/Settings/Webhook/Delivery/index.html.twig
+++ b/templates/Settings/Webhook/Delivery/index.html.twig
@@ -20,7 +20,8 @@
                     <div class="flex items-center gap-2">
                         <label for="event-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.webhook.deliveries.filter.event'|trans }}:</label>
                         <select id="event-filter"
-                                onchange="window.location.href = this.value"
+                                data-controller="navigate"
+                                data-action="change->navigate#go"
                                 class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
                             <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status}|filter(v => v)) }}"{% if eventType == '' %} selected{% endif %}>{{ 'settings.webhook.deliveries.filter.all'|trans }}</option>
                             <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: status, eventType: 'user.created'}|filter(v => v)) }}"{% if eventType == 'user.created' %} selected{% endif %}>user.created</option>
@@ -31,7 +32,8 @@
                     <div class="flex items-center gap-2">
                         <label for="status-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.webhook.deliveries.filter.label'|trans }}:</label>
                         <select id="status-filter"
-                                onchange="window.location.href = this.value"
+                                data-controller="navigate"
+                                data-action="change->navigate#go"
                                 class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
                             <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, eventType: eventType}|filter(v => v)) }}"{% if status == '' %} selected{% endif %}>{{ 'settings.webhook.deliveries.filter.all'|trans }}</option>
                             <option value="{{ path('settings_webhook_delivery_index', {id: endpoint.id, status: 'success', eventType: eventType}|filter(v => v)) }}"{% if status == 'success' %} selected{% endif %}>{{ 'settings.webhook.deliveries.status.delivered'|trans }}</option>

--- a/templates/_locale_switcher.html.twig
+++ b/templates/_locale_switcher.html.twig
@@ -84,7 +84,8 @@
 <noscript>
     <div class="relative inline-block text-left">
         <select
-            onchange="window.location.href=this.value"
+            data-controller="navigate"
+            data-action="change->navigate#go"
             class="bg-gray-900/95 text-white text-sm border-gray-600/50 rounded-2xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-white/50 backdrop-blur-md"
             aria-label="{{ 'navbar.select-language'|trans }}"
         >


### PR DESCRIPTION
## Summary

- Replace all inline `onchange="window.location.href = this.value"` event handlers with a new Stimulus `navigate` controller
- Fixes CSP `script-src-attr` violations caused by the nonce-based `script-src` policy (from NelmioSecurityBundle) overriding `unsafe-inline` for inline event handler attributes

## Details

Modern browsers ignore `'unsafe-inline'` in `script-src` when a nonce is present. This caused CSP violations for all `<select>` filter dropdowns that used inline `onchange` handlers.

The new `navigate_controller.ts` Stimulus controller listens for `change` events and redirects to `event.target.value`, providing the same behavior without inline JavaScript.

### Affected templates (6 locations)

| Template | Element |
|---|---|
| `Settings/Alias/index.html.twig` | Status filter (active/deleted/all) |
| `Settings/Webhook/Delivery/index.html.twig` | Event type filter |
| `Settings/Webhook/Delivery/index.html.twig` | Status filter |
| `Settings/UserNotification/index.html.twig` | Notification type filter |
| `Settings/Voucher/index.html.twig` | Status filter |
| `_locale_switcher.html.twig` | noscript locale fallback |

### Note on `unsafe-inline` in CSP

`'unsafe-inline'` remains in `script-src` in `nelmio_security.yaml` because Sonata Admin vendor templates contain extensive inline `<script>` blocks and `onclick` handlers without nonce support. Removing it would break the entire admin panel.

---
<sub>The changes and the PR were generated by OpenCode.</sub>