### PR TITLE
Fix usage of AliasRepository::findByUser method

### DIFF
--- a/features/api_roundcube.feature
+++ b/features/api_roundcube.feature
@@ -9,6 +9,7 @@ Feature: Roundcube API
         And the following Domain exists:
             | name        |
             | example.org |
+            | example.com |
         And the following User exists:
             | email             | password | roles     |
             | user@example.org  | password | ROLE_USER |
@@ -59,3 +60,17 @@ Feature: Roundcube API
             """
             []
             """
+
+    @aliases
+    Scenario: Get cross-domain aliases for user
+        Given the following Alias exists:
+            | user_id | source                      | destination       |
+            | 2       | crossdomain@example.com     | user2@example.org |
+        And I have a valid API token "roundcube-test-123"
+        When I send a POST request to "/api/roundcube/aliases" with form data:
+            | email    | user2@example.org |
+            | password | password          |
+        Then the response status code should equal 200
+        And the JSON response should contain "alias@example.org"
+        And the JSON response should contain "alias2@example.org"
+        And the JSON response should contain "crossdomain@example.com"

--- a/features/openpgp.feature
+++ b/features/openpgp.feature
@@ -5,6 +5,7 @@ Feature: OpenPGP
     And the following Domain exists:
       | name        |
       | example.org |
+      | example.com |
     And the following User exists:
       | email               | password |
       | alice@example.org   | asdasd   |
@@ -408,3 +409,13 @@ Feature: OpenPGP
 
     Then I should be on "/account/openpgp"
     And I should see text matching "You are not authorized to manage this identity."
+
+  @openpgp-cross-domain-identity
+  Scenario: Cross-domain alias appears as identity on OpenPGP page
+    Given the following Alias exists:
+      | user_id | source                  | destination       | deleted | random |
+      | 1       | crossdomain@example.com | alice@example.org | 0       | 0      |
+    When I am authenticated as "alice@example.org"
+    And I am on "/account/openpgp"
+    Then the response status code should be 200
+    And I should see "crossdomain@example.com"

--- a/features/user.feature
+++ b/features/user.feature
@@ -132,6 +132,14 @@ Feature: User
 
     Then I should be on "/"
 
+  @delete-user-cross-domain-aliases
+  Scenario: Deleting a user also deletes their cross-domain aliases
+    Given the following Alias exists:
+      | user_id | source                  | destination      | deleted | random |
+      | 2       | crossdomain@example.com | user@example.org | 0       | 0      |
+    When the user "user@example.org" is deleted
+    Then the alias "crossdomain@example.com" should be deleted
+
   @create-voucher
   Scenario: Create voucher as Admin
     When I am authenticated as "admin@example.org"

--- a/features/user.feature
+++ b/features/user.feature
@@ -5,6 +5,7 @@ Feature: User
     And the following Domain exists:
       | name        | invitation_enabled | invitation_limit |
       | example.org | 1                  | 3                |
+      | example.com |                    |                  |
     And the following User exists:
       | email               | password | roles           |
       | admin@example.org   | asdasd   | ROLE_ADMIN      |
@@ -291,6 +292,16 @@ Feature: User
     When I am authenticated as "spam@example.org"
     And I am on "/account/alias"
     Then the response status code should be 403
+
+  @alias-cross-domain
+  Scenario: User can see cross-domain aliases on alias page
+    Given the following Alias exists:
+      | user_id | source                      | destination      | deleted | random |
+      | 2       | crossdomain@example.com     | user@example.org | 0       | 0      |
+    When I am authenticated as "user@example.org"
+    And I am on "/account/alias"
+    Then the response status code should be 200
+    And I should see "crossdomain@example.com"
 
   @voucher-access
   Scenario: Unauthenticated user is redirected to login from voucher page

--- a/src/Controller/Account/AliasController.php
+++ b/src/Controller/Account/AliasController.php
@@ -57,8 +57,8 @@ final class AliasController extends AbstractController
         );
 
         $aliasRepository = $this->manager->getRepository(Alias::class);
-        $aliasesRandom = $aliasRepository->findByUser($user, true, true);
-        $aliasesCustom = $aliasRepository->findByUser($user, false, true);
+        $aliasesRandom = $aliasRepository->findByUserAcrossDomains($user, random: true);
+        $aliasesCustom = $aliasRepository->findByUserAcrossDomains($user, random: false);
 
         return $this->render(
             'Alias/show.html.twig',

--- a/src/Controller/Account/OpenPGPController.php
+++ b/src/Controller/Account/OpenPGPController.php
@@ -151,7 +151,7 @@ final class OpenPGPController extends AbstractController
         ];
 
         // Non-random alias sources from all domains
