### PR TITLE
♻️ Remove redundant max-width constraints from page templates

### DIFF
--- a/templates/Account/index.html.twig
+++ b/templates/Account/index.html.twig
@@ -14,7 +14,7 @@
 {% block page_content %}
 
             {# Dashboard cards grid #}
-            <div class="flex flex-wrap justify-center gap-6 max-w-7xl mx-auto">
+            <div class="flex flex-wrap justify-center gap-6">
 
                 {# Webmail card #}
                 {% set webmail_url = setting('webmail_url') %}
@@ -106,5 +106,4 @@
                     </a>
                 </div>
         </div>
-    </div>
 {% endblock %}

--- a/templates/Account/show.html.twig
+++ b/templates/Account/show.html.twig
@@ -8,7 +8,7 @@
 
 {% block page_content %}
     {# Dashboard cards grid #}
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 auto-rows-fr place-content-center max-w-7xl mx-auto">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 auto-rows-fr place-content-center">
 
         {# Password Change card #}
         <div class="group h-full">

--- a/templates/Account/twofactor_backup_code_confirm.html.twig
+++ b/templates/Account/twofactor_backup_code_confirm.html.twig
@@ -82,5 +82,4 @@
 
                 {% include 'Account/_twofactor_info.html.twig' %}
             </div>
-    </div>
 {% endblock %}

--- a/templates/Account/twofactor_confirm.html.twig
+++ b/templates/Account/twofactor_confirm.html.twig
@@ -98,5 +98,4 @@
 
                 {% include 'Account/_twofactor_info.html.twig' %}
             </div>
-    </div>
 {% endblock %}

--- a/templates/Account/twofactor_disable.html.twig
+++ b/templates/Account/twofactor_disable.html.twig
@@ -58,5 +58,4 @@
                 <!-- Right column: Information -->
                 {% include 'Account/_twofactor_info.html.twig' %}
             </div>
-    </div>
 {% endblock %}

--- a/templates/Account/twofactor_enable.html.twig
+++ b/templates/Account/twofactor_enable.html.twig
@@ -58,5 +58,4 @@
                 <!-- Right column: Information -->
                 {% include 'Account/_twofactor_info.html.twig' %}
             </div>
-    </div>
 {% endblock %}

--- a/templates/Account/twofactor_show.html.twig
+++ b/templates/Account/twofactor_show.html.twig
@@ -101,5 +101,4 @@
                 <!-- Right column: Information -->
                 {% include 'Account/_twofactor_info.html.twig' %}
             </div>
-    </div>
 {% endblock %}

--- a/templates/Alias/show.html.twig
+++ b/templates/Alias/show.html.twig
@@ -10,7 +10,7 @@
 {% block page_subtitle %}{{ "index.alias-subtitle"|trans }}{% endblock %}
 
 {% block page_content %}
-    <div class="max-w-5xl mx-auto">
+    <div class="max-w-4xl mx-auto">
         {# Brief motivational explanation #}
                 <div class="mb-8 text-center">
                     <p class="text-lg text-gray-600 dark:text-gray-300 leading-relaxed max-w-3xl mx-auto">

--- a/templates/Start/index_anonymous.html.twig
+++ b/templates/Start/index_anonymous.html.twig
@@ -7,9 +7,7 @@
 {% block page_subtitle %}{{ "start.intro"|trans }}{% endblock %}
 
 {% block page_content %}
-    <div class="max-w-6xl mx-auto">
-        {# Main content area #}
-        <div class="max-w-5xl mx-auto">
+    <div class="max-w-5xl mx-auto">
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
                     {# Registration section #}
                     <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 sm:p-8">
@@ -63,7 +61,5 @@
                         {{ form_end(login_form) }}
                     </div>
                 </div>
-            </div>
-        </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Remove redundant inner `max-w-7xl mx-auto` from `Account/index.html.twig` and `Account/show.html.twig` (identical to the parent constraint from `base_page.html.twig`)
- Remove orphaned closing `</div>` tags from the 5 twofactor templates left over from a prior partial cleanup
- Collapse double-nested `max-w-6xl` + `max-w-5xl` wrappers in `Start/index_anonymous.html.twig` into a single `max-w-5xl`
- Change `Alias/show.html.twig` from `max-w-5xl` to `max-w-4xl` for visual consistency with `Voucher/show.html.twig`

This continues the layout cleanup started in #1151 by removing remaining redundant width constraints that either duplicate the parent `max-w-7xl` or were left behind from prior refactoring.

---
<sub>The changes and the PR were generated by OpenCode.</sub>