### PR TITLE
✨ Add native User Admin under /settings/users/

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -499,6 +499,7 @@ settings:
     vouchers: Einladungen
     domains: Domains
     user-notifications: Benachrichtigungen
+    users: Benutzer:innen
   maintenance:
     title: Wartung
     subtitle: Führe Wartungsaufgaben bei Bedarf aus
@@ -879,6 +880,95 @@ settings:
       previous: Zurück
       next: Weiter
       page: "Seite %page% von %totalPages%"
+
+  user:
+    title: Benutzer
+    heading: Benutzer
+    description: Verwalte Benutzerkonten, Rollen und Sicherheitseinstellungen
+    table:
+      email: E-Mail
+      roles: Rollen
+      twofactor: 2FA
+      mailcrypt: MailCrypt
+      status: Status
+      empty-title: Keine Benutzer gefunden
+      empty-description: Keine Benutzerkonten entsprechen deinen aktuellen Filtern.
+    filter:
+      status: Status
+      active: Aktiv
+      deleted: Gelöscht
+      all: Alle
+      role: Rolle
+      mailcrypt: MailCrypt
+      twofactor: 2FA
+      enabled: Aktiviert
+      disabled: Deaktiviert
+    status:
+      active: Aktiv
+      deleted: Gelöscht
+    create:
+      button: Benutzer erstellen
+      title: Benutzer erstellen
+      success: Benutzer wurde erfolgreich erstellt.
+    edit:
+      title: Benutzer bearbeiten
+      success: Benutzer wurde erfolgreich aktualisiert.
+    delete:
+      confirm: "Möchtest du den Benutzer \"%email%\" wirklich löschen?"
+      success: Benutzer wurde erfolgreich gelöscht.
+    actions:
+      edit: Bearbeiten
+      delete: Löschen
+    search:
+      placeholder: Nach E-Mail suchen...
+      submit: Suchen
+    pagination:
+      total: "%count% Benutzer insgesamt"
+      previous: Zurück
+      next: Weiter
+      page: "Seite %page% von %totalPages%"
+    form:
+      title:
+        edit: Benutzer bearbeiten
+        create: Neuen Benutzer erstellen
+      description:
+        create: Gib E-Mail-Adresse, Passwort und Rollen für das neue Benutzerkonto an.
+      email:
+        label: E-Mail
+        help:
+          edit: Die E-Mail-Adresse kann nicht geändert werden.
+          create: Die vollständige E-Mail-Adresse für das neue Benutzerkonto.
+      password:
+        label: Passwort
+        help:
+          mailcrypt: "Achtung: Das Ändern des Passworts setzt die Postfachverschlüsselung des Benutzers zurück. Ein neuer Wiederherstellungscode wird generiert."
+      password_confirmation:
+        label: Passwort bestätigen
+      roles:
+        label: Rollen
+        help: Wähle die Rollen, die diesem Benutzer zugewiesen werden sollen.
+      quota:
+        label: Quota (MB)
+        help: Postfach-Quota in Megabyte. Leer lassen für das Standard-Quota.
+      smtp_quota_limits:
+        label: SMTP-Quota Limits
+        help: Überschreibe die Standard-SMTP-Quota-Limits für diesen Benutzer.
+      totp:
+        label: Zwei-Faktor-Authentifizierung aktiviert
+        help: Deaktivieren, um die Zwei-Faktor-Authentifizierung für diesen Benutzer zu entfernen. Das TOTP-Secret und die Backup-Codes werden gelöscht.
+        help_disabled: Die Zwei-Faktor-Authentifizierung kann nur von der Benutzerin/dem Benutzer selbst aktiviert werden. Als Admin kann sie nur deaktiviert werden.
+      password_change_required:
+        label: Passwortänderung erforderlich
+        help: Wenn aktiviert, wird der Benutzer beim nächsten Login gezwungen, sein Passwort zu ändern.
+      last_login: Letzter Login
+      recovery_token:
+        label: Wiederherstellungscode
+        "yes": Konfiguriert
+        "no": Nicht konfiguriert
+      cancel: Abbrechen
+      submit:
+        save: Speichern
+        create: Erstellen
 
   user-notification:
     title: Benutzerbenachrichtigungen

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -517,6 +517,7 @@ settings:
     vouchers: Vouchers
     domains: Domains
     user-notifications: Notifications
+    users: Users
   coming-soon: Coming Soon
   table:
     id: ID
@@ -879,6 +880,95 @@ settings:
       previous: Previous
       next: Next
       page: "Page %page% of %totalPages%"
+
+  user:
+    title: Users
+    heading: Users
+    description: Manage user accounts, roles, and security settings
+    table:
+      email: Email
+      roles: Roles
+      twofactor: 2FA
+      mailcrypt: MailCrypt
+      status: Status
+      empty-title: No users found
+      empty-description: No user accounts match your current filters.
+    filter:
+      status: Status
+      active: Active
+      deleted: Deleted
+      all: All
+      role: Role
+      mailcrypt: MailCrypt
+      twofactor: 2FA
+      enabled: Enabled
+      disabled: Disabled
+    status:
+      active: Active
+      deleted: Deleted
+    create:
+      button: Create User
+      title: Create User
+      success: User has been created successfully.
+    edit:
+      title: Edit User
+      success: User has been updated successfully.
+    delete:
+      confirm: "Are you sure you want to delete the user \"%email%\"?"
+      success: User has been deleted successfully.
+    actions:
+      edit: Edit
+      delete: Delete
+    search:
+      placeholder: Search by email...
+      submit: Search
+    pagination:
+      total: "%count% users total"
+      previous: Previous
+      next: Next
+      page: "Page %page% of %totalPages%"
+    form:
+      title:
+        edit: Edit User
+        create: Create new User
+      description:
+        create: Provide the email, password, and roles for the new user account.
+      email:
+        label: Email
+        help:
+          edit: The email address cannot be changed.
+          create: The full email address for the new user account.
+      password:
+        label: Password
+        help:
+          mailcrypt: "Warning: Changing the password will reset the user's mailbox encryption. A new recovery token will be generated."
+      password_confirmation:
+        label: Confirm Password
+      roles:
+        label: Roles
+        help: Select the roles to assign to this user.
+      quota:
+        label: Quota (MB)
+        help: Mailbox quota in megabytes. Leave empty for the default quota.
+      smtp_quota_limits:
+        label: SMTP Quota Limits
+        help: Override the default SMTP quota limits for this user.
+      totp:
+        label: Two-factor authentication enabled
+        help: Uncheck to disable two-factor authentication for this user. This will clear the TOTP secret and backup codes.
+        help_disabled: Two-factor authentication can only be enabled by the user themselves. As an admin, you can only deactivate it.
+      password_change_required:
+        label: Password change required
+        help: When enabled, the user will be forced to change their password on next login.
+      last_login: Last Login
+      recovery_token:
+        label: Recovery Token
+        "yes": Configured
+        "no": Not configured
+      cancel: Cancel
+      submit:
+        save: Save
+        create: Create
 
   user-notification:
     title: User Notifications

