### PR TITLE
🎨 Remove duplicate px-4 padding from inner layout wrappers

### DIFF
--- a/templates/Init/domain.html.twig
+++ b/templates/Init/domain.html.twig
@@ -6,7 +6,7 @@
 
 {% block content %}
     <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">
-        <div class="max-w-5xl mx-auto px-4">
+        <div class="max-w-5xl mx-auto">
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
                 <!-- Left column: Information (1/3) -->
                 <div class="lg:col-span-1">

--- a/templates/Init/settings.html.twig
+++ b/templates/Init/settings.html.twig
@@ -6,7 +6,7 @@
 
 {% block content %}
     <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">
-        <div class="max-w-5xl mx-auto px-4">
+        <div class="max-w-5xl mx-auto">
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
                 <!-- Left column: Information (1/3) -->
                 <div class="lg:col-span-1">

--- a/templates/Init/user.html.twig
+++ b/templates/Init/user.html.twig
@@ -6,7 +6,7 @@
 
 {% block content %}
     <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">
-        <div class="max-w-5xl mx-auto px-4">
+        <div class="max-w-5xl mx-auto">
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
                 <!-- Left column: Information (1/3) -->
                 <div class="lg:col-span-1">

--- a/templates/base_page.html.twig
+++ b/templates/base_page.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">
-        <div class="max-w-6xl mx-auto px-4">
+        <div class="max-w-6xl mx-auto">
             {# Standard page header #}
             <div class="mb-8 sm:mb-12">
                 <div class="text-center">

--- a/templates/base_step.html.twig
+++ b/templates/base_step.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div class="min-h-[calc(100vh-8rem)] py-6 sm:py-8">
-        <div class="max-w-lg mx-auto px-4">
+        <div class="max-w-lg mx-auto">
             <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
                 {# Main content section #}
                 <div class="p-6 sm:p-8">


### PR DESCRIPTION
## Summary

`base.html.twig` already sets `px-4` on `<main>`. The inner `max-w-*` wrapper divs in `base_page.html.twig`, `base_step.html.twig`, and the three Init templates also had `px-4`, which doubled the horizontal padding on narrow viewports where `max-w-*` doesn't yet constrain the width (32px per side instead of 16px).

This PR removes the redundant `px-4` from those inner wrappers. On wide viewports nothing changes visually — the `max-w-*` constraint kicks in before the padding matters. On mobile viewports (~375px) all pages gain back ~16px of breathing room per side.

**Changed files:**

| File | Change |
|------|--------|
| `templates/base_page.html.twig` | `max-w-6xl mx-auto px-4` → `max-w-6xl mx-auto` |
| `templates/base_step.html.twig` | `max-w-lg mx-auto px-4` → `max-w-lg mx-auto` |
| `templates/Init/domain.html.twig` | `max-w-5xl mx-auto px-4` → `max-w-5xl mx-auto` |
| `templates/Init/user.html.twig` | `max-w-5xl mx-auto px-4` → `max-w-5xl mx-auto` |
| `templates/Init/settings.html.twig` | `max-w-5xl mx-auto px-4` → `max-w-5xl mx-auto` |

This is Phase 1 of the layout & modal improvements plan (`.opencode/plans/layout-and-modal-improvements.md`).

---
<sub>The changes and the PR were generated by OpenCode.</sub>