### PR TITLE
💚 Scope Docker build concurrency group to git ref

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,7 +78,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     needs: test
     concurrency:
-      group: docker-build-push
+      group: docker-build-push-${{ github.head_ref || github.ref }}
       cancel-in-progress: true
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Scope the Docker build concurrency group from the static `docker-build-push` to `docker-build-push-${{ github.ref }}`, so only builds for the same branch/PR cancel each other instead of all Docker builds across the repository.

## Problem

The static concurrency group caused Docker builds from different branches and PRs to cancel each other. In an active repository with multiple open PRs, this led to frequent build cancellations.

---
<sub>The changes and the PR were generated by OpenCode.</sub>