### PR TITLE
✅ Add JavaScript testing support to Behat via Symfony Panther

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,8 +5,12 @@ DATABASE_DRIVER=pdo_sqlite
 DATABASE_URL=sqlite:///%kernel.project_dir%/var/db_test.sqlite
 DEFAULT_URI=http://localhost
 KERNEL_CLASS='App\Kernel'
-PANTHER_APP_ENV=panther
-PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 REGISTRATION_OPEN="1"
 SYMFONY_DEPRECATIONS_HELPER=999999
 TRUSTED_PROXIES=""
+
+###> symfony/panther ###
+PANTHER_APP_ENV=test
+PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
+PANTHER_DEVTOOLS=0
+###< symfony/panther ###

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,6 +68,9 @@ jobs:
         run: |
           bin/console cache:clear --env=test
           bin/behat --format progress
+        env:
+          PANTHER_CHROME_ARGUMENTS: '--disable-gpu --headless --no-sandbox --disable-dev-shm-usage'
+          PANTHER_NO_SANDBOX: 1
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ yarn-error.log
 ###> vitest ###
 coverage/
 ###< vitest ###
+
+###> symfony/panther ###
+/drivers/
+###< symfony/panther ###

--- a/behat.yml
+++ b/behat.yml
@@ -13,10 +13,24 @@ default:
         path: ~
         environment: ~
         debug: ~
+
+    Robertfausk\Behat\PantherExtension: ~
+
     Behat\MinkExtension:
+      javascript_session: panther
       sessions:
         symfony:
           symfony: ~
