### PR TITLE
♻️ Generalize confirm modal and replace inline JS with Stimulus controller

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -633,6 +633,7 @@ settings:
         pending: Ausstehend
       retry:
         confirm: Zustellung erneut versuchen?
+        confirm-title: Wiederholung bestätigen
         action: Erneut senden
         queued: Zustellung zur erneuten Ausführung eingeplant.
       detail:

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -635,6 +635,7 @@ settings:
         pending: Pending
       retry:
         confirm: Retry this delivery?
+        confirm-title: Confirm retry
         action: Retry
         queued: Delivery retry queued.
       detail:

--- a/templates/Settings/Alias/index.html.twig
+++ b/templates/Settings/Alias/index.html.twig
@@ -122,6 +122,6 @@
             {% endif %}
         </div>
 
-        {% include 'Settings/_delete_confirm_modal.html.twig' %}
+        {% include 'Settings/_confirm_modal.html.twig' %}
     </div>
 {% endblock %}

--- a/templates/Settings/Api/show.html.twig
+++ b/templates/Settings/Api/show.html.twig
@@ -110,6 +110,6 @@
             {% endif %}
         </div>
 
-        {% include 'Settings/_delete_confirm_modal.html.twig' %}
+        {% include 'Settings/_confirm_modal.html.twig' %}
     </div>
 {% endblock %}

--- a/templates/Settings/ReservedName/index.html.twig
+++ b/templates/Settings/ReservedName/index.html.twig
@@ -95,6 +95,6 @@
             {% endif %}
         </div>
 
-        {% include 'Settings/_delete_confirm_modal.html.twig' %}
+        {% include 'Settings/_confirm_modal.html.twig' %}
     </div>
 {% endblock %}

--- a/templates/Settings/Voucher/index.html.twig
+++ b/templates/Settings/Voucher/index.html.twig
@@ -137,6 +137,6 @@
             {% endif %}
         </div>
 
-        {% include 'Settings/_delete_confirm_modal.html.twig' %}
+        {% include 'Settings/_confirm_modal.html.twig' %}
     </div>
 {% endblock %}

--- a/templates/Settings/Webhook/Delivery/index.html.twig
+++ b/templates/Settings/Webhook/Delivery/index.html.twig
@@ -2,7 +2,8 @@
 {% extends 'Settings/base_settings.html.twig' %}
 {% block title %}{{ setting('app_name') }} - {{ 'settings.webhook.deliveries.title'|trans }}{% endblock %}
 {% block settings_content %}