--- a/features/settings_users.feature
+++ b/features/settings_users.feature
@@ -1,0 +1,178 @@
+Feature: Settings (Users)
+
+  Background:
+    Given the database is clean
+    And the following Domain exists:
+      | name        |
+      | example.org |
+    And the following User exists:
+      | email               | password | roles             |
+      | admin@example.org   | asdasd   | ROLE_ADMIN        |
+      | user@example.org    | asdasd   | ROLE_USER         |
+      | support@example.org | asdasd   | ROLE_DOMAIN_ADMIN |
+
+  @settings-users
+  Scenario: Regular user cannot access users page
+    Given I am authenticated as "user@example.org"
+    When I am on "/settings/users/"
+
+    Then I should see "Access Denied"
+    And the response status code should be 403
+
+  @settings-users
+  Scenario: Domain admin cannot access users page
+    Given I am authenticated as "support@example.org"
+    When I am on "/settings/users/"
+
+    Then I should see "Access Denied"
+    And the response status code should be 403
+
+  @settings-users
+  Scenario: Admin can list users
+    Given I am authenticated as "admin@example.org"
+    When I am on "/settings/users/"
+
+    Then the response status code should be 200
+    And I should see "Users"
+    And I should see "user@example.org"
+    And I should see "support@example.org"
+
+  @settings-users
+  Scenario: Admin can search users
+    Given I am authenticated as "admin@example.org"
+    When I am on "/settings/users/?search=user"
+
+    Then the response status code should be 200
+    And I should see "user@example.org"
+    And I should not see "support@example.org"
+
+  @settings-users
+  Scenario: Admin can filter by deleted status
+    Given the following User exists:
+      | email               | password | roles     |
+      | deleted@example.org | asdasd   | ROLE_USER |
+    And I am authenticated as "admin@example.org"
+    When I am on "/settings/users/?deleted=deleted"
+
+    Then the response status code should be 200
+
+  @settings-users
+  Scenario: Admin can filter by role
+    Given I am authenticated as "admin@example.org"
+    When I am on "/settings/users/?role=ROLE_DOMAIN_ADMIN"
+
+    Then the response status code should be 200
+    And I should see "support@example.org"
+    And I should not see "user@example.org"
+
+  @settings-users
+  Scenario: Admin can access create user page
+    Given I am authenticated as "admin@example.org"
+    When I am on "/settings/users/create"
+
+    Then the response status code should be 200
+    And I should see "Create new User"
+
+  @settings-users
+  Scenario: Admin can create a user
+    Given I am authenticated as "admin@example.org"
+    When I am on "/settings/users/create"
+    Then the response status code should be 200
+
+    When I fill in "user_admin_email" with "new@example.org"
+    And I fill in "user_admin_plainPassword_first" with "securePassword123!"
+    And I fill in "user_admin_plainPassword_second" with "securePassword123!"
+    And I press "Create"
+
+    Then I should see "User has been created successfully"
+    And the user "new@example.org" should exist
+    And the user "new@example.org" should have passwordChangeRequired
+
+  @settings-users
+  Scenario: Admin sees validation error on empty password
+    Given I am authenticated as "admin@example.org"
+    When I am on "/settings/users/create"
+
+    When I fill in "user_admin_email" with "test@example.org"
+    And I press "Create"
+
+    Then the response status code should be 422
+    And I should not see "User has been created successfully"
+
+  @settings-users
+  Scenario: Admin sees error on duplicate email
+    Given I am authenticated as "admin@example.org"
+    When I am on "/settings/users/create"
+
+    When I fill in "user_admin_email" with "user@example.org"
+    And I fill in "user_admin_plainPassword_first" with "securePassword123!"
+    And I fill in "user_admin_plainPassword_second" with "securePassword123!"
+    And I press "Create"
+
+    Then the response status code should be 422
+    And I should not see "User has been created successfully"
+
+  @settings-users
+  Scenario: Admin can access edit user page
+    Given I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/settings/users/edit/__user_id__"
+
+    Then the response status code should be 200
+    And I should see "Edit User"
+
+  @settings-users
+  Scenario: Admin can edit user roles
+    Given I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/settings/users/edit/__user_id__"
+
+    Then the response status code should be 200
+
+    When I press "Save"
+
+    Then I should see "User has been updated successfully"
+
+  @settings-users
+  Scenario: Admin can change user password
+    Given I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/settings/users/edit/__user_id__"
+
+    When I fill in "user_admin_plainPassword_first" with "newSecurePassword123!"
+    And I fill in "user_admin_plainPassword_second" with "newSecurePassword123!"
+    And I press "Save"
+
+    Then I should see "User has been updated successfully"
+    And the user "user@example.org" should have passwordChangeRequired
+
+  @settings-users
+  Scenario: Admin can disable 2FA for a user
+    Given the following User exists:
+      | email              | password | roles     | totpConfirmed | totpSecret     |
+      | totp@example.org   | asdasd   | ROLE_USER | true          | JBSWY3DPEHPK3PXP |
+    And I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "totp@example.org"
+    When I am on "/settings/users/edit/__user_id__"
+
+    Then the response status code should be 200
+
+    When I uncheck "user_admin_totpConfirmed"
+    And I press "Save"
+
+    Then I should see "User has been updated successfully"
+    And the user "totp@example.org" should not have totpConfirmed
+
+  @javascript @settings-users @delete-modal
+  Scenario: Admin can delete a user via modal
+    Given I am authenticated as "admin@example.org"
+    When I am on "/settings/users/"
+    Then I should see "user@example.org"
+
+    When I press "Delete"
+    And I wait for the modal to appear
+    Then I should see "Confirm deletion" in the modal
+
+    When I click "Delete" in the modal
+
+    Then I should see "User has been deleted successfully"