-        $aliases = $this->aliasRepository->findByUser($user, false, true);
+        $aliases = $this->aliasRepository->findByUserAcrossDomains($user, random: false);
         foreach ($aliases as $alias) {
             $source = $alias->getSource();
             if (null !== $source) {

--- a/src/Controller/Account/OpenPGPController.php
+++ b/src/Controller/Account/OpenPGPController.php
@@ -175,7 +175,7 @@ final class OpenPGPController extends AbstractController
             return true;
         }
 
-        $aliases = $this->aliasRepository->findByUser($user, false);
+        $aliases = $this->aliasRepository->findByUserAcrossDomains($user, false);
 
         return array_any($aliases, static fn ($alias) => $alias->getSource() === $email);
     }

--- a/src/Controller/Api/RoundcubeController.php
+++ b/src/Controller/Api/RoundcubeController.php
@@ -35,7 +35,10 @@ final class RoundcubeController extends AbstractController
             throw new AuthenticationException('Bad credentials', 401);
         }
 
-        $aliases = $this->manager->getRepository(Alias::class)->findByUser($user);
+        // Uses findByUserAcrossDomains to include cross-domain aliases. The domain
+        // filter is typically not active for API-authenticated requests (see the
+        // method's doc comment), but this ensures correct behavior regardless.
+        $aliases = $this->manager->getRepository(Alias::class)->findByUserAcrossDomains($user);
         $aliasSources = array_map(static fn ($alias) => $alias->getSource(), $aliases);
 
         return $this->json($aliasSources);

--- a/src/Handler/DeleteHandler.php
+++ b/src/Handler/DeleteHandler.php
@@ -86,7 +86,7 @@ final readonly class DeleteHandler
         $this->manager->flush();
 
         // Get custom aliases from all domains
-        $customAliases = $this->manager->getRepository(Alias::class)->findByUser($user, false, true);
+        $customAliases = $this->manager->getRepository(Alias::class)->findByUserAcrossDomains($user, random: false);
         foreach ($customAliases as $customAlias) {
             $this->eventDispatcher->dispatch(new AliasDeletedEvent($customAlias), AliasDeletedEvent::CUSTOM);
         }