-    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm"
+         data-controller="modal">
         <div class="p-6 sm:p-8">
             {% include 'Settings/_section_header.html.twig' with {
                 icon: 'heroicons:paper-airplane',
@@ -84,7 +85,9 @@
                                     {% if delivery.error and not delivery.success %}
                                         <form method="post"
                                               action="{{ path('settings_webhook_delivery_retry', {id: delivery.id}) }}"
-                                              onsubmit="return confirm('{{ 'settings.webhook.deliveries.retry.confirm'|trans }}')">
+                                              data-action="submit->modal#open"
+                                              data-modal-title-param="{{ 'settings.webhook.deliveries.retry.confirm-title'|trans|e('html_attr') }}"
+                                              data-modal-message-param="{{ 'settings.webhook.deliveries.retry.confirm'|trans|e('html_attr') }}">
                                             <input type="hidden" name="_token"
                                                    value="{{ csrf_token('retry_delivery_' ~ delivery.id) }}">
                                             <button type="submit"
@@ -133,5 +136,13 @@
                 </div>
             {% endif %}
         </div>
+
+        {% if deliveries|filter(d => d.error and not d.success)|length > 0 %}
+            {% include 'Settings/_confirm_modal.html.twig' with {
+                variant: 'info',
+                confirm_label: 'settings.webhook.deliveries.retry.action',
+                modal_id: 'retry-confirm-title',
+            } %}
+        {% endif %}
     </div>
 {% endblock %}

--- a/templates/Settings/Webhook/Delivery/show.html.twig
+++ b/templates/Settings/Webhook/Delivery/show.html.twig
@@ -2,7 +2,8 @@
 {% extends 'Settings/base_settings.html.twig' %}
 {% block title %}{{ setting('app_name') }} - {{ 'settings.webhook.delivery.title'|trans({'%id%': delivery.id}) }}{% endblock %}
 {% block settings_content %}
-    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm"
+         data-controller="modal">
         <div class="p-6 sm:p-8 space-y-8">
             <div class="flex items-start justify-between">
                 <div class="flex items-center">
@@ -24,7 +25,9 @@
                 {% if delivery.error and not delivery.success %}
                     <form method="post"
                           action="{{ path('settings_webhook_delivery_retry', {id: delivery.id}) }}"
-                          onsubmit="return confirm('{{ 'settings.webhook.deliveries.retry.confirm'|trans }}')">
+                          data-action="submit->modal#open"
+                          data-modal-title-param="{{ 'settings.webhook.deliveries.retry.confirm-title'|trans|e('html_attr') }}"
+                          data-modal-message-param="{{ 'settings.webhook.deliveries.retry.confirm'|trans|e('html_attr') }}">
                         <input type="hidden" name="_token"
                                value="{{ csrf_token('retry_delivery_' ~ delivery.id) }}">
                         <button class="inline-flex items-center px-3 py-2 bg-blue-600 dark:bg-blue-500 text-white text-sm font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors">
@@ -106,5 +109,13 @@
                 </div>
             {% endif %}
         </div>
+
+        {% if delivery.error and not delivery.success %}
+            {% include 'Settings/_confirm_modal.html.twig' with {
+                variant: 'info',
+                confirm_label: 'settings.webhook.deliveries.retry.action',
+                modal_id: 'retry-confirm-title',
+            } %}
+        {% endif %}
     </div>
 {% endblock %}

--- a/templates/Settings/Webhook/Endpoint/index.html.twig
+++ b/templates/Settings/Webhook/Endpoint/index.html.twig
@@ -103,6 +103,6 @@
             {% endif %}
         </div>
 
-        {% include 'Settings/_delete_confirm_modal.html.twig' %}
+        {% include 'Settings/_confirm_modal.html.twig' %}
     </div>
 {% endblock %}

--- a/templates/Settings/_confirm_modal.html.twig
+++ b/templates/Settings/_confirm_modal.html.twig
@@ -1,5 +1,5 @@
 {#
-    Reusable delete confirmation modal for Settings pages.
+    Reusable confirmation modal for Settings pages.
 
     This modal is controlled by the modal Stimulus controller. The form's
     submit event is intercepted by `modal#open`, which populates the title
@@ -8,18 +8,41 @@
 
     Usage:
         Wrap your page content and this include in a single element with
-        `data-controller="modal"`. Each delete form should use:
+        `data-controller="modal"`. Each form that needs confirmation should use:
 
             data-action="submit->modal#open"
-            data-modal-title-param="{{ 'delete.confirm-title'|trans }}"
-            data-modal-message-param="{{ '...'|trans({...}) }}"
+            data-modal-title-param="{{ 'some.title'|trans }}"
+            data-modal-message-param="{{ 'some.message'|trans({...}) }}"
+
+    Customization (via `with`):
+        - variant:         'danger' (default) or 'info' — controls icon/button colors
+        - cancel_label:    Translation key for the cancel button (default: 'delete.cancel')
+        - confirm_label:   Translation key for the confirm button (default: 'delete.confirm')
+        - modal_id:        Unique ID for aria-labelledby (default: 'confirm-modal-title')
 #}
+{% set variant = variant|default('danger') %}
+{% set cancel_label = cancel_label|default('delete.cancel') %}
+{% set confirm_label = confirm_label|default('delete.confirm') %}
+{% set modal_id = modal_id|default('confirm-modal-title') %}
+
+{% if variant == 'info' %}
+    {% set icon_bg = 'bg-blue-100 dark:bg-blue-900/50' %}
+    {% set icon_color = 'text-blue-600 dark:text-blue-400' %}
+    {% set icon_name = 'heroicons:arrow-path' %}
+    {% set btn_bg = 'bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-blue-500' %}
+{% else %}
+    {% set icon_bg = 'bg-red-100 dark:bg-red-900/50' %}
+    {% set icon_color = 'text-red-600 dark:text-red-400' %}
+    {% set icon_name = 'heroicons:exclamation-triangle' %}
+    {% set btn_bg = 'bg-red-600 dark:bg-red-500 hover:bg-red-700 dark:hover:bg-red-600 focus:ring-red-500' %}
+{% endif %}
+
 <div data-modal-target="overlay"
      data-action="click->modal#backdropClose"
      class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm opacity-0 transition-opacity duration-200"
      aria-modal="true"
      role="dialog"
-     aria-labelledby="delete-confirm-title">
+     aria-labelledby="{{ modal_id }}">
 
     <div data-modal-target="dialog"
          class="relative w-full max-w-md mx-4 bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-xl opacity-0 scale-95 transition-all duration-200 transform">
@@ -28,10 +51,10 @@
             {# Modal header #}
             <div class="flex items-center justify-between mb-4">
                 <div class="flex items-center">
-                    <div class="w-10 h-10 bg-red-100 dark:bg-red-900/50 rounded-xl flex items-center justify-center mr-3">
-                        {{ ux_icon('heroicons:exclamation-triangle', {'class': 'w-5 h-5 text-red-600 dark:text-red-400'}) }}
+                    <div class="w-10 h-10 {{ icon_bg }} rounded-xl flex items-center justify-center mr-3">
+                        {{ ux_icon(icon_name, {'class': 'w-5 h-5 ' ~ icon_color}) }}
                     </div>
-                    <h3 id="delete-confirm-title"
+                    <h3 id="{{ modal_id }}"
                         data-modal-target="title"
                         class="text-lg font-semibold text-gray-900 dark:text-gray-100">
                     </h3>
@@ -53,13 +76,13 @@
                 <button type="button"
                         data-action="modal#close"
                         class="px-5 py-2.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-medium rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800">
-                    {{ 'delete.cancel'|trans }}
+                    {{ cancel_label|trans }}
                 </button>
                 <button type="button"
                         data-action="modal#confirm"
                         data-modal-target="autofocus"
-                        class="px-5 py-2.5 bg-red-600 dark:bg-red-500 text-white font-medium rounded-lg hover:bg-red-700 dark:hover:bg-red-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800">
-                    {{ 'delete.confirm'|trans }}
+                        class="px-5 py-2.5 {{ btn_bg }} text-white font-medium rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800">
+                    {{ confirm_label|trans }}
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- Generalizes `_delete_confirm_modal.html.twig` into a reusable `_confirm_modal.html.twig` with configurable variants (`danger` for delete, `info` for retry), button labels, icons, and ARIA IDs
- Replaces the last two inline `onsubmit="return confirm()"` handlers in webhook delivery templates with the accessible modal Stimulus controller pattern
- Updates all 5 existing delete modal includes to use the new partial
- Adds `confirm-title` translation keys for retry confirmation (EN/DE)

After this change, **zero inline JavaScript** remains in the template codebase.

---
<sub>The changes and the PR were generated by OpenCode.</sub>