### PR TITLE
📝 Add hierarchical AGENTS.md knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,25 +14,24 @@ Userli — Symfony 7.4 web app for self-managing email users with Dovecot mailbo
 userli/
 ├── src/                    # Application code (see src/AGENTS.md)
 │   ├── Controller/         # HTTP layer (see src/Controller/AGENTS.md)
-│   ├── Entity/             # 11 Doctrine entities, trait-composed
+│   ├── Entity/             # Doctrine entities, trait-composed
 │   ├── Form/               # Symfony forms + models (see src/Form/AGENTS.md)
-│   ├── Handler/            # Business logic operations
-│   ├── Service/            # Managers + domain services
+│   ├── Service/            # Business logic, managers + domain services
 │   ├── EventListener/      # Symfony event listeners
 │   ├── Message/            # Messenger messages (async)
 │   ├── MessageHandler/     # Messenger handlers (1:1 with messages)
-│   ├── Command/            # 18 console commands
+│   ├── Command/            # Console commands
 │   ├── Validator/          # Custom constraint + validator pairs
-│   ├── Traits/             # 27 reusable entity traits
+│   ├── Traits/             # Entity composition traits
 │   ├── Enum/               # PHP enums (roles, scopes, cache keys)
 │   └── Security/           # Authenticator, provider, voter
 ├── templates/              # Twig templates (see templates/AGENTS.md)
 ├── config/                 # Symfony config, routes, settings.yaml
 ├── tests/                  # Tests mirror src/ (see tests/AGENTS.md)
-├── features/               # 30 Behat feature files
+├── features/               # Behat feature files
 ├── assets/                 # Stimulus controllers, TailwindCSS, JS
 ├── default_translations/   # EN/DE manual, others via Weblate