+        panther:
+          panther:
+            options:
+              browser: 'chrome'
+              webServerDir: '%paths.base%/public'
+            manager_options:
+              capabilities:
+                goog:chromeOptions:
+                  args:
+                    - '--accept-lang=en'
 
     DVDoug\Behat\CodeCoverage\Extension:
       filter:

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
   "require-dev": {
     "behat/mink": "^1.13",
     "behat/mink-browserkit-driver": "^2.3",
+    "dbrekelmans/bdi": "*",
     "dg/bypass-finals": "^1.1",
     "doctrine/doctrine-fixtures-bundle": "^4.0",
     "dvdoug/behat-code-coverage": "^5.3.7",
@@ -59,6 +60,7 @@
     "phpunit/phpunit": "^12.0",
     "psalm/plugin-symfony": "^5.2",
     "rector/rector": "^2.1.0",
+    "robertfausk/behat-panther-extension": "*",
     "symfony/browser-kit": "^7.4",
     "symfony/css-selector": "^7.4",
     "symfony/debug-bundle": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d1430fa2c53fb025ee8e3e1c68deecb",
+    "content-hash": "51709c9d3be9cabd9686d8209bfb4ee8",
     "packages": [
         {
             "name": "arubacao/tld-checker",
@@ -11523,6 +11523,55 @@
             "time": "2024-04-12T12:12:48+00:00"
         },
         {
+            "name": "dbrekelmans/bdi",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dbrekelmans/bdi.git",
+                "reference": "c2b77127d7aa3fad25d57575c207b54b108ab300"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dbrekelmans/bdi/zipball/c2b77127d7aa3fad25d57575c207b54b108ab300",
+                "reference": "c2b77127d7aa3fad25d57575c207b54b108ab300",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "php": "^8.1"
+            },
+            "bin": [
+                "bdi",
+                "bdi.phar"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniël Brekelmans",
+                    "homepage": "https://github.com/dbrekelmans"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/dbrekelmans/bdi/graphs/contributors"
+                }
+            ],
+            "description": "PHAR distribution of dbrekelmans/browser-driver-installer.",
+            "homepage": "https://github.com/dbrekelmans/bdi",
+            "keywords": [
+                "browser-driver-installer"
+            ],
+            "support": {
+                "source": "https://github.com/dbrekelmans/bdi/tree/1.4.1"
+            },
+            "time": "2025-11-03T11:32:28+00:00"
+        },
+        {
             "name": "dg/bypass-finals",
             "version": "v1.9.0",
             "source": {
@@ -12854,6 +12903,72 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-webdriver/webdriver",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-webdriver/php-webdriver.git",
+                "reference": "ac0662863aa120b4f645869f584013e4c4dba46a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/ac0662863aa120b4f645869f584013e4c4dba46a",
+                "reference": "ac0662863aa120b4f645869f584013e4c4dba46a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php": "^7.3 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.12",
+                "symfony/process": "^5.0 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "replace": {
+                "facebook/webdriver": "*"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.20.0",
+                "ondram/ci-detector": "^4.0",
+                "php-coveralls/php-coveralls": "^2.4",
+                "php-mock/php-mock-phpunit": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpunit/phpunit": "^9.3",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/var-dumper": "^5.0 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-simplexml": "For Firefox profile creation"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Exception/TimeoutException.php"
+                ],
+                "psr-4": {
+                    "Facebook\\WebDriver\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP client for Selenium WebDriver. Previously facebook/webdriver.",
+            "homepage": "https://github.com/php-webdriver/php-webdriver",
+            "keywords": [
+                "Chromedriver",
+                "geckodriver",
+                "php",
+                "selenium",
+                "webdriver"
+            ],
+            "support": {
+                "issues": "https://github.com/php-webdriver/php-webdriver/issues",
+                "source": "https://github.com/php-webdriver/php-webdriver/tree/1.16.0"
+            },
+            "time": "2025-12-28T23:57:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -14416,6 +14531,171 @@
             "time": "2025-08-27T21:33:23+00:00"
         },
         {
+            "name": "robertfausk/behat-panther-extension",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/robertfausk/behat-panther-extension.git",
+                "reference": "838984a60cd53d950382bee321f8b670c3a5d120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/robertfausk/behat-panther-extension/zipball/838984a60cd53d950382bee321f8b670c3a5d120",
+                "reference": "838984a60cd53d950382bee321f8b670c3a5d120",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "^3.0.5",
+                "friends-of-behat/mink-extension": "^2.3.0",
+                "php": ">=7.2",
+                "robertfausk/mink-panther-driver": "^1.0",
+                "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "g1a/composer-test-scenarios": "^3.0",
+                "matthiasnoback/symfony-config-test": "^4.1|^5.1",
+                "phpunit/phpunit": "~7.5|~9.3",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "behat-extension",
+            "extra": {
+                "scenarios": {
+                    "symfony3": {
+                        "require": {
+                            "symfony/config": "^3.4"
+                        }
+                    },
+                    "symfony4": {
+                        "require": {
+                            "symfony/config": "^4.0"
+                        }
+                    },
+                    "symfony5": {
+                        "require": {
+                            "symfony/config": "^5.0"
+                        }
+                    },
+                    "symfony6": {
+                        "require": {
+                            "symfony/config": "^6.0"
+                        }
+                    },
+                    "symfony7": {
+                        "require": {
+                            "symfony/config": "^7.0"
+                        }
+                    }
+                },
+                "branch-alias": {
+                    "dev-main": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Robertfausk\\Behat\\PantherExtension\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Freigang",
+                    "email": "robertfreigang@gmx.de"
+                }
+            ],
+            "description": "Symfony Panther extension for Behat",
+            "keywords": [
+                "Behat",
+                "Cucumber",
+                "Panther",
+                "browser",
+                "chrome",
+                "firefox",
+                "gherkin",
+                "gui",
+                "symfony",
+                "test",
+                "web"
+            ],
+            "support": {
+                "issues": "https://github.com/robertfausk/behat-panther-extension/issues",
+                "source": "https://github.com/robertfausk/behat-panther-extension/tree/v1.2.0"
+            },
+            "time": "2025-04-04T10:09:14+00:00"
+        },
+        {
+            "name": "robertfausk/mink-panther-driver",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/robertfausk/mink-panther-driver.git",
+                "reference": "ac95116505015a43af687220a8e00cefabd34dc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/robertfausk/mink-panther-driver/zipball/ac95116505015a43af687220a8e00cefabd34dc0",
+                "reference": "ac95116505015a43af687220a8e00cefabd34dc0",
+                "shasum": ""
+            },
+            "require": {
+                "behat/mink": "~1.8",
+                "ext-dom": "*",
+                "php": ">=7.2",
+                "symfony/panther": "~0.7|~1.0|~2.0"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1.0",
+                "mink/driver-testsuite": "dev-master",
+                "phpunit/phpunit": "~8.5|~9.3",
+                "symfony/dom-crawler": "~4.0|~5.0|~6.0",
+                "symfony/http-kernel": "~4.0|~5.0|~6.0"
+            },
+            "suggest": {
+                "ext-gd": "*"
+            },
+            "type": "mink-driver",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Behat\\Mink\\Driver\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Freigang",
+                    "email": "robertfreigang@gmx.de"
+                }
+            ],
+            "description": "Symfony Panther driver for Mink framework",
+            "homepage": "http://mink.behat.org/",
+            "keywords": [
+                "Mink",
+                "Panther",
+                "browser",
+                "chrome",
+                "chromium",
+                "firefox",
+                "headless",
+                "symfony",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/robertfausk/mink-panther-driver/issues",
+                "source": "https://github.com/robertfausk/mink-panther-driver/tree/v1.1.2"
+            },
+            "time": "2025-04-03T21:55:18+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "4.2.0",
             "source": {
@@ -15720,6 +16000,95 @@
                 }
             ],
             "time": "2026-02-17T07:53:42+00:00"