--- a/src/Handler/DeleteHandler.php
+++ b/src/Handler/DeleteHandler.php
@@ -48,7 +48,7 @@ final readonly class DeleteHandler
     public function deleteUser(User $user): void
     {
         // Delete aliases of user
-        $aliases = $this->manager->getRepository(Alias::class)->findByUser($user);
+        $aliases = $this->manager->getRepository(Alias::class)->findByUserAcrossDomains($user);
         foreach ($aliases as $alias) {
             $alias->setDeleted(true);
             $alias->clearSensitiveData();

--- a/src/Repository/AliasRepository.php
+++ b/src/Repository/AliasRepository.php
@@ -136,20 +136,45 @@ final class AliasRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return array|Alias[]
+     * @return Alias[]
      */
-    public function findByUser(User $user, ?bool $random = null, ?bool $disableDomainFilter = false): array
+    public function findByUser(User $user, ?bool $random = null): array
+    {
+        $criteria = ['user' => $user, 'deleted' => false];
+
+        if (null !== $random) {
+            $criteria['random'] = $random;
+        }
+
+        return $this->findBy($criteria);
+    }
+
+    /**
+     * Find active aliases owned by the user across all domains.
+     *
+     * Temporarily disables the domain filter to include cross-domain aliases
+     * (e.g. aliases where the source domain differs from the user's domain).
+     * If the domain filter is not active (e.g. for API-authenticated requests
+     * where BeforeRequestListener does not enable it), this behaves identically
+     * to findByUser().
+     *
+     * @return Alias[]
+     */
+    public function findByUserAcrossDomains(User $user, ?bool $random = null): array
     {
         $filters = $this->getEntityManager()->getFilters();
+        $wasEnabled = $filters->isEnabled('domain_filter');
 
-        if ($filters->isEnabled('domain_filter') && $disableDomainFilter == true) {
+        if ($wasEnabled) {
             $filters->disable('domain_filter');
         }
 
-        if (isset($random)) {
-            return $this->findBy(['user' => $user, 'random' => $random, 'deleted' => false]);
+        try {
+            return $this->findByUser($user, $random);
+        } finally {
+            if ($wasEnabled) {
+                $filters->enable('domain_filter');
+            }
         }
-
-        return $this->findBy(['user' => $user, 'deleted' => false]);
     }
 }

--- a/tests/Behat/ApiContext.php
+++ b/tests/Behat/ApiContext.php
@@ -223,6 +223,40 @@ class ApiContext extends RawMinkContext implements Context
     }
 
     /**
+     * @Then the JSON response should contain :value
+     */
+    public function theJsonResponseShouldContain(string $value): void
+    {
+        $content = $this->getSession()->getPage()->getContent();
+        $data = json_decode($content, true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new RuntimeException(sprintf('Response is not valid JSON: %s', json_last_error_msg()));
+        }
+
+        if (!is_array($data) || !in_array($value, $data, true)) {
+            throw new RuntimeException(sprintf('JSON response does not contain "%s". Response: %s', $value, $content));
+        }
+    }
+
+    /**
+     * @Then the JSON response should not contain :value
+     */
+    public function theJsonResponseShouldNotContain(string $value): void
+    {
+        $content = $this->getSession()->getPage()->getContent();
+        $data = json_decode($content, true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new RuntimeException(sprintf('Response is not valid JSON: %s', json_last_error_msg()));
+        }
+
+        if (is_array($data) && in_array($value, $data, true)) {
+            throw new RuntimeException(sprintf('JSON response should not contain "%s" but it does. Response: %s', $value, $content));
+        }
+    }
+
+    /**
      * @throws UnsupportedDriverActionException
      */
     private function sendRequest(string $method, string $path, array $parameters = [], ?string $content = null, bool $setContentType = true): void

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -752,6 +752,39 @@ class FeatureContext extends MinkContext
     }
 
     /**
+     * @When /^the user "([^"]*)" is deleted$/
+     */
+    public function theUserIsDeleted(string $email): void
+    {
+        $user = $this->getUserRepository()->findByEmail($email);
+
+        if (null === $user) {
+            throw new RuntimeException(sprintf('User "%s" does not exist', $email));
+        }
+
+        $deleteHandler = $this->getContainer()->get('App\Handler\DeleteHandler');
+        $deleteHandler->deleteUser($user);
+    }
+
+    /**
+     * @Then /^the alias "([^"]*)" should be deleted$/
+     */
+    public function theAliasShouldBeDeleted(string $source): void
+    {
+        $this->manager->clear();
+
+        $alias = $this->manager->getRepository(Alias::class)->findOneBySource($source, includeDeleted: true);
+
+        if (null === $alias) {
+            throw new RuntimeException(sprintf('Alias "%s" does not exist', $source));
+        }
+
+        if (!$alias->isDeleted()) {
+            throw new RuntimeException(sprintf('Alias "%s" is not deleted', $source));
+        }
+    }
+
+    /**
      * @Then /^the user "([^"]*)" should have passwordChangeRequired$/
      */
     public function theUserShouldHavePasswordChangeRequired(string $email): void

--- a/tests/Handler/DeleteHandlerTest.php
+++ b/tests/Handler/DeleteHandlerTest.php
@@ -34,6 +34,7 @@ class DeleteHandlerTest extends TestCase
 
         $aliasRepository = $this->createStub(AliasRepository::class);
         $aliasRepository->method('findByUser')->willReturn($aliases);
+        $aliasRepository->method('findByUserAcrossDomains')->willReturn($aliases);
 
         $voucherRepository = $this->createStub(VoucherRepository::class);
         $voucherRepository->method('findByUser')->willReturn($vouchers);

--- a/tests/Handler/DeleteHandlerTest.php
+++ b/tests/Handler/DeleteHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Handler;
 
 use App\Entity\Alias;
+use App\Entity\Domain;
 use App\Entity\User;
 use App\Entity\UserNotification;
 use App\Entity\Voucher;
@@ -170,12 +171,20 @@ class DeleteHandlerTest extends TestCase
         $alias2->setUser($user);
         $alias2->setSource('alias2@example.org');
 
-        $handler = $this->createHandler([$alias1, $alias2]);
+        $alias3 = new Alias();
+        $alias3->setUser($user);
+        $alias3->setSource('crossdomain@example.com');
+        $crossDomain = new Domain();
+        $crossDomain->setName('example.com');
+        $alias3->setDomain($crossDomain);
+
+        $handler = $this->createHandler([$alias1, $alias2, $alias3]);
 
         $handler->deleteUser($user);
 
         self::assertTrue($alias1->isDeleted());
         self::assertTrue($alias2->isDeleted());
+        self::assertTrue($alias3->isDeleted());
     }
 
     public function testDeleteUserRemovesNotifications(): void


### PR DESCRIPTION
* ♻️ Split AliasRepository::findByUser into findByUser() (with domain filter) and findByUserAcrossDomains() (disables domain filter)
* 🐛 Fix cross domain alias search in DeleteHandler and OpenPGPKeyController:
  * Allow to to manage OpenPGP keys for cross domain aliases
  * DeleteHandler::deleteUser($user) should delete aliases of $user from all domains