-├── migrations/             # 15 Doctrine migrations
+├── migrations/             # Doctrine migrations
 └── docs/                   # MkDocs documentation site
 ```
 
@@ -43,11 +42,11 @@ userli/
 | Add user-facing feature | `src/Controller/`, `src/Form/`, `templates/` | GET/POST split pattern |
 | Add admin feature | `src/Controller/Admin/` | Role-gated, Twig admin templates |
 | Add API endpoint | `src/Controller/Api/` | Token auth, scope-based |
-| Business logic | `src/Handler/` or `src/Service/` | Handlers = operations, Services = managers |
+| Business logic | `src/Service/` | Primary location for business logic |
 | Background job | `src/Message/` + `src/MessageHandler/` | Always paired 1:1 |
 | Scheduled task | `src/Schedule/MaintenanceSchedule.php` | Symfony Scheduler |
 | Custom validation | `src/Validator/` | Constraint + Validator pair |
-| Entity change | `src/Entity/` + `src/Traits/` | Entities compose many traits |
+| Entity change | `src/Entity/` + `src/Traits/` | Entities compose traits |
 | Cache invalidation | `src/EntityListener/` | Doctrine lifecycle listeners |
 | Domain events | `src/Event/` + `src/EventListener/` | Dispatched via EventDispatcher |
 | Email templates | `templates/Email/` | Twig email templates |
@@ -56,7 +55,7 @@ userli/
 
 ## Entities
 
-- `User`: Email account — roles, 2FA (TOTP + backup codes), mailbox encryption, composed of 27 traits
+- `User`: Email account — roles, 2FA (TOTP + backup codes), mailbox encryption, composed of traits
 - `Domain`: Email domains with admin relationships
 - `Alias`: Email aliases → users (random + custom)
 - `Voucher`: Invite codes for registration (users get 3 after one week)
@@ -151,7 +150,7 @@ yarn test                      # JS/TS unit tests
 
 ## Notes
 
-- `config/reference.php` (2179 lines) — largest file, auto-generated settings reference
-- `tests/Behat/FeatureContext.php` (1132 lines) — monolithic Behat context, main BDD entry point
+- `config/reference.php` — largest file, auto-generated settings reference
+- `tests/Behat/FeatureContext.php` — monolithic Behat context, main BDD entry point
 - Docker Compose uses MariaDB + Postfix for full email stack testing
 - `dg/bypass-finals` in dev deps — allows mocking final classes in tests

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,53 +1,54 @@
 # src/ — Application Code
 
-327 PHP files across 33 subdirectories. Standard Symfony structure with project-specific conventions.
+Standard Symfony structure with project-specific conventions.
 
 ## Directory Map
 
-| Directory | Files | Purpose |
-|-----------|-------|---------|
-| `Controller/` | 32 | HTTP layer — 3 subdirs: Account/, Admin/, Api/ (see Controller/AGENTS.md) |
-| `Form/` | 50 | Symfony forms + Model/ DTOs (see Form/AGENTS.md) |
-| `Traits/` | 27 | Entity composition — User entity uses all 27 |
-| `Validator/` | 22 | Custom constraints: 11 Constraint + Validator pairs |
-| `Service/` | 20 | Domain services and entity managers |
-| `Command/` | 18 | Console commands, all extend `AbstractUsersCommand` base |
-| `EventListener/` | 16 | Symfony event listeners (login, locale, webhooks, etc.) |
-| `Message/` | 15 | Symfony Messenger messages — async job definitions |
-| `MessageHandler/` | 15 | Messenger handlers — 1:1 with Message/ (always paired) |
-| `Entity/` | 13 | Doctrine entities — heavily trait-composed |
-| `Repository/` | 12 | Doctrine repositories |
-| `Handler/` | 12 | Business logic operations (registration, recovery, crypto) |
-| `Enum/` | 10 | PHP enums: Roles, ApiScope, CacheKeys, MailCrypt, etc. |
-| `DataFixtures/` | 10 | Test data fixtures |
-| `EntityListener/` | 7 | Doctrine lifecycle listeners (cache invalidation, timestamps) |
-| `Event/` | 7 | Domain events: User, Alias, Domain, Login, Notification |
-| `Exception/` | 7 | Custom exception classes |
-| `Security/` | 6 | Auth: ApiTokenAuthenticator, UserChecker, UserProvider, RequireApiScope |
-| `Helper/` | 6 | Utility classes |
-| `Dto/` | 6 | Data transfer objects |
-| `Twig/` | 3 | Twig extensions: SafeHtmlExtension, SettingsExtension |
-| `Mail/` | 3 | Mail builder/sender utilities |
-| `Voter/` | 2 | AliasVoter, DomainVoter — resource-level authorization |
-| `Model/` | 2 | Domain model classes |
-| `Importer/` | 2 | GPG key import utilities |
-| `Creator/` | 2 | Factory-like creators |
-| `Schedule/` | 1 | MaintenanceSchedule — Symfony Scheduler cron jobs |
-| `Remover/` | 1 | Entity removal logic |
-| `Guesser/` | 1 | Domain guesser |
-| `Factory/` | 1 | Entity factory |
-| `DependencyInjection/` | 1 | Settings configuration |
+| Directory | Purpose |
+|-----------|---------|
+| `Controller/` | HTTP layer — 3 subdirs: Account/, Admin/, Api/ (see Controller/AGENTS.md) |
+| `Form/` | Symfony forms + Model/ DTOs (see Form/AGENTS.md) |
+| `Traits/` | Entity composition traits |
+| `Validator/` | Custom constraints: Constraint + Validator pairs |
+| `Service/` | Domain services, entity managers, and business logic |
+| `Command/` | Console commands, many extend `AbstractUsersCommand` base |
+| `EventListener/` | Symfony event listeners (login, locale, webhooks, etc.) |
+| `Message/` | Symfony Messenger messages — async job definitions |
+| `MessageHandler/` | Messenger handlers — 1:1 with Message/ (always paired) |
+| `Entity/` | Doctrine entities — trait-composed |
+| `Repository/` | Doctrine repositories |
+| `Handler/` | Legacy business logic (being migrated to Service/) |
+| `Enum/` | PHP enums: Roles, ApiScope, CacheKeys, MailCrypt, etc. |
+| `DataFixtures/` | Test data fixtures |
+| `EntityListener/` | Doctrine lifecycle listeners (cache invalidation, timestamps) |
+| `Event/` | Domain events: User, Alias, Domain, Login, Notification |
+| `Exception/` | Custom exception classes |
+| `Security/` | Auth: ApiTokenAuthenticator, UserChecker, UserProvider, RequireApiScope |
+| `Helper/` | Utility classes |
+| `Dto/` | Data transfer objects |
+| `Twig/` | Twig extensions: SafeHtmlExtension, SettingsExtension |
+| `Mail/` | Mail builder/sender utilities |
+| `Voter/` | AliasVoter, DomainVoter — resource-level authorization |
+| `Model/` | Domain model classes |
+| `Importer/` | GPG key import utilities |
+| `Creator/` | Factory-like creators |
+| `Schedule/` | MaintenanceSchedule — Symfony Scheduler cron jobs |
+| `Remover/` | Entity removal logic |
+| `Guesser/` | Domain guesser |
+| `Factory/` | Entity factory |
+| `DependencyInjection/` | Settings configuration |
 
 ## Key Patterns
 
-### Handlers vs Services
+### Services
 
-- **Handlers** (`Handler/`): Stateless operations on entities. Named by action: `RegistrationHandler`, `RecoveryHandler`, `MailCryptKeyHandler`. Called from controllers.
-- **Services** (`Service/`): Entity managers and domain services. Named `*Manager` (CRUD wrappers) or `*Service` (cross-cutting). Called from handlers, controllers, commands.
+`Service/` is the primary location for business logic. Named `*Manager` (CRUD wrappers) or `*Service` (cross-cutting). Called from controllers, commands, and other services.
+
+`Handler/` exists but is deprecated — handlers are being migrated into `Service/`. New business logic should go in `Service/`.
 
 ### Entity Composition via Traits
 
-Entities in `Entity/` are thin — most properties come from `Traits/`. `User` uses all 27 traits. When adding a field to an entity, check if an existing trait provides it or create a new one.
+Entities in `Entity/` are thin — most properties come from `Traits/`.
 
 ### Message/MessageHandler Pairing
 
@@ -55,7 +56,7 @@ Every file in `Message/` has a matching handler in `MessageHandler/`. Example: `
 
 ### Validator Pairs
 