+        },
+        {
+            "name": "symfony/panther",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/panther.git",
+                "reference": "2d810395942e71aea2f7ea8e8b5f82326bb4b8b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/panther/zipball/2d810395942e71aea2f7ea8e8b5f82326bb4b8b4",
+                "reference": "2d810395942e71aea2f7ea8e8b5f82326bb4b8b4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": ">=8.1",
+                "php-webdriver/webdriver": "^1.8.2",
+                "symfony/browser-kit": "^6.4 || ^7.3 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.3 || ^8.0",
+                "symfony/deprecation-contracts": "^2.4 || ^3",
+                "symfony/dom-crawler": "^6.4 || ^7.3 || ^8.0",
+                "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0",
+                "symfony/mime": "^6.4 || ^7.3 || ^8.0",
+                "symfony/phpunit-bridge": ">=7.3.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Panther\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "kevin@dunglas.dev",
+                    "homepage": "https://dunglas.dev"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A browser testing and web scraping library for PHP and Symfony.",
+            "homepage": "https://symfony.com/packages/Panther",
+            "keywords": [
+                "e2e",
+                "scraping",
+                "selenium",
+                "symfony",
+                "testing",
+                "webdriver"
+            ],
+            "support": {
+                "issues": "https://github.com/symfony/panther/issues",
+                "source": "https://github.com/symfony/panther/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.panthera.org/donate",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/dunglas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/panther",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-08T05:29:21+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",

--- a/features/password_strength.feature
+++ b/features/password_strength.feature
@@ -1,0 +1,30 @@
+Feature: password_strength
+
+  Background:
+    Given the database is clean
+    And the following Domain exists:
+      | name        |
+      | example.org |
+    And the following User exists:
+      | email             | password |
+      | louis@example.org | asdasd   |
+    And the following Voucher exists:
+      | code   | user              |
+      | TEST00 | louis@example.org |
+
+  @javascript @password_strength
+  Scenario: Password strength meter shows minimum length warning for short passwords
+    When I am on "/register/TEST00"
+    And I fill in "registration[password][first]" with "short"
+    And I wait 500 milliseconds
+    Then I should see the password strength feedback "At least 12 characters required."
+    And I should see 1 active password strength segments
+
+  @javascript @password_strength
+  Scenario: Password strength meter shows strong feedback for a strong password
+    When I am on "/register/TEST00"
+    And I fill in "registration[password][first]" with "C0mpl3x!P@ssw0rd#2024"
+    And I wait 500 milliseconds
+    Then I should see the password strength feedback "Great choice! Your password is strong."
+    And I should see 4 active password strength segments
+

--- a/symfony.lock
+++ b/symfony.lock
@@ -401,6 +401,15 @@
     "symfony/options-resolver": {
         "version": "v4.1.4"
     },
+    "symfony/panther": {
+        "version": "2.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "4380502301e68b744b21d2a0c917693676a72f33"
+        }
+    },
     "symfony/phpunit-bridge": {
         "version": "8.0",
         "recipe": {

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -419,14 +419,25 @@ class FeatureContext extends MinkContext
 
     /**
      * @Given /^I am authenticated as "([^"]*)"$/
-     *
-     * @throws UnsupportedDriverActionException
      */
     public function iAmAuthenticatedAs(string $username): void
     {
         $driver = $this->getSession()->getDriver();
+
+        // For real browser drivers (e.g. Panther), authenticate via the login form
         if (!$driver instanceof BrowserKitDriver) {
-            throw new UnsupportedDriverActionException('This step is only supported by the BrowserKitDriver', $driver);
+            $user = $this->getUserRepository()->findByEmail($username);
+            if (null === $user) {
+                throw new RuntimeException(sprintf('User "%s" does not exist', $username));
+            }
+
+            // Find the plain password from our test fixtures (default: "asdasd")
+            $this->visit('/login');
+            $this->fillField('_username', $username);
+            $this->fillField('_password', 'asdasd');
+            $this->pressButton('Sign in');
+
+            return;
         }
 
         $user = $this->getUserRepository()->findByEmail($username);
@@ -831,5 +842,129 @@ class FeatureContext extends MinkContext
     public function getUserRepository(): ObjectRepository
     {
         return $this->manager->getRepository(User::class);
+    }
+
+    /**
+     * @Then /^I should see the password strength feedback "([^"]*)"$/
+     */
+    public function iShouldSeeThePasswordStrengthFeedback(string $expectedText): void
+    {
+        $this->assertDriverSupportsJavascript();
+
+        $feedback = $this->getSession()->getPage()->find('css', '[data-password-strength-target="feedback"]');
+        if (null === $feedback) {
+            throw new RuntimeException('Password strength feedback element not found');
+        }
+
+        $this->getSession()->wait(5000, sprintf(
+            'document.querySelector(\'[data-password-strength-target="feedback"]\').textContent.includes(%s)',
+            json_encode($expectedText)
+        ));
+
+        $actualText = $feedback->getText();
+        if (!str_contains($actualText, $expectedText)) {
+            throw new RuntimeException(sprintf('Expected password strength feedback to contain "%s", but got "%s"', $expectedText, $actualText));
+        }
+    }
+
+    /**
+     * @Then /^the password strength feedback should not be visible$/
+     */
+    public function thePasswordStrengthFeedbackShouldNotBeVisible(): void
+    {
+        $this->assertDriverSupportsJavascript();
+
+        $feedback = $this->getSession()->getPage()->find('css', '[data-password-strength-target="feedback"]');
+        if (null === $feedback) {
+            throw new RuntimeException('Password strength feedback element not found');
+        }
+
+        if ($feedback->isVisible()) {
+            throw new RuntimeException(sprintf('Expected password strength feedback to be hidden, but it is visible with text: "%s"', $feedback->getText()));
+        }
+    }
+
+    /**
+     * @Then /^I should see (\d+) active password strength segments$/
+     */
+    public function iShouldSeeActivePasswordStrengthSegments(int $expectedCount): void
+    {
+        $this->assertDriverSupportsJavascript();
+
+        // Wait for the strength meter to update
+        $this->getSession()->wait(2000, sprintf(
+            'document.querySelectorAll(\'[data-password-strength-target="segment"]:not(.bg-gray-200)\').length === %d',
+            $expectedCount
+        ));
+
+        $segments = $this->getSession()->getPage()->findAll('css', '[data-password-strength-target="segment"]');
+        $activeCount = 0;
+
+        foreach ($segments as $segment) {
+            $class = $segment->getAttribute('class') ?? '';
+            if (!str_contains($class, 'bg-gray-200')) {
+                ++$activeCount;
+            }
+        }
+
+        if ($activeCount !== $expectedCount) {
+            throw new RuntimeException(sprintf('Expected %d active password strength segments, but found %d', $expectedCount, $activeCount));
+        }
+    }
+
+    /**
+     * @Then /^I wait for the element "([^"]*)" to appear$/
+     */
+    public function iWaitForTheElementToAppear(string $cssSelector): void
+    {
+        $this->assertDriverSupportsJavascript();
+
+        $result = $this->getSession()->wait(5000, sprintf(
+            'document.querySelector(%s) !== null',
+            json_encode($cssSelector)
+        ));
+
+        if (!$result) {
+            throw new RuntimeException(sprintf('Element "%s" did not appear within 5 seconds', $cssSelector));
+        }
+    }
+
+    /**
+     * @When /^I type "([^"]*)" into the field "([^"]*)"$/
+     */
+    public function iTypeIntoTheField(string $value, string $field): void
+    {
+        $this->assertDriverSupportsJavascript();
+
+        $element = $this->getSession()->getPage()->findField($field);
+
+        if (null === $element) {
+            throw new RuntimeException(sprintf('Field "%s" not found', $field));
+        }
+
+        // Focus the field first (triggers Stimulus connect/focus events)
+        $element->focus();
+
+        // Type character by character to trigger input events
+        foreach (str_split($value) as $char) {
+            $currentValue = $element->getValue().$char;
+            $element->setValue($currentValue);
+        }
+    }
+
+    /**
+     * @Then /^I wait (\d+) milliseconds$/
+     */
+    public function iWaitMilliseconds(int $milliseconds): void
+    {
+        $this->getSession()->wait($milliseconds);
+    }
+
+    private function assertDriverSupportsJavascript(): void
+    {
+        $driver = $this->getSession()->getDriver();
+        if ($driver instanceof BrowserKitDriver) {
+            throw new UnsupportedDriverActionException('This step requires a JavaScript-capable browser driver', $driver);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add Symfony Panther as a JavaScript-capable browser driver for Behat, enabling end-to-end testing of Stimulus controllers, modals, and other JS-dependent behavior
- Scenarios tagged with `@javascript` run in headless Chrome; all other tests continue using the fast BrowserKit driver unchanged
- Include example `@javascript` feature testing the password strength meter on the registration form
- Update CI workflow with Chrome environment variables for headless execution in GitHub Actions

### Key changes

**New dependencies:** `robertfausk/behat-panther-extension`, `dbrekelmans/bdi` (browser driver installer)

**`behat.yml`:** Panther session registered as `javascript_session`, Chrome configured with `--accept-lang=en` to ensure consistent English locale in JS tests

**`FeatureContext`:** `iAmAuthenticatedAs()` now falls back to form-based login for real browser drivers instead of throwing; new reusable JS step definitions (`I should see the password strength feedback "..."`, `I should see N active password strength segments`, `I wait for the element "..." to appear`, `I wait N milliseconds`, etc.)

**`features/password_strength.feature`:** Two `@javascript` scenarios verifying the Stimulus-based password strength indicator (short password warning + strong password feedback)

### How to write new `@javascript` tests

Tag any scenario with `@javascript` to run it in Chrome:

```gherkin
@javascript
Scenario: Modal confirms deletion
  Given I am authenticated as "louis@example.org"
  When I am on "/account"
  And I press "Delete"
  Then I wait for the element "[data-modal-target='dialog']" to appear
  And I should see "Are you sure?"
```

### Local setup

```bash
composer require --dev dbrekelmans/bdi && vendor/bin/bdi detect drivers
bin/behat --format progress --tags javascript
```

---
<sub>The changes and the PR were generated by OpenCode.</sub>