### PR TITLE
💚 Fix SonarCloud PR decoration with pull_request_target

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,6 +71,15 @@ jobs:
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+        with:
+          args: >
+            ${{ github.event_name == 'pull_request_target' && format(
+              '-Dsonar.pullrequest.key={0} -Dsonar.pullrequest.branch={1} -Dsonar.pullrequest.base={2} -Dsonar.scm.revision={3}',
+              github.event.pull_request.number,
+              github.event.pull_request.head.ref,
+              github.event.pull_request.base.ref,
+              github.event.pull_request.head.sha
+            ) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Pass explicit SonarCloud PR parameters (`sonar.pullrequest.key`, `sonar.pullrequest.branch`, `sonar.pullrequest.base`, `sonar.scm.revision`) when the workflow is triggered by `pull_request_target`
- For `push` events on `main`, no extra args are passed and the standard branch analysis runs as before

## Context

The SonarScanner CLI [only recognizes](https://github.com/SonarSource/sonarqube/blob/master/sonar-scanner-engine/src/main/java/org/sonar/scanner/ci/vendors/GithubActions.java#L91) `pull_request` as a GitHub event name (exact string match). When using `pull_request_target` (introduced in #1145 for fork PR support), the scanner cannot detect the PR context and falls back to a branch analysis. This prevents SonarCloud from decorating PRs with coverage, issues, and quality gate status.

By explicitly passing the PR metadata via scanner args, SonarCloud correctly identifies the analysis as a PR analysis and restores PR decoration.

---
<sub>The changes and the PR were generated by OpenCode.</sub>