-Every constraint in `Validator/` is paired: `EmailAvailable.php` (constraint attribute) + `EmailAvailableValidator.php` (logic). 11 pairs covering email rules, passwords, vouchers, TOTP.
+Every constraint in `Validator/` is paired: `EmailAvailable.php` (constraint attribute) + `EmailAvailableValidator.php` (logic). Pairs cover email rules, passwords, vouchers, TOTP.
 
 ### EntityListener Cache Invalidation
 
@@ -63,11 +64,10 @@ Every constraint in `Validator/` is paired: `EmailAvailable.php` (constraint att
 
 ### Console Commands
 
-18 commands in `Command/`. Many extend `AbstractUsersCommand` which provides domain filtering and batch user operations. Commands are prefixed: `app:users:*`, `app:voucher:*`, `app:domain:*`, `app:admin:*`, `app:api-token:*`.
+Commands in `Command/`. Many extend `AbstractUsersCommand` which provides domain filtering and batch user operations. Commands are prefixed: `app:users:*`, `app:voucher:*`, `app:domain:*`, `app:admin:*`, `app:api-token:*`.
 
 ## Anti-Patterns
 
-- **NEVER** put business logic in controllers — use Handler/ or Service/
+- **NEVER** put business logic in controllers — use `Service/`
 - **NEVER** access entity properties directly from outside — use repository methods
 - **NEVER** create a Message without a matching MessageHandler
-- **NEVER** add entity properties inline — use or create a Trait

--- a/src/Controller/AGENTS.md
+++ b/src/Controller/AGENTS.md
@@ -1,18 +1,18 @@
 # src/Controller/ — HTTP Layer
 
-32 files across 3 subdirectories + 5 root controllers.
+Three subdirectories + root controllers.
 
 ## Structure
 
 ```
 Controller/
-├── Account/              # Authenticated user self-service (5 controllers)
+├── Account/              # Authenticated user self-service
 │   ├── AccountController.php     # Password change, recovery token, delete account
 │   ├── AliasController.php       # Custom + random alias management
 │   ├── OpenPGPController.php     # OpenPGP key upload/delete
 │   ├── TwofactorController.php   # TOTP setup + backup codes
 │   └── VoucherController.php     # View/create invite vouchers
-├── Admin/                # Admin panel (15 controllers)
+├── Admin/                # Admin panel
 │   ├── DashboardController.php   # Admin dashboard
 │   ├── UserController.php        # User CRUD
 │   ├── DomainController.php      # Domain management
@@ -20,7 +20,7 @@ Controller/
 │   ├── SettingsController.php    # Global settings editor
 │   ├── MaintenanceController.php # Maintenance operations
 │   └── ...                       # Voucher, ApiToken, Webhook, ReservedName, etc.
-├── Api/                  # API endpoints (7 controllers)
+├── Api/                  # API endpoints
 │   ├── DovecotController.php     # Dovecot mailbox auth + encryption
 │   ├── PostfixController.php     # Postfix mail routing
 │   ├── KeycloakController.php    # Keycloak SSO integration
@@ -48,14 +48,14 @@ public function submit(Request $request): Response { /* handle submission */ }
 ```
 
 - GET method: Creates form, renders template
-- POST method: Handles request, validates, delegates to Handler
+- POST method: Handles request, validates, delegates to Service
 - Separate route names: `*_show` / `*_submit` or similar
 
 ## Controller Conventions
 
 - Controllers are `final` classes extending `AbstractController`
 - Constructor injection via `readonly` promoted properties
-- Business logic delegated to `Handler/` — controllers only coordinate
+- Business logic delegated to `Service/` — controllers only coordinate
 - Flash messages use translation keys: `$this->addFlash('error', 'flashes.voucher-invalid')`
 - Forms created with `$this->createForm()`, specify `action` and `method` in options
 

--- a/src/Form/AGENTS.md
+++ b/src/Form/AGENTS.md
@@ -1,12 +1,10 @@
 # src/Form/ — Forms and Models
 
-50 files: 30 form types + 18 form models + 2 data transformers.
-
 ## Structure
 
 ```
 Form/
-├── Model/                  # Form DTOs (18 files) — NEVER use entities
+├── Model/                  # Form DTOs — NEVER use entities
 │   ├── Registration.php    # Registration flow data
 │   ├── Password.php        # Password change
 │   ├── AliasCreate.php     # Alias creation
@@ -18,7 +16,7 @@ Form/
 ├── PasswordType.php        # Password input with constraints
 ├── SettingsType.php        # Dynamic global settings form
 ├── UserAdminType.php       # Admin user edit form
-└── ...                     # 26 more form types
+└── ...                     # Additional form types
 ```
 
 ## Entity-Form Separation (MANDATORY)
@@ -34,7 +32,7 @@ $form = $this->createForm(RegistrationType::class, $registration);
 $form = $this->createForm(UserType::class, $user);  // Entity bound to form
 ```
 
-Form models are plain PHP classes with getters/setters + validation attributes. After form submission, data is transferred from model to entity in the Handler.
+Form models are plain PHP classes with getters/setters + validation attributes. After form submission, data is transferred from model to entity in the Service.
 
 ## Form Type Conventions
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,7 +1,5 @@
 # templates/ — Twig Templates
 
-85 templates across 12 subdirectories.
-
 ## Base Template Hierarchy
 
 Three base templates — every page extends one:
@@ -21,20 +19,20 @@ base.html.twig              # Root: HTML shell, dark mode, assets, navbar, flash
 
 ## Directory Map
 
-| Directory | Templates | Purpose |
-|-----------|-----------|---------|
-| `Account/` | 14 | User self-service pages (password, aliases, 2FA, OpenPGP) |
-| `Admin/` | 11 | Admin panel (users, domains, settings, maintenance) |
-| `Alias/` | - | Alias management partials |
-| `Email/` | - | Email notification templates |
-| `Form/` | 1 | `fields.html.twig` — global Symfony form theme |
-| `Init/` | - | First-run setup |
-| `Recovery/` | - | Account recovery flow |
-| `Registration/` | - | Registration multi-step |
-| `Security/` | - | Login page |
-| `Start/` | - | Landing/index page |
-| `Voucher/` | - | Invite code pages |
-| `bundles/` | - | Bundle template overrides |
+| Directory | Purpose |
+|-----------|---------|
+| `Account/` | User self-service pages (password, aliases, 2FA, OpenPGP) |
+| `Admin/` | Admin panel (users, domains, settings, maintenance) |
+| `Alias/` | Alias management partials |
+| `Email/` | Email notification templates |
+| `Form/` | `fields.html.twig` — global Symfony form theme |
+| `Init/` | First-run setup |
+| `Recovery/` | Account recovery flow |
+| `Registration/` | Registration multi-step |
+| `Security/` | Login page |
+| `Start/` | Landing/index page |
+| `Voucher/` | Invite code pages |
+| `bundles/` | Bundle template overrides |
 
 ## Shared Partials (root level)
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,42 +1,42 @@
 # tests/ — Testing Infrastructure
 
-200+ files mirroring `src/` structure. Three test frameworks: PHPUnit, Behat, Vitest.
+Tests mirror `src/` structure. Three test frameworks: PHPUnit, Behat, Vitest.
 
 ## Structure
 
 ```
 tests/
-├── Command/           # 17 command tests
+├── Command/           # Command tests
 ├── Controller/        # (via Behat features/ instead)
 ├── Creator/           # Creator tests
 ├── DependencyInjection/ # Configuration tests
 ├── Dto/               # DTO tests
 ├── Entity/            # Entity unit tests
-├── EntityListener/    # 7 Doctrine listener tests
+├── EntityListener/    # Doctrine listener tests
 ├── Enum/              # Enum tests
 ├── Event/             # Event tests
-├── EventListener/     # 16 event listener tests
-├── Form/              # 26 form type tests
+├── EventListener/     # Event listener tests
+├── Form/              # Form type tests
 ├── Functional/        # Functional integration tests
 ├── Guesser/           # Guesser tests
-├── Handler/           # 12 handler tests
+├── Handler/           # Handler tests
 ├── Helper/            # Helper tests
 ├── Importer/          # Importer tests
 ├── Integration/       # Integration tests
 ├── Mail/              # Mail tests
-├── MessageHandler/    # 15 message handler tests
+├── MessageHandler/    # Message handler tests
 ├── Model/             # Model tests
 ├── Schedule/          # Schedule tests
 ├── Security/          # Auth tests (ApiTokenAuthenticator, UserChecker, etc.)
-├── Service/           # 20 service tests
+├── Service/           # Service tests
 ├── Twig/              # Twig extension tests
-├── Validator/         # 10 validator tests
+├── Validator/         # Validator tests
 ├── Voter/             # Voter tests
 ├── Behat/             # Behat contexts
-│   ├── FeatureContext.php  # Main context (1132 lines — monolithic)
+│   ├── FeatureContext.php  # Main context (monolithic)
 │   └── ApiContext.php      # API testing context
 ├── js/                # Vitest JS/TS tests
-│   └── controllers/   # 10 Stimulus controller tests
+│   └── controllers/   # Stimulus controller tests
 ├── autoload.php       # Test autoloader (dg/bypass-finals)
 ├── bootstrap.php      # PHPUnit bootstrap
 └── dovecot-api-mock.py # Mock Dovecot API for integration tests
@@ -54,7 +54,7 @@ tests/
 ## Behat
 
 - Config: `behat.yml.dist`
-- Features: `features/` (30 `.feature` files)
+- Features: `features/` (`.feature` files)
 - Main context: `tests/Behat/FeatureContext.php` — handles all web scenarios
 - API context: `tests/Behat/ApiContext.php` — API-specific steps
 - Uses BrowserKit driver, no real browser needed
@@ -63,7 +63,7 @@ tests/
 ## Vitest (JS/TS)
 
 - Config: `vitest.config.ts`
-- Tests: `tests/js/controllers/` (10 Stimulus controller tests)
+- Tests: `tests/js/controllers/` (Stimulus controller tests)
 - Run: `yarn test`
 
 ## Special Files
@@ -76,4 +76,4 @@ tests/
 
 - **NEVER** delete failing tests to make CI pass
 - **NEVER** use `$this->assert*` — always `self::assert*`
-- **NEVER** skip adding test when creating new Handler/Service/Command
+- **NEVER** skip adding test when creating new Service/Command


### PR DESCRIPTION
## Summary

- Update root `AGENTS.md` with structured overview: directory tree with cross-references, task routing table, entity descriptions, CI/CD pipeline list, security and anti-pattern sections
- Create 5 subdirectory `AGENTS.md` files for `src/`, `src/Controller/`, `src/Form/`, `tests/`, and `templates/` with detailed patterns, conventions, and directory maps
- Establish parent-child hierarchy where child files cover domain-specific details without repeating root content

### Why

AI coding assistants (Copilot, Cursor, Claude Code, opencode, etc.) automatically pick up `AGENTS.md` files as context when working in a directory. A single root file works for small projects, but Userli has 327 PHP files across 33 subdirectories with project-specific patterns (GET/POST controller split, entity-form separation, trait composition, message/handler pairing) that are easy to get wrong.

Hierarchical AGENTS.md files let AI tools load only the relevant conventions for the directory they are working in — a controller change gets the GET/POST split pattern, a form change gets the model separation rule, a test change gets the PHPUnit/Behat conventions — without stuffing everything into one large root file.

### Files

| File | Lines | Purpose |
|------|-------|---------|
| `AGENTS.md` | 157 | Root — project overview, structure, routing table |
| `src/AGENTS.md` | 73 | Application code map, handler/service distinction, entity traits |
| `src/Controller/AGENTS.md` | 74 | GET/POST split pattern, controller hierarchy, API auth |
| `src/Form/AGENTS.md` | 49 | Entity-form separation, model pattern, type conventions |
| `tests/AGENTS.md` | 79 | PHPUnit/Behat/Vitest setup, test structure, special files |
| `templates/AGENTS.md` | 57 | Base template hierarchy, Twig conventions, partials |

Generated with `/init-deep` via [opencode](https://github.com/opencode-ai/opencode) using Claude Opus 4.6.