--- a/src/Controller/Settings/UserController.php
+++ b/src/Controller/Settings/UserController.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Settings;
+
+use App\Entity\User;
+use App\Enum\Roles;
+use App\Form\Model\UserAdminModel;
+use App\Form\UserAdminType;
+use App\Service\UserManager;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class UserController extends AbstractController
+{
+    public function __construct(
+        private readonly UserManager $manager,
+    ) {
+    }
+
+    #[Route('/settings/users/', name: 'settings_user_index', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $search = $request->query->getString('search', '');
+        $deleted = $request->query->getString('deleted', 'active');
+        $role = $request->query->getString('role', '');
+        $mailCrypt = $request->query->getString('mailCrypt', '');
+        $twofactor = $request->query->getString('twofactor', '');
+
+        return $this->render('Settings/User/index.html.twig', [
+            'pagination' => $this->manager->findPaginated($request->query->getInt('page', 1), $search, $deleted, $role, $mailCrypt, $twofactor),
+            'search' => $search,
+            'deleted' => $deleted,
+            'role' => $role,
+            'mailCrypt' => $mailCrypt,
+            'twofactor' => $twofactor,
+            'all_roles' => Roles::getAll(),
+        ]);
+    }
+
+    #[Route('/settings/users/create', name: 'settings_user_create', methods: ['GET'])]
+    public function create(): Response
+    {
+        $model = new UserAdminModel();
+        $model->setRoles([Roles::USER]);
+        $model->setPasswordChangeRequired(true);
+
+        $form = $this->createForm(UserAdminType::class, $model, [
+            'action' => $this->generateUrl('settings_user_create_post'),
+            'method' => 'POST',
+        ]);
+
+        return $this->render('Settings/User/form.html.twig', [
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/settings/users/create', name: 'settings_user_create_post', methods: ['POST'])]
+    public function createSubmit(Request $request): Response
+    {
+        $model = new UserAdminModel();
+        $model->setRoles([Roles::USER]);
+        $model->setPasswordChangeRequired(true);
+
+        $form = $this->createForm(UserAdminType::class, $model, [
+            'validation_groups' => ['Default', 'create'],
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->manager->create($model);
+            $this->addFlash('success', 'settings.user.create.success');
+
+            return $this->redirectToRoute('settings_user_index');
+        }
+
+        return $this->render('Settings/User/form.html.twig', [
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/settings/users/edit/{id}', name: 'settings_user_edit', methods: ['GET'])]
+    public function edit(#[MapEntity] User $user): Response
+    {
+        if ($user->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
+        $model = UserAdminModel::fromUser($user);
+
+        $form = $this->createForm(UserAdminType::class, $model, [
+            'action' => $this->generateUrl('settings_user_edit_post', ['id' => $user->getId()]),
+            'method' => 'POST',
+            'is_edit' => true,
+            'has_mail_crypt' => $user->hasMailCryptSecretBox(),
+            'totp_enabled' => $user->isTotpAuthenticationEnabled(),
+        ]);
+
+        return $this->render('Settings/User/form.html.twig', [
+            'form' => $form,
+            'user' => $user,
+        ]);
+    }
+
+    #[Route('/settings/users/edit/{id}', name: 'settings_user_edit_post', methods: ['POST'])]
+    public function editSubmit(#[MapEntity] User $user, Request $request): Response
+    {
+        if ($user->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
+        $model = new UserAdminModel();
+        $form = $this->createForm(UserAdminType::class, $model, [
+            'is_edit' => true,
+            'has_mail_crypt' => $user->hasMailCryptSecretBox(),
+            'totp_enabled' => $user->isTotpAuthenticationEnabled(),
+            'validation_groups' => ['Default', 'edit'],
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $recoveryToken = $this->manager->update($user, $model);
+            $this->addFlash('success', 'settings.user.edit.success');
+
+            if (null !== $recoveryToken) {
+                $this->addFlash('info', sprintf('Recovery Token: %s', $recoveryToken));
+            }
+
+            return $this->redirectToRoute('settings_user_index');
+        }
+
+        return $this->render('Settings/User/form.html.twig', [
+            'form' => $form,
+            'user' => $user,
+        ]);
+    }
+
+    #[Route('/settings/users/delete/{id}', name: 'settings_user_delete', methods: ['POST'])]
+    public function delete(#[MapEntity] User $user, Request $request): RedirectResponse
+    {
+        if ($user->isDeleted()) {
+            return $this->redirectToRoute('settings_user_index');
+        }
+
+        if (!$this->isCsrfTokenValid('delete_user_'.$user->getId(), $request->request->get('_token'))) {
+            return $this->redirectToRoute('settings_user_index');
+        }
+
+        $this->manager->delete($user);
+        $this->addFlash('success', 'settings.user.delete.success');
+
+        return $this->redirectToRoute('settings_user_index');
+    }
+}

--- a/src/Form/Model/UserAdminModel.php
+++ b/src/Form/Model/UserAdminModel.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Model;
+
+use App\Entity\User;
+
+final class UserAdminModel
+{
+    private ?string $email = null;
+
+    private ?string $plainPassword = null;
+
+    /** @var string[] */
+    private array $roles = [];
+
+    private ?int $quota = null;
+
+    /** @var array<string, int>|null */
+    private ?array $smtpQuotaLimits = null;
+
+    private bool $totpConfirmed = false;
+
+    private bool $passwordChangeRequired = false;
+
+    public static function fromUser(User $user): self
+    {
+        $model = new self();
+        $model->email = $user->getEmail();
+        $model->roles = $user->getRoles();
+        $model->quota = $user->getQuota();
+        $model->smtpQuotaLimits = $user->getSmtpQuotaLimits();
+        $model->totpConfirmed = $user->isTotpAuthenticationEnabled();
+        $model->passwordChangeRequired = $user->isPasswordChangeRequired();
+
+        return $model;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(?string $email): void
+    {
+        $this->email = $email;
+    }
+
+    public function getPlainPassword(): ?string
+    {
+        return $this->plainPassword;
+    }
+
+    public function setPlainPassword(?string $plainPassword): void
+    {
+        $this->plainPassword = $plainPassword;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    public function setRoles(array $roles): void
+    {
+        $this->roles = $roles;
+    }
+
+    public function getQuota(): ?int
+    {
+        return $this->quota;
+    }
+
+    public function setQuota(?int $quota): void
+    {
+        $this->quota = $quota;
+    }
+
+    /**
+     * @return array<string, int>|null
+     */
+    public function getSmtpQuotaLimits(): ?array
+    {
+        return $this->smtpQuotaLimits;
+    }
+
+    /**
+     * @param array<string, int>|null $smtpQuotaLimits
+     */
+    public function setSmtpQuotaLimits(?array $smtpQuotaLimits): void
+    {
+        $this->smtpQuotaLimits = $smtpQuotaLimits;
+    }
+
+    public function isTotpConfirmed(): bool
+    {
+        return $this->totpConfirmed;
+    }
+
+    public function setTotpConfirmed(bool $totpConfirmed): void
+    {
+        $this->totpConfirmed = $totpConfirmed;
+    }
+
+    public function isPasswordChangeRequired(): bool
+    {
+        return $this->passwordChangeRequired;
+    }
+
+    public function setPasswordChangeRequired(bool $passwordChangeRequired): void
+    {
+        $this->passwordChangeRequired = $passwordChangeRequired;
+    }
+}

--- a/src/Form/UserAdminType.php
+++ b/src/Form/UserAdminType.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Entity\User;
+use App\Enum\Roles;
+use App\Form\Model\UserAdminModel;
+use App\Validator\Lowercase;
+use App\Validator\PasswordPolicy;
+use App\Validator\UniqueField;
+use Override;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @extends AbstractType<UserAdminModel>
+ */
+final class UserAdminType extends AbstractType
+{
+    #[Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $isEdit = $options['is_edit'];
+        $hasMailCrypt = $options['has_mail_crypt'];
+
+        if ($isEdit) {
+            $builder->add('email', EmailType::class, [
+                'disabled' => true,
+            ]);
+        } else {
+            $builder->add('email', EmailType::class, [
+                'constraints' => [
+                    new Assert\NotNull(),
+                    new Assert\Email(mode: 'strict'),
+                    new Lowercase(),
+                    new UniqueField(entityClass: User::class, field: 'email', message: 'registration.email-already-taken'),
+                ],
+            ]);
+        }
+
+        $passwordHelp = null;
+        if ($isEdit && $hasMailCrypt) {
+            $passwordHelp = 'settings.user.form.password.help.mailcrypt';
+        }
+
+        $builder->add('plainPassword', RepeatedType::class, [
+            'type' => PasswordType::class,
+            'required' => !$isEdit,
+            'first_options' => [
+                'label' => 'form.password',
+                'help' => $passwordHelp,
+                'help_translation_parameters' => [],
+            ],
+            'second_options' => [
+                'label' => 'form.password_confirmation',
+            ],
+            'invalid_message' => 'different-password',
+            'constraints' => array_filter([
+                !$isEdit ? new Assert\NotBlank() : null,
+                new PasswordPolicy(),
+                new Assert\NotCompromisedPassword(skipOnError: true),
+            ]),
+        ]);
+
+        $availableRoles = Roles::getReachableRoles([Roles::ADMIN]);
+        $availableRoleChoices = array_combine($availableRoles, $availableRoles) ?: [];
+
+        $builder->add('roles', ChoiceType::class, [
+            'choices' => $availableRoleChoices,
+            'multiple' => true,
+            'expanded' => true,
+            'constraints' => [
+                new Assert\NotBlank(),
+                new Assert\NotNull(),
+            ],
+        ]);
+
+        $builder->add('quota', IntegerType::class, [
+            'required' => false,
+        ]);
+
+        $builder->add('smtpQuotaLimits', SmtpQuotaLimitsType::class, [
+            'required' => false,
+        ]);
+
+        $builder->add('totpConfirmed', CheckboxType::class, [
+            'required' => false,
+            'disabled' => !$isEdit || !$options['totp_enabled'],
+        ]);
+
+        $builder->add('passwordChangeRequired', CheckboxType::class, [
+            'required' => false,
+        ]);
+
+        $builder->add('submit', SubmitType::class);
+    }
+
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => UserAdminModel::class,
+            'is_edit' => false,
+            'has_mail_crypt' => false,
+            'totp_enabled' => false,
+        ]);
+
+        $resolver->setAllowedTypes('is_edit', 'bool');
+        $resolver->setAllowedTypes('has_mail_crypt', 'bool');
+        $resolver->setAllowedTypes('totp_enabled', 'bool');
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use DateInterval;
 use DateTimeImmutable;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Override;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -223,6 +224,73 @@ final class UserRepository extends ServiceEntityRepository implements PasswordUp
             ->setParameter('totpConfirmed', true)
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    public function countByFilters(string $search = '', string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = ''): int
+    {
+        $qb = $this->createQueryBuilder('u')
+            ->select('COUNT(u.id)');
+
+        $this->applyFilters($qb, $search, $deleted, $role, $mailCrypt, $twofactor);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @return User[]
+     */
+    public function findPaginatedByFilters(string $search = '', string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = '', int $limit = 20, int $offset = 0): array
+    {
+        $qb = $this->createQueryBuilder('u')
+            ->orderBy('u.id', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset);
+
+        $this->applyFilters($qb, $search, $deleted, $role, $mailCrypt, $twofactor);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    private function applyFilters(QueryBuilder $qb, string $search, string $deleted, string $role, string $mailCrypt, string $twofactor): void
+    {
+        if ('' !== $search) {
+            $qb->andWhere('u.email LIKE :search')
+                ->setParameter('search', '%'.$search.'%');
+        }
+
+        if ('active' === $deleted) {
+            $qb->andWhere('u.deleted = :deleted')
+                ->setParameter('deleted', false);
+        } elseif ('deleted' === $deleted) {
+            $qb->andWhere('u.deleted = :deleted')
+                ->setParameter('deleted', true);
+        }
+
+        if ('' !== $role) {
+            $qb->andWhere('u.roles LIKE :role')
+                ->setParameter('role', '%'.$role.'%');
+        }
+
+        if ('enabled' === $mailCrypt) {
+            $qb->andWhere('u.mailCryptEnabled = :mailCryptEnabled')
+                ->setParameter('mailCryptEnabled', true);
+        } elseif ('disabled' === $mailCrypt) {
+            $qb->andWhere('u.mailCryptEnabled = :mailCryptEnabled')
+                ->setParameter('mailCryptEnabled', false);
+        }
+
+        if ('enabled' === $twofactor) {
+            $qb->andWhere('u.totpConfirmed = :totpConfirmed')
+                ->andWhere('u.totpSecret IS NOT NULL')
+                ->setParameter('totpConfirmed', true);
+        } elseif ('disabled' === $twofactor) {
+            $qb->andWhere(
+                $qb->expr()->orX(
+                    'u.totpConfirmed = :totpConfirmed',
+                    'u.totpSecret IS NULL'
+                )
+            )->setParameter('totpConfirmed', false);
+        }
     }
 
     #[Override]

--- a/src/Service/UserManager.php
+++ b/src/Service/UserManager.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Dto\PaginatedResult;
+use App\Entity\User;
+use App\Enum\MailCrypt;
+use App\Enum\Roles;
+use App\Form\Model\UserAdminModel;
+use App\Guesser\DomainGuesser;
+use App\Handler\DeleteHandler;
+use App\Handler\MailCryptKeyHandler;
+use App\Helper\PasswordUpdater;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class UserManager
+{
+    private const int PAGE_SIZE = 20;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private UserRepository $repository,
+        private PasswordUpdater $passwordUpdater,
+        private MailCryptKeyHandler $mailCryptKeyHandler,
+        private SettingsService $settingsService,
+        private DomainGuesser $domainGuesser,
+        private UserResetService $userResetService,
+        private DeleteHandler $deleteHandler,
+    ) {
+    }
+
+    /**
+     * Find users with offset-based pagination and optional filters.
+     *
+     * @return PaginatedResult<User>
+     */
+    public function findPaginated(int $page = 1, string $search = '', string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = ''): PaginatedResult
+    {
+        $page = max(1, $page);
+        $offset = ($page - 1) * self::PAGE_SIZE;
+        $total = $this->repository->countByFilters($search, $deleted, $role, $mailCrypt, $twofactor);
+        $totalPages = max(1, (int) ceil($total / self::PAGE_SIZE));
+        $items = $this->repository->findPaginatedByFilters($search, $deleted, $role, $mailCrypt, $twofactor, self::PAGE_SIZE, $offset);
+
+        return new PaginatedResult($items, $page, $totalPages, $total);
+    }
+
+    /**
+     * Create a new user from the admin form model.
+     */
+    public function create(UserAdminModel $model): User
+    {
+        $user = new User($model->getEmail() ?? '');
+
+        $roles = $model->getRoles();
+        if (!in_array(Roles::USER, $roles, true)) {
+            $roles[] = Roles::USER;
+        }
+
+        $user->setRoles($roles);
+
+        $user->setQuota($model->getQuota());
+        $user->setSmtpQuotaLimits($model->getSmtpQuotaLimits());
+        $user->setPasswordChangeRequired(true);
+
+        $plainPassword = $model->getPlainPassword() ?? '';
+        $this->passwordUpdater->updatePassword($user, $plainPassword);
+
+        $mailCrypt = MailCrypt::from($this->settingsService->get('mail_crypt'));
+        $this->mailCryptKeyHandler->create($user, $plainPassword, $mailCrypt->isAtLeast(MailCrypt::ENABLED_ENFORCE_NEW_USERS));
+
+        $domain = $this->domainGuesser->guess($user->getEmail());
+        if (null !== $domain) {
+            $user->setDomain($domain);
+        }
+
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    /**
+     * Update an existing user from the admin form model.
+     *
+     * Returns a recovery token string if the password was changed and MailCrypt is active,
+     * or null otherwise.
+     */
+    public function update(User $user, UserAdminModel $model): ?string
+    {
+        $recoveryToken = null;
+
+        $user->setRoles($model->getRoles());
+        $user->setQuota($model->getQuota());
+        $user->setSmtpQuotaLimits($model->getSmtpQuotaLimits());
+        $user->setPasswordChangeRequired($model->isPasswordChangeRequired());
+
+        $plainPassword = $model->getPlainPassword();
+        if (!empty($plainPassword)) {
+            if ($user->hasMailCryptSecretBox()) {
+                $recoveryToken = $this->userResetService->resetUser($user, $plainPassword);
+            } else {
+                $this->passwordUpdater->updatePassword($user, $plainPassword);
+            }
+
+            $user->setPasswordChangeRequired(true);
+        }
+
+        // Deactivate 2FA if checkbox was unchecked
+        if (!$model->isTotpConfirmed() && $user->isTotpAuthenticationEnabled()) {
+            $user->setTotpSecret(null);
+            $user->setTotpConfirmed(false);
+            $user->setTotpBackupCodes([]);
+        }
+
+        $this->em->flush();
+
+        return $recoveryToken;
+    }
+
+    /**
+     * Soft-delete a user.
+     */
+    public function delete(User $user): void
+    {
+        $this->deleteHandler->deleteUser($user);
+    }
+}

--- a/templates/Settings/User/form.html.twig
+++ b/templates/Settings/User/form.html.twig
@@ -1,0 +1,201 @@
+{% set current_section = 'users' %}
+{% extends 'Settings/base_settings.html.twig' %}
+
+{% form_theme form 'Form/fields.html.twig' %}
+{% set is_edit = user is defined %}
+
+{% block title %}
+    {{ setting('app_name') }} - {{ is_edit ? 'settings.user.edit.title'|trans : 'settings.user.create.title'|trans }}
+{% endblock %}
+
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            <div class="flex items-center mb-6">
+                <div class="w-12 h-12 {{ is_edit ? 'bg-indigo-100 dark:bg-indigo-900/50' : 'bg-blue-100 dark:bg-blue-900/50' }} rounded-xl flex items-center justify-center mr-4">
+                    {% if is_edit %}
+                        {{ ux_icon('heroicons:pencil-square', {class: 'w-6 h-6 text-indigo-600 dark:text-indigo-400'}) }}
+                    {% else %}
+                        {{ ux_icon('heroicons:plus', {class: 'w-6 h-6 text-blue-600 dark:text-blue-400'}) }}
+                    {% endif %}
+                </div>
+                <div>
+                    <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                        {% if is_edit %}
+                            {{ 'settings.user.form.title.edit'|trans }}
+                        {% else %}
+                            {{ 'settings.user.form.title.create'|trans }}
+                        {% endif %}
+                    </h3>
+                    {% if not is_edit %}
+                        <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'settings.user.form.description.create'|trans }}</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            {% if is_edit %}
+                <div class="mb-6 grid grid-cols-2 sm:grid-cols-5 divide-x divide-gray-200 dark:divide-gray-600 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'settings.table.created'|trans }}</dt>
+                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ user.creationTime|format_datetime('short', 'short') }}</dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'settings.user.form.last_login'|trans }}</dt>
+                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ user.lastLoginTime ? user.lastLoginTime|format_datetime('short', 'short') : '—' }}</dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'settings.user.form.recovery_token.label'|trans }}</dt>
+                        <dd class="mt-1">
+                            {% if user.recoverySecretBox %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.user.form.recovery_token.yes'|trans }}</span>
+                            {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">{{ 'settings.user.form.recovery_token.no'|trans }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'settings.user.table.mailcrypt'|trans }}</dt>
+                        <dd class="mt-1">
+                            {% if user.mailCryptEnabled %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.user.filter.enabled'|trans }}</span>
+                            {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">{{ 'settings.user.filter.disabled'|trans }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'settings.user.table.status'|trans }}</dt>
+                        <dd class="mt-1">
+                            {% if user.deleted %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ 'settings.user.status.deleted'|trans }}</span>
+                            {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'settings.user.status.active'|trans }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
+                </div>
+            {% endif %}
+
+            {{ form_start(form) }}
+            {{ form_errors(form) }}
+
+            <div class="space-y-6">
+                <div>
+                    {{ form_label(form.email, 'settings.user.form.email.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.email) }}
+                    {{ form_widget(form.email) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ is_edit ? 'settings.user.form.email.help.edit'|trans : 'settings.user.form.email.help.create'|trans }}
+                    </p>
+                </div>
+
+                <div data-controller="password-strength"
+                     data-password-strength-strong-label-value="{{ "form.password-strong"|trans }}"
+                     data-password-strength-min-length-value="12"
+                     data-password-strength-min-length-label-value="{{ "form.password-min-length"|trans({'%min%': 12}) }}"
+                >
+                    {{ form_label(form.plainPassword.first, 'settings.user.form.password.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.plainPassword) }}
+                    {{ form_widget(form.plainPassword.first, {'attr': {'data-password-strength-target': 'input', 'data-action': 'focus->password-strength#loadAndEvaluate:once input->password-strength#evaluate', 'autocomplete': 'new-password'}}) }}
+                    {# Password strength meter #}
+                    <div class="flex gap-1 mt-2" data-password-strength-meter aria-hidden="true">
+                        <div class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-600 transition-colors duration-300" data-password-strength-target="segment"></div>
+                        <div class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-600 transition-colors duration-300" data-password-strength-target="segment"></div>
+                        <div class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-600 transition-colors duration-300" data-password-strength-target="segment"></div>
+                        <div class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-600 transition-colors duration-300" data-password-strength-target="segment"></div>
+                    </div>
+                    <p class="text-xs text-gray-500 dark:text-gray-400 hidden mt-1" data-password-strength-target="feedback" aria-live="polite"></p>
+                    {% if form.plainPassword.first.vars.help %}
+                        <div class="mt-2 p-3 bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded-lg">
+                            <p class="text-sm text-amber-800 dark:text-amber-100">
+                                {{ ux_icon('heroicons:exclamation-triangle', {class: 'w-4 h-4 inline mr-1'}) }}
+                                {{ form.plainPassword.first.vars.help|trans }}
+                            </p>
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div>
+                    {{ form_label(form.plainPassword.second, 'settings.user.form.password_confirmation.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_widget(form.plainPassword.second) }}
+                </div>
+
+                <div>
+                    {{ form_label(form.roles, 'settings.user.form.roles.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.roles) }}
+                    <div class="flex flex-wrap gap-4">
+                        {% for child in form.roles %}
+                            <label class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                                {{ form_widget(child) }}
+                                {{ child.vars.label }}
+                            </label>
+                        {% endfor %}
+                    </div>
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.user.form.roles.help'|trans }}
+                    </p>
+                </div>
+
+                <div>
+                    {{ form_label(form.quota, 'settings.user.form.quota.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.quota) }}
+                    {{ form_widget(form.quota) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.user.form.quota.help'|trans }}
+                    </p>
+                </div>
+
+                <div>
+                    {{ form_label(form.smtpQuotaLimits, 'settings.user.form.smtp_quota_limits.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.smtpQuotaLimits) }}
+                    {{ form_widget(form.smtpQuotaLimits) }}
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.user.form.smtp_quota_limits.help'|trans }}
+                    </p>
+                </div>
+
+                <div class="flex items-center gap-3">
+                    {{ form_widget(form.totpConfirmed) }}
+                    {{ form_label(form.totpConfirmed, 'settings.user.form.totp.label', {'label_attr': {'class': 'text-sm font-medium text-gray-700 dark:text-gray-300'}}) }}
+                    {{ form_errors(form.totpConfirmed) }}
+                </div>
+                {% if form.totpConfirmed.vars.disabled %}
+                    <div class="-mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg">
+                        <p class="text-sm text-blue-800 dark:text-blue-200">
+                            {{ ux_icon('heroicons:information-circle', {class: 'w-4 h-4 inline mr-1'}) }}
+                            {{ 'settings.user.form.totp.help_disabled'|trans }}
+                        </p>
+                    </div>
+                {% else %}
+                    <p class="-mt-4 text-sm text-gray-500 dark:text-gray-300">
+                        {{ 'settings.user.form.totp.help'|trans }}
+                    </p>
+                {% endif %}
+
+                <div class="flex items-center gap-3">
+                    {{ form_widget(form.passwordChangeRequired) }}
+                    {{ form_label(form.passwordChangeRequired, 'settings.user.form.password_change_required.label', {'label_attr': {'class': 'text-sm font-medium text-gray-700 dark:text-gray-300'}}) }}
+                    {{ form_errors(form.passwordChangeRequired) }}
+                </div>
+                <p class="-mt-4 text-sm text-gray-500 dark:text-gray-300">
+                    {{ 'settings.user.form.password_change_required.help'|trans }}
+                </p>
+
+                <div class="flex items-center justify-between pt-6">
+                    <a href="{{ path('settings_user_index') }}"
+                       class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.user.form.cancel'|trans }}
+                    </a>
+                    {{ form_widget(form.submit, {
+                        label: is_edit ? 'settings.user.form.submit.save' : 'settings.user.form.submit.create',
+                        attr: {
+                            class: 'inline-flex items-center px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
+                        }
+                    }) }}
+                </div>
+            </div>
+            {{ form_end(form) }}
+        </div>
+    </div>
+{% endblock %}

--- a/templates/Settings/User/index.html.twig
+++ b/templates/Settings/User/index.html.twig
@@ -1,0 +1,181 @@
+{% set current_section = 'users' %}
+{% extends 'Settings/base_settings.html.twig' %}
+{% block title %}{{ setting('app_name') }} - {{ 'settings.user.title'|trans }}{% endblock %}
+{% block settings_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm"
+         data-controller="modal">
+        <div class="p-6 sm:p-8">
+            {% include 'Settings/_section_header.html.twig' with {
+                icon: 'heroicons:users',
+                icon_color: 'violet',
+                heading_key: 'settings.user.heading',
+                description_key: 'settings.user.description',
+            } %}
+
+            <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                <div class="flex flex-wrap items-center gap-2">
+                    <a href="{{ path('settings_user_create') }}"
+                       class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:plus', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'settings.user.create.button'|trans }}
+                    </a>
+                </div>
+
+                {% include 'Settings/_search_form.html.twig' with {
+                    index_route: 'settings_user_index',
+                    placeholder_key: 'settings.user.search.placeholder',
+                    submit_key: 'settings.user.search.submit',
+                    search: search,
+                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v != 'active'),
+                } %}
+            </div>
+
+            <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
+                <div class="flex flex-wrap items-center gap-2">
+                    <label for="deleted-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'settings.user.filter.status'|trans }}:</label>
+                    <select id="deleted-filter"
+                            data-controller="navigate"
+                            data-action="change->navigate#go"
+                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('settings_user_index', {search: search, deleted: 'active', role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'settings.user.filter.active'|trans }}</option>
+                        <option value="{{ path('settings_user_index', {search: search, deleted: 'deleted', role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'settings.user.filter.deleted'|trans }}</option>
+                        <option value="{{ path('settings_user_index', {search: search, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == '' %} selected{% endif %}>{{ 'settings.user.filter.all'|trans }}</option>
+                    </select>
+
+                    <label for="role-filter" class="text-sm text-gray-600 dark:text-gray-400 ml-2">{{ 'settings.user.filter.role'|trans }}:</label>
+                    <select id="role-filter"
+                            data-controller="navigate"
+                            data-action="change->navigate#go"
+                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('settings_user_index', {search: search, deleted: deleted, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if role == '' %} selected{% endif %}>{{ 'settings.user.filter.all'|trans }}</option>
+                        {% for role_key, role_value in all_roles %}
+                            <option value="{{ path('settings_user_index', {search: search, deleted: deleted, role: role_value, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if role == role_value %} selected{% endif %}>{{ role_value }}</option>
+                        {% endfor %}
+                    </select>
+
+                    <label for="mailcrypt-filter" class="text-sm text-gray-600 dark:text-gray-400 ml-2">{{ 'settings.user.filter.mailcrypt'|trans }}:</label>
+                    <select id="mailcrypt-filter"
+                            data-controller="navigate"
+                            data-action="change->navigate#go"
+                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('settings_user_index', {search: search, deleted: deleted, role: role, twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if mailCrypt == '' %} selected{% endif %}>{{ 'settings.user.filter.all'|trans }}</option>
+                        <option value="{{ path('settings_user_index', {search: search, deleted: deleted, role: role, mailCrypt: 'enabled', twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if mailCrypt == 'enabled' %} selected{% endif %}>{{ 'settings.user.filter.enabled'|trans }}</option>
+                        <option value="{{ path('settings_user_index', {search: search, deleted: deleted, role: role, mailCrypt: 'disabled', twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if mailCrypt == 'disabled' %} selected{% endif %}>{{ 'settings.user.filter.disabled'|trans }}</option>
+                    </select>
+
+                    <label for="twofactor-filter" class="text-sm text-gray-600 dark:text-gray-400 ml-2">{{ 'settings.user.filter.twofactor'|trans }}:</label>
+                    <select id="twofactor-filter"
+                            data-controller="navigate"
+                            data-action="change->navigate#go"
+                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('settings_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt}|filter(v => v and v != 'active')) }}"{% if twofactor == '' %} selected{% endif %}>{{ 'settings.user.filter.all'|trans }}</option>
+                        <option value="{{ path('settings_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: 'enabled'}|filter(v => v and v != 'active')) }}"{% if twofactor == 'enabled' %} selected{% endif %}>{{ 'settings.user.filter.enabled'|trans }}</option>
+                        <option value="{{ path('settings_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: 'disabled'}|filter(v => v and v != 'active')) }}"{% if twofactor == 'disabled' %} selected{% endif %}>{{ 'settings.user.filter.disabled'|trans }}</option>
+                    </select>
+                </div>
+            </div>
+
+            {% if pagination.items is empty %}
+                {% include 'Settings/_empty_state.html.twig' with {
+                    icon: 'heroicons:users',
+                    title_key: 'settings.user.table.empty-title',
+                    description_key: 'settings.user.table.empty-description',
+                } %}
+            {% else %}
+                {% embed 'Settings/_table.html.twig' with {
+                    headers: [
+                        {label: 'settings.table.id', class: 'hidden xl:table-cell'},
+                        {label: 'settings.user.table.email'},
+                        {label: 'settings.table.created', class: 'hidden xl:table-cell'},
+                        {label: 'settings.user.table.roles'},
+                        {label: 'settings.user.table.twofactor', class: 'hidden lg:table-cell', align: 'center'},
+                        {label: 'settings.user.table.mailcrypt', class: 'hidden lg:table-cell', align: 'center'},
+                        {label: 'settings.user.table.status', align: 'center'},
+                        {label: 'settings.table.actions', align: 'right'},
+                    ]
+                } %}
+                    {% block table_body %}
+                        {% for user in pagination.items %}
+                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                <td class="hidden xl:table-cell px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ user.id }}</td>
+                                <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 max-w-xs truncate" title="{{ user.email }}">{{ user.email }}</td>
+                                <td class="hidden xl:table-cell px-4 py-3 text-sm text-gray-500 dark:text-gray-300">
+                                    {{ user.creationTime|format_datetime('short', 'short') }}
+                                </td>
+                                <td class="px-4 py-3">
+                                    <div class="flex flex-wrap gap-1">
+                                        {% for role in user.roles %}
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">{{ role }}</span>
+                                        {% endfor %}
+                                    </div>
+                                </td>
+                                <td class="hidden lg:table-cell px-4 py-3 text-center">
+                                    {% if user.totpAuthenticationEnabled %}
+                                        {{ ux_icon('heroicons:check-circle-20-solid', {class: 'w-5 h-5 text-green-500 dark:text-green-400 inline', title: 'settings.user.filter.enabled'|trans}) }}
+                                    {% else %}
+                                        {{ ux_icon('heroicons:x-circle-20-solid', {class: 'w-5 h-5 text-gray-300 dark:text-gray-600 inline', title: 'settings.user.filter.disabled'|trans}) }}
+                                    {% endif %}
+                                </td>
+                                <td class="hidden lg:table-cell px-4 py-3 text-center">
+                                    {% if user.mailCryptEnabled %}
+                                        {{ ux_icon('heroicons:check-circle-20-solid', {class: 'w-5 h-5 text-green-500 dark:text-green-400 inline', title: 'settings.user.filter.enabled'|trans}) }}
+                                    {% else %}
+                                        {{ ux_icon('heroicons:x-circle-20-solid', {class: 'w-5 h-5 text-gray-300 dark:text-gray-600 inline', title: 'settings.user.filter.disabled'|trans}) }}
+                                    {% endif %}
+                                </td>
+                                <td class="px-4 py-3 text-center">
+                                    {% if user.deleted %}
+                                        {{ ux_icon('heroicons:x-circle-20-solid', {class: 'w-5 h-5 text-red-500 dark:text-red-400 inline', title: 'settings.user.status.deleted'|trans}) }}
+                                    {% else %}
+                                        {{ ux_icon('heroicons:check-circle-20-solid', {class: 'w-5 h-5 text-green-500 dark:text-green-400 inline', title: 'settings.user.status.active'|trans}) }}
+                                    {% endif %}
+                                </td>
+                                <td class="px-4 py-3 text-right">
+                                    <div class="inline-flex items-center gap-1">
+                                        {% if not user.deleted %}
+                                            <a href="{{ path('settings_user_edit', {id: user.id}) }}"
+                                               title="{{ 'settings.user.actions.edit'|trans }}"
+                                               data-controller="tooltip"
+                                               class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                                {{ ux_icon('heroicons:pencil-square', {class: 'w-4 h-4'}) }}
+                                                <span class="sr-only">{{ 'settings.user.actions.edit'|trans }}</span>
+                                            </a>
+                                            <form method="post"
+                                                  action="{{ path('settings_user_delete', {id: user.id}) }}"
+                                                  data-action="submit->modal#open"
+                                                  data-modal-title-param="{{ 'delete.confirm-title'|trans|e('html_attr') }}"
+                                                  data-modal-message-param="{{ 'settings.user.delete.confirm'|trans({'%email%': user.email})|e('html_attr') }}">
+                                                <input type="hidden" name="_token"
+                                                       value="{{ csrf_token('delete_user_' ~ user.id) }}">
+                                                <button type="submit"
+                                                        title="{{ 'settings.user.actions.delete'|trans }}"
+                                                        data-controller="tooltip"
+                                                        class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                                    {{ ux_icon('heroicons:trash', {class: 'w-4 h-4'}) }}
+                                                    <span class="sr-only">{{ 'settings.user.actions.delete'|trans }}</span>
+                                                </button>
+                                            </form>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endblock %}
+                {% endembed %}
+
+                {% include 'Settings/_pagination.html.twig' with {
+                    index_route: 'settings_user_index',
+                    total_key: 'settings.user.pagination.total',
+                    previous_key: 'settings.user.pagination.previous',
+                    next_key: 'settings.user.pagination.next',
+                    page_key: 'settings.user.pagination.page',
+                    pagination: pagination,
+                    search: search,
+                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v != 'active'),
+                } %}
+            {% endif %}
+        </div>
+
+        {% include 'Settings/_confirm_modal.html.twig' %}
+    </div>
+{% endblock %}

--- a/templates/Settings/_navigation.html.twig
+++ b/templates/Settings/_navigation.html.twig
@@ -13,6 +13,7 @@
     {route: 'settings_webhook_endpoint_index', section: 'webhooks', icon: 'heroicons:cursor-arrow-rays', label: 'settings.navigation.webhooks'},
     {route: 'settings_maintenance_show', section: 'maintenance', icon: 'heroicons:building-library', label: 'settings.navigation.maintenance'},
     {route: 'settings_domain_index', section: 'domains', icon: 'heroicons:globe-alt', label: 'settings.navigation.domains'},
+    {route: 'settings_user_index', section: 'users', icon: 'heroicons:users', label: 'settings.navigation.users'},
     {route: 'settings_reserved_name_index', section: 'reserved-names', icon: 'heroicons:shield-exclamation', label: 'settings.navigation.reserved-names'},
     {route: 'settings_alias_index', section: 'aliases', icon: 'heroicons:at-symbol', label: 'settings.navigation.aliases'},
     {route: 'settings_voucher_index', section: 'vouchers', icon: 'heroicons:ticket', label: 'settings.navigation.vouchers'},

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -721,7 +721,7 @@ class FeatureContext extends MinkContext
     {
         foreach ($this->getAllPlaceholders() as $key => $value) {
             if (str_contains($string, $key)) {
-                $string = str_replace($key, $value, $string);
+                $string = str_replace($key, (string) $value, $string);
             }
         }
 

--- a/tests/Form/UserAdminTypeTest.php
+++ b/tests/Form/UserAdminTypeTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form;
+
+use App\Form\Model\UserAdminModel;
+use App\Form\SmtpQuotaLimitsType;
+use App\Form\UserAdminType;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Validation;
+
+class UserAdminTypeTest extends TypeTestCase
+{
+    protected function setUp(): void
+    {
+        $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
+        parent::setUp();
+    }
+
+    protected function getExtensions(): array
+    {
+        $validator = Validation::createValidator();
+
+        return [
+            new PreloadedExtension([new SmtpQuotaLimitsType()], []),
+            new ValidatorExtension($validator),
+        ];
+    }
+
+    public function testCreateFormHasExpectedFields(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => false,
+        ]);
+        $view = $form->createView();
+
+        self::assertArrayHasKey('email', $view->children);
+        self::assertArrayHasKey('plainPassword', $view->children);
+        self::assertArrayHasKey('roles', $view->children);
+        self::assertArrayHasKey('quota', $view->children);
+        self::assertArrayHasKey('smtpQuotaLimits', $view->children);
+        self::assertArrayHasKey('totpConfirmed', $view->children);
+        self::assertArrayHasKey('passwordChangeRequired', $view->children);
+        self::assertArrayHasKey('submit', $view->children);
+    }
+
+    public function testEditFormHasDisabledEmail(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => true,
+        ]);
+
+        $emailConfig = $form->get('email')->getConfig();
+        self::assertTrue($emailConfig->getOption('disabled'));
+    }
+
+    public function testCreateFormHasEnabledEmail(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => false,
+        ]);
+
+        $emailConfig = $form->get('email')->getConfig();
+        self::assertFalse($emailConfig->getOption('disabled'));
+    }
+
+    public function testTotpDisabledWhenNotEdit(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => false,
+            'totp_enabled' => false,
+        ]);
+
+        $totpConfig = $form->get('totpConfirmed')->getConfig();
+        self::assertTrue($totpConfig->getOption('disabled'));
+    }
+
+    public function testTotpDisabledWhenEditButTotpNotEnabled(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => true,
+            'totp_enabled' => false,
+        ]);
+
+        $totpConfig = $form->get('totpConfirmed')->getConfig();
+        self::assertTrue($totpConfig->getOption('disabled'));
+    }
+
+    public function testTotpEnabledWhenEditAndTotpEnabled(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => true,
+            'totp_enabled' => true,
+        ]);
+
+        $totpConfig = $form->get('totpConfirmed')->getConfig();
+        self::assertFalse($totpConfig->getOption('disabled'));
+    }
+
+    public function testPasswordHelpShownForMailCryptEdit(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => true,
+            'has_mail_crypt' => true,
+        ]);
+
+        $passwordFirstConfig = $form->get('plainPassword')->get('first')->getConfig();
+        self::assertSame('settings.user.form.password.help.mailcrypt', $passwordFirstConfig->getOption('help'));
+    }
+
+    public function testPasswordHelpNullWhenNoMailCrypt(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => true,
+            'has_mail_crypt' => false,
+        ]);
+
+        $passwordFirstConfig = $form->get('plainPassword')->get('first')->getConfig();
+        self::assertNull($passwordFirstConfig->getOption('help'));
+    }
+
+    public function testPasswordNotRequiredForEdit(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => true,
+        ]);
+
+        $passwordConfig = $form->get('plainPassword')->getConfig();
+        self::assertFalse($passwordConfig->getRequired());
+    }
+
+    public function testPasswordRequiredForCreate(): void
+    {
+        $form = $this->factory->create(UserAdminType::class, null, [
+            'is_edit' => false,
+        ]);
+
+        $passwordConfig = $form->get('plainPassword')->getConfig();
+        self::assertTrue($passwordConfig->getRequired());
+    }
+
+    public function testSubmitValidCreateData(): void
+    {
+        $formData = [
+            'email' => 'test@example.org',
+            'plainPassword' => [
+                'first' => 'securePassword123',
+                'second' => 'securePassword123',
+            ],
+            'roles' => ['ROLE_USER'],
+            'quota' => 1024,
+            'smtpQuotaLimits' => ['per_hour' => 100, 'per_day' => 1000],
+            'passwordChangeRequired' => true,
+        ];
+
+        $model = new UserAdminModel();
+        $form = $this->factory->create(UserAdminType::class, $model, [
+            'is_edit' => false,
+            'validation_groups' => false,
+        ]);
+
+        $form->submit($formData);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('test@example.org', $model->getEmail());
+        self::assertSame('securePassword123', $model->getPlainPassword());
+        self::assertSame(['ROLE_USER'], $model->getRoles());
+        self::assertSame(1024, $model->getQuota());
+        self::assertSame(['per_hour' => 100, 'per_day' => 1000], $model->getSmtpQuotaLimits());
+        self::assertTrue($model->isPasswordChangeRequired());
+    }
+
+    public function testSubmitEditDataWithDisabledEmail(): void
+    {
+        $model = new UserAdminModel();
+        $model->setEmail('original@example.org');
+
+        $form = $this->factory->create(UserAdminType::class, $model, [
+            'is_edit' => true,
+            'validation_groups' => false,
+        ]);
+
+        $form->submit([
+            'email' => 'changed@example.org',
+            'plainPassword' => ['first' => '', 'second' => ''],
+            'roles' => ['ROLE_USER', 'ROLE_ADMIN'],
+            'quota' => 2048,
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        // Email is disabled in edit mode, so it should not change
+        self::assertSame('original@example.org', $model->getEmail());
+        self::assertEqualsCanonicalizing(['ROLE_USER', 'ROLE_ADMIN'], $model->getRoles());
+        self::assertSame(2048, $model->getQuota());
+    }
+}

--- a/tests/Service/UserManagerTest.php
+++ b/tests/Service/UserManagerTest.php
@@ -1,0 +1,366 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Dto\PaginatedResult;
+use App\Entity\Domain;
+use App\Entity\User;
+use App\Enum\Roles;
+use App\Form\Model\UserAdminModel;
+use App\Guesser\DomainGuesser;
+use App\Handler\DeleteHandler;
+use App\Handler\MailCryptKeyHandler;
+use App\Helper\PasswordUpdater;
+use App\Repository\UserRepository;
+use App\Service\SettingsService;
+use App\Service\UserManager;
+use App\Service\UserResetService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+class UserManagerTest extends TestCase
+{
+    private UserRepository&Stub $repository;
+    private EntityManagerInterface&Stub $entityManager;
+    private PasswordUpdater&Stub $passwordUpdater;
+    private MailCryptKeyHandler&Stub $mailCryptKeyHandler;
+    private SettingsService&Stub $settingsService;
+    private DomainGuesser&Stub $domainGuesser;
+    private UserResetService&Stub $userResetService;
+    private DeleteHandler&Stub $deleteHandler;
+    private UserManager $manager;
+    private Domain $domain;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createStub(UserRepository::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->passwordUpdater = $this->createStub(PasswordUpdater::class);
+        $this->mailCryptKeyHandler = $this->createStub(MailCryptKeyHandler::class);
+        $this->settingsService = $this->createStub(SettingsService::class);
+        $this->domainGuesser = $this->createStub(DomainGuesser::class);
+        $this->userResetService = $this->createStub(UserResetService::class);
+        $this->deleteHandler = $this->createStub(DeleteHandler::class);
+
+        $this->domain = new Domain();
+        $this->domain->setName('example.org');
+
+        $this->settingsService->method('get')->willReturn(0);
+        $this->domainGuesser->method('guess')->willReturn($this->domain);
+
+        $this->manager = new UserManager(
+            $this->entityManager,
+            $this->repository,
+            $this->passwordUpdater,
+            $this->mailCryptKeyHandler,
+            $this->settingsService,
+            $this->domainGuesser,
+            $this->userResetService,
+            $this->deleteHandler,
+        );
+    }
+
+    public function testFindPaginated(): void
+    {
+        $this->repository->method('countByFilters')->willReturn(25);
+        $this->repository->method('findPaginatedByFilters')->willReturn([
+            new User('user1@example.org'),
+            new User('user2@example.org'),
+        ]);
+
+        $result = $this->manager->findPaginated(1, '', 'active');
+
+        self::assertInstanceOf(PaginatedResult::class, $result);
+        self::assertSame(1, $result->page);
+        self::assertSame(2, $result->totalPages);
+        self::assertSame(25, $result->total);
+        self::assertCount(2, $result->items);
+    }
+
+    public function testFindPaginatedWithFilters(): void
+    {
+        $this->repository->method('countByFilters')->willReturn(5);
+        $this->repository->method('findPaginatedByFilters')->willReturn([
+            new User('user@example.org'),
+        ]);
+
+        $result = $this->manager->findPaginated(1, 'test', 'deleted', 'ROLE_ADMIN', 'enabled', 'enabled');
+
+        self::assertSame(1, $result->page);
+        self::assertSame(1, $result->totalPages);
+        self::assertSame(5, $result->total);
+        self::assertCount(1, $result->items);
+    }
+
+    public function testFindPaginatedClampsPageToMin1(): void
+    {
+        $this->repository->method('countByFilters')->willReturn(0);
+        $this->repository->method('findPaginatedByFilters')->willReturn([]);
+
+        $result = $this->manager->findPaginated(0);
+
+        self::assertSame(1, $result->page);
+        self::assertSame(1, $result->totalPages);
+    }
+
+    public function testCreate(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('persist')->with($this->isInstanceOf(User::class));
+        $entityManager->expects($this->once())->method('flush');
+
+        /** @var PasswordUpdater&MockObject $passwordUpdater */
+        $passwordUpdater = $this->createMock(PasswordUpdater::class);
+        $passwordUpdater->expects($this->once())->method('updatePassword');
+
+        /** @var MailCryptKeyHandler&MockObject $mailCryptKeyHandler */
+        $mailCryptKeyHandler = $this->createMock(MailCryptKeyHandler::class);
+        $mailCryptKeyHandler->expects($this->once())->method('create');
+
+        $manager = new UserManager(
+            $entityManager,
+            $this->repository,
+            $passwordUpdater,
+            $mailCryptKeyHandler,
+            $this->settingsService,
+            $this->domainGuesser,
+            $this->userResetService,
+            $this->deleteHandler,
+        );
+
+        $model = new UserAdminModel();
+        $model->setEmail('newuser@example.org');
+        $model->setPlainPassword('securePassword123');
+        $model->setRoles([Roles::USER]);
+        $model->setQuota(1024);
+
+        $user = $manager->create($model);
+
+        self::assertInstanceOf(User::class, $user);
+        self::assertSame('newuser@example.org', $user->getEmail());
+        self::assertContains(Roles::USER, $user->getRoles());
+        self::assertSame(1024, $user->getQuota());
+        self::assertTrue($user->isPasswordChangeRequired());
+        self::assertSame($this->domain, $user->getDomain());
+    }
+
+    public function testCreateAddsRoleUserIfMissing(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new UserManager(
+            $entityManager,
+            $this->repository,
+            $this->passwordUpdater,
+            $this->mailCryptKeyHandler,
+            $this->settingsService,
+            $this->domainGuesser,
+            $this->userResetService,
+            $this->deleteHandler,
+        );
+
+        $model = new UserAdminModel();
+        $model->setEmail('admin@example.org');
+        $model->setPlainPassword('securePassword123');
+        $model->setRoles([Roles::ADMIN]);
+
+        $user = $manager->create($model);
+
+        self::assertContains(Roles::USER, $user->getRoles());
+        self::assertContains(Roles::ADMIN, $user->getRoles());
+    }
+
+    public function testCreateWithMailCryptEnforced(): void
+    {
+        $settingsService = $this->createStub(SettingsService::class);
+        $settingsService->method('get')->willReturn(2);
+
+        /** @var MailCryptKeyHandler&MockObject $mailCryptKeyHandler */
+        $mailCryptKeyHandler = $this->createMock(MailCryptKeyHandler::class);
+        $mailCryptKeyHandler->expects($this->once())->method('create')
+            ->with($this->isInstanceOf(User::class), 'securePassword123', true);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new UserManager(
+            $entityManager,
+            $this->repository,
+            $this->passwordUpdater,
+            $mailCryptKeyHandler,
+            $settingsService,
+            $this->domainGuesser,
+            $this->userResetService,
+            $this->deleteHandler,
+        );
+
+        $model = new UserAdminModel();
+        $model->setEmail('user@example.org');
+        $model->setPlainPassword('securePassword123');
+        $model->setRoles([Roles::USER]);
+
+        $manager->create($model);
+    }
+
+    public function testUpdateWithoutPasswordChange(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new UserManager(
+            $entityManager,
+            $this->repository,
+            $this->passwordUpdater,
+            $this->mailCryptKeyHandler,
+            $this->settingsService,
+            $this->domainGuesser,
+            $this->userResetService,
+            $this->deleteHandler,
+        );
+
+        $user = new User('user@example.org');
+
+        $model = new UserAdminModel();
+        $model->setRoles([Roles::USER, Roles::ADMIN]);
+        $model->setQuota(2048);
+        $model->setTotpConfirmed(false);
+        $model->setPasswordChangeRequired(false);
+
+        $recoveryToken = $manager->update($user, $model);
+
+        self::assertNull($recoveryToken);
+        self::assertSame([Roles::USER, Roles::ADMIN], $user->getRoles());
+        self::assertSame(2048, $user->getQuota());
+        self::assertFalse($user->isPasswordChangeRequired());
+    }
+
+    public function testUpdateWithPasswordChangeAndMailCrypt(): void
+    {
+        /** @var UserResetService&MockObject $userResetService */
+        $userResetService = $this->createMock(UserResetService::class);
+        $userResetService->expects($this->once())->method('resetUser')
+            ->with($this->isInstanceOf(User::class), 'newPassword123')
+            ->willReturn('recovery-token-abc123');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new UserManager(
+            $entityManager,
+            $this->repository,
+            $this->passwordUpdater,
+            $this->mailCryptKeyHandler,
+            $this->settingsService,
+            $this->domainGuesser,
+            $userResetService,
+            $this->deleteHandler,
+        );
+
+        $user = new User('user@example.org');
+        $user->setMailCryptSecretBox('encrypted-secret');
+
+        $model = new UserAdminModel();
+        $model->setRoles([Roles::USER]);
+        $model->setPlainPassword('newPassword123');
+        $model->setTotpConfirmed(false);
+
+        $recoveryToken = $manager->update($user, $model);
+
+        self::assertSame('recovery-token-abc123', $recoveryToken);
+        self::assertTrue($user->isPasswordChangeRequired());
+    }
+
+    public function testUpdateWithPasswordChangeWithoutMailCrypt(): void
+    {
+        /** @var PasswordUpdater&MockObject $passwordUpdater */
+        $passwordUpdater = $this->createMock(PasswordUpdater::class);
+        $passwordUpdater->expects($this->once())->method('updatePassword');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new UserManager(
+            $entityManager,
+            $this->repository,
+            $passwordUpdater,
+            $this->mailCryptKeyHandler,
+            $this->settingsService,
+            $this->domainGuesser,
+            $this->userResetService,
+            $this->deleteHandler,
+        );
+
+        $user = new User('user@example.org');
+
+        $model = new UserAdminModel();
+        $model->setRoles([Roles::USER]);
+        $model->setPlainPassword('newPassword123');
+        $model->setTotpConfirmed(false);
+
+        $recoveryToken = $manager->update($user, $model);
+
+        self::assertNull($recoveryToken);
+        self::assertTrue($user->isPasswordChangeRequired());
+    }
+
+    public function testUpdateDeactivates2fa(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('flush');
+
+        $manager = new UserManager(
+            $entityManager,
+            $this->repository,
+            $this->passwordUpdater,
+            $this->mailCryptKeyHandler,
+            $this->settingsService,
+            $this->domainGuesser,
+            $this->userResetService,
+            $this->deleteHandler,
+        );
+
+        $user = new User('user@example.org');
+        $user->setTotpSecret('totp-secret');
+        $user->setTotpConfirmed(true);
+        $user->setTotpBackupCodes(['code1', 'code2']);
+
+        $model = new UserAdminModel();
+        $model->setRoles([Roles::USER]);
+        $model->setTotpConfirmed(false);
+
+        $manager->update($user, $model);
+
+        self::assertNull($user->getTotpSecret());
+        self::assertFalse($user->isTotpAuthenticationEnabled());
+        self::assertEmpty($user->getTotpBackupCodes());
+    }
+
+    public function testDelete(): void
+    {
+        $user = new User('user@example.org');
+
+        /** @var DeleteHandler&MockObject $deleteHandler */
+        $deleteHandler = $this->createMock(DeleteHandler::class);
+        $deleteHandler->expects($this->once())->method('deleteUser')->with($user);
+
+        $manager = new UserManager(
+            $this->entityManager,
+            $this->repository,
+            $this->passwordUpdater,
+            $this->mailCryptKeyHandler,
+            $this->settingsService,
+            $this->domainGuesser,
+            $this->userResetService,
+            $deleteHandler,
+        );
+
+        $manager->delete($user);
+    }
+}


### PR DESCRIPTION
## Summary

Implements a native user administration interface at `/settings/users/` for `ROLE_ADMIN` users, replacing the need to use Sonata Admin for common user management tasks like creating users, editing roles, resetting passwords, and disabling 2FA.

<img width="2880" height="1800" alt="Bildschirmfoto am 2026-03-11 um 20 36 00" src="https://github.com/user-attachments/assets/a533da7f-dd48-48e2-8f9b-00640c2bfe6b" />
<img width="2880" height="1800" alt="Bildschirmfoto am 2026-03-11 um 20 35 50" src="https://github.com/user-attachments/assets/5438c53e-4c31-489f-b8dd-54b463b0329c" />


**Key features:**
- User list with search, pagination, and filters (status, role, MailCrypt, 2FA)
- Compact status icons (check-circle/x-circle) for boolean columns
- Create user form with password strength meter and pre-selected "password change required"
- Edit user form with status bar (created, last login, recovery token, MailCrypt, status)
- Password changes handle MailCrypt re-encryption and recovery token generation
- 2FA deactivation with info hint (only users can enable, admins can only disable)
- Full EN and DE translations (~65 keys each)
- 23 PHPUnit tests and 15 Behat scenarios

**Architecture:** Follows the existing Alias admin pattern (Controller → Manager → FormType → FormModel → Repository).

**Note:** Sonata UserAdmin remains in place for Domain Admins.

Closes #1085

---
<sub>The changes and the PR were generated by OpenCode.</sub>