### PR TITLE
✨ Add admin user show page with detail view and delete action

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -977,8 +977,42 @@ admin:
       confirm: "Möchtest du den Benutzer \"%email%\" wirklich löschen?"
       success: Benutzer wurde erfolgreich gelöscht.
     actions:
+      show: Anzeigen
       edit: Bearbeiten
       delete: Löschen
+    show:
+      description: Benutzerdetails und Statistiken
+      back: Zurück zu Benutzer:innen
+      back_to_user: Zurück zum Benutzer
+      roles: Rollen
+      status: Status
+      twofactor: 2FA
+      mailcrypt: MailCrypt
+      password_change_required: Passwortänderung erforderlich
+      password_change_required_warning: Bei der nächsten Anmeldung muss das Passwort geändert werden.
+      password_compromised: Das Passwort wurde in einem Datenleck gefunden.
+      recovery_token: Recovery-Token
+      recovery_token_yes: Konfiguriert
+      recovery_token_no: Nicht konfiguriert
+      quota: Quota (MB)
+      quota_default: Standard
+      smtp_limits: SMTP-Limits
+      smtp_limits_default: Standard
+      smtp_limits_format: "%per_hour%/h · %per_day%/d"
+      last_login: Letzte Anmeldung
+      created: Erstellt
+      invited_by: Eingeladen von
+      related_data: Verknüpfte Daten
+      aliases: Aliase
+      vouchers: Einladungscodes
+      vouchers_redeemed: "%count% eingelöst"
+      openpgp_keys: OpenPGP-Schlüssel
+      enabled: Aktiviert
+      disabled: Deaktiviert
+      deleted: Gelöscht
+      yes: "Ja"
+      no: "Nein"
+      never: Nie
     search:
       placeholder: Nach E-Mail suchen...
       submit: Suchen

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -979,8 +979,42 @@ admin:
       confirm: "Are you sure you want to delete the user \"%email%\"?"
       success: User has been deleted successfully.
     actions:
+      show: Show
       edit: Edit
       delete: Delete
+    show:
+      description: User details and statistics
+      back: Back to Users
+      back_to_user: Back to User
+      roles: Roles
+      status: Status
+      twofactor: 2FA
+      mailcrypt: MailCrypt
+      password_change_required: Password Change Required
+      password_change_required_warning: A password change is required on next login.
+      password_compromised: This user's password has been found in a data breach.
+      recovery_token: Recovery Token
+      recovery_token_yes: Configured
+      recovery_token_no: Not configured
+      quota: Quota (MB)
+      quota_default: Default
+      smtp_limits: SMTP Limits
+      smtp_limits_default: Default
+      smtp_limits_format: "%per_hour%/h · %per_day%/d"
+      last_login: Last Login
+      created: Created
+      invited_by: Invited By
+      related_data: Related Data
+      aliases: Aliases
+      vouchers: Invite Codes
+      vouchers_redeemed: "%count% redeemed"
+      openpgp_keys: OpenPGP Keys
+      enabled: Enabled
+      disabled: Disabled
+      deleted: Deleted
+      yes: "Yes"
+      no: "No"
+      never: Never
     search:
       placeholder: Search by email...
       submit: Search

--- a/features/admin_users.feature
+++ b/features/admin_users.feature
@@ -191,3 +191,97 @@ Feature: Settings (Users)
     When I click "Delete" in the modal
 
     Then I wait for text "User has been deleted successfully" to appear
+
+  @settings-users
+  Scenario: Admin can view user show page
+    Given I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/admin/users/__user_id__"
+
+    Then the response status code should be 200
+    And I should see "user@example.org"
+    And I should see "User details and statistics"
+    And I should see "Status"
+    And I should see "2FA"
+    And I should see "MailCrypt"
+    And I should see "Related Data"
+    And I should see "Aliases"
+    And I should see "Invite Codes"
+    And I should see "OpenPGP Keys"
+
+  @settings-users
+  Scenario: Show page displays password compromised warning
+    Given the following UserNotification exists:
+      | email            | type                 |
+      | user@example.org | password_compromised |
+    And I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/admin/users/__user_id__"
+
+    Then the response status code should be 200
+    And I should see "password has been found in a data breach"
+
+  @settings-users
+  Scenario: Show page displays password change required warning
+    Given the following User exists:
+      | email                   | password | roles     | passwordChangeRequired |
+      | pwchange@example.org    | asdasd   | ROLE_USER | true                   |
+    And I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "pwchange@example.org"
+    When I am on "/admin/users/__user_id__"
+
+    Then the response status code should be 200
+    And I should see "password change is required on next login"
+
+  @settings-users
+  Scenario: Regular user cannot access user show page
+    Given I am authenticated as "user@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/admin/users/__user_id__"
+
+    Then I should see "Access Denied"
+    And the response status code should be 403
+
+  @settings-users
+  Scenario: Domain admin can view user in own domain
+    Given I am authenticated as "support@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/admin/users/__user_id__"
+
+    Then the response status code should be 200
+    And I should see "user@example.org"
+
+  @settings-users
+  Scenario: Domain admin cannot view user in other domain
+    Given the following Domain exists:
+      | name      |
+      | other.org |
+    And the following User exists:
+      | email          | password | roles     |
+      | foo@other.org  | asdasd   | ROLE_USER |
+    And I am authenticated as "support@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "foo@other.org"
+    When I am on "/admin/users/__user_id__"
+
+    Then the response status code should be 404
+
+  @javascript @settings-users @delete-modal
+  Scenario: Admin can delete a user via modal on show page
+    Given I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/admin/users/__user_id__"
+    Then I should see "user@example.org"
+
+    When I press "Delete"
+    And I wait for the modal to appear
+    Then I should see "Confirm deletion" in the modal
+
+    When I click "Cancel" in the modal
+    And I wait for the modal to close
+    Then I should see "user@example.org"
+
+    When I press "Delete"
+    And I wait for the modal to appear
+    When I click "Delete" in the modal
+
+    Then I wait for text "User has been deleted successfully" to appear

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -150,6 +150,17 @@ final class UserController extends AbstractController
         ]);
     }
 
+    #[Route('/admin/users/{id}', name: 'admin_user_show', requirements: ['id' => '\d+'], methods: ['GET'])]
+    public function show(#[MapEntity] User $user): Response
+    {
+        $this->denyAccessUnlessGranted('view', $user);
+
+        return $this->render('Admin/User/show.html.twig', [
+            'user' => $user,
+            'stats' => $this->manager->getUserStats($user),
+        ]);
+    }
+
     #[Route('/admin/users/delete/{id}', name: 'admin_user_delete', methods: ['POST'])]
     public function delete(#[MapEntity] User $user, Request $request): RedirectResponse
     {

--- a/src/Service/UserManager.php
+++ b/src/Service/UserManager.php
@@ -8,11 +8,16 @@ use App\Dto\PaginatedResult;
 use App\Entity\User;
 use App\Enum\MailCrypt;
 use App\Enum\Roles;
+use App\Enum\UserNotificationType;
 use App\Form\Model\UserAdminModel;
 use App\Handler\DeleteHandler;
 use App\Handler\MailCryptKeyHandler;
 use App\Helper\PasswordUpdater;
+use App\Repository\AliasRepository;
+use App\Repository\OpenPgpKeyRepository;
+use App\Repository\UserNotificationRepository;
 use App\Repository\UserRepository;
+use App\Repository\VoucherRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
 final readonly class UserManager
@@ -28,6 +33,10 @@ final readonly class UserManager
         private DomainGuesser $domainGuesser,
         private UserResetService $userResetService,
         private DeleteHandler $deleteHandler,
+        private AliasRepository $aliasRepository,
+        private VoucherRepository $voucherRepository,
+        private OpenPgpKeyRepository $openPgpKeyRepository,
+        private UserNotificationRepository $userNotificationRepository,
     ) {
     }
 
@@ -126,5 +135,19 @@ final readonly class UserManager
     public function delete(User $user): void
     {
         $this->deleteHandler->deleteUser($user);
+    }
+
+    /**
+     * @return array{aliases: int, vouchers: int, vouchers_redeemed: int, openpgp_keys: int, password_compromised: bool}
+     */
+    public function getUserStats(User $user): array
+    {
+        return [
+            'aliases' => count($this->aliasRepository->findByUser($user)),
+            'vouchers' => $this->voucherRepository->countVouchersByUser($user, null),
+            'vouchers_redeemed' => $this->voucherRepository->countVouchersByUser($user, true),
+            'openpgp_keys' => count($this->openPgpKeyRepository->findByUploader($user)),
+            'password_compromised' => $this->userNotificationRepository->hasRecentNotification($user, UserNotificationType::PASSWORD_COMPROMISED, 24 * 365),
+        ];
     }
 }

--- a/templates/Admin/User/form.html.twig
+++ b/templates/Admin/User/form.html.twig
@@ -34,45 +34,11 @@
             </div>
 
             {% if is_edit %}
-                <div class="mb-6 grid grid-cols-2 sm:grid-cols-5 divide-x divide-gray-200 dark:divide-gray-600 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
-                    <div class="text-center px-3">
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.table.created'|trans }}</dt>
-                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ user.creationTime|format_datetime('short', 'short') }}</dd>
-                    </div>
-                    <div class="text-center px-3">
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.form.last_login'|trans }}</dt>
-                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ user.lastLoginTime ? user.lastLoginTime|format_datetime('short', 'short') : '—' }}</dd>
-                    </div>
-                    <div class="text-center px-3">
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.form.recovery_token.label'|trans }}</dt>
-                        <dd class="mt-1">
-                            {% if user.recoverySecretBox %}
-                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'admin.user.form.recovery_token.yes'|trans }}</span>
-                            {% else %}
-                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">{{ 'admin.user.form.recovery_token.no'|trans }}</span>
-                            {% endif %}
-                        </dd>
-                    </div>
-                    <div class="text-center px-3">
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.table.mailcrypt'|trans }}</dt>
-                        <dd class="mt-1">
-                            {% if user.mailCryptEnabled %}
-                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'admin.user.filter.enabled'|trans }}</span>
-                            {% else %}
-                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">{{ 'admin.user.filter.disabled'|trans }}</span>
-                            {% endif %}
-                        </dd>
-                    </div>
-                    <div class="text-center px-3">
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.table.status'|trans }}</dt>
-                        <dd class="mt-1">
-                            {% if user.deleted %}
-                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ 'admin.user.status.deleted'|trans }}</span>
-                            {% else %}
-                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'admin.user.status.active'|trans }}</span>
-                            {% endif %}
-                        </dd>
-                    </div>
+                <div class="mb-6">
+                    <a href="{{ path('admin_user_show', {id: user.id}) }}"
+                       class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'admin.user.show.back_to_user'|trans }}
+                    </a>
                 </div>
             {% endif %}
 

--- a/templates/Admin/User/index.html.twig
+++ b/templates/Admin/User/index.html.twig
@@ -132,6 +132,13 @@
                                 </td>
                                 <td class="px-4 py-3 text-right">
                                     <div class="inline-flex items-center gap-1">
+                                        <a href="{{ path('admin_user_show', {id: user.id}) }}"
+                                           title="{{ 'admin.user.actions.show'|trans }}"
+                                           data-controller="tooltip"
+                                           class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                            {{ ux_icon('heroicons:eye', {class: 'w-4 h-4'}) }}
+                                            <span class="sr-only">{{ 'admin.user.actions.show'|trans }}</span>
+                                        </a>
                                         {% if not user.deleted %}
                                             <a href="{{ path('admin_user_edit', {id: user.id}) }}"
                                                title="{{ 'admin.user.actions.edit'|trans }}"

--- a/templates/Admin/User/show.html.twig
+++ b/templates/Admin/User/show.html.twig
@@ -1,0 +1,198 @@
+{% set current_section = 'users' %}
+{% extends 'Admin/base_admin.html.twig' %}
+{% block title %}{{ setting('app_name') }} - {{ user.email }}{% endblock %}
+{% block admin_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm"
+         data-controller="modal">
+            <div class="p-6 sm:p-8">
+                <div class="flex items-center mb-6">
+                    <div class="w-12 h-12 bg-violet-100 dark:bg-violet-900/50 rounded-xl flex items-center justify-center mr-4">
+                        {{ ux_icon('heroicons:user', {class: 'w-6 h-6 text-violet-600 dark:text-violet-400'}) }}
+                    </div>
+                    <div>
+                        <div class="flex items-center gap-2">
+                            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ user.email }}</h3>
+                            {% if user.deleted %}
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">
+                                    {{ ux_icon('heroicons:x-mark', {class: 'w-3 h-3 mr-1'}) }}{{ 'admin.user.show.deleted'|trans }}
+                                </span>
+                            {% endif %}
+                        </div>
+                        <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'admin.user.show.description'|trans }}</p>
+                    </div>
+                </div>
+
+                <div class="mb-6 flex gap-2">
+                    <a href="{{ path('admin_user_index') }}"
+                       class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'admin.user.show.back'|trans }}
+                    </a>
+                    {% if not user.deleted and is_granted('edit', user) %}
+                        <a href="{{ path('admin_user_edit', {id: user.id}) }}"
+                           class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                            {{ ux_icon('heroicons:pencil-square', {class: 'w-4 h-4 mr-1'}) }} {{ 'admin.user.actions.edit'|trans }}
+                        </a>
+                        <form method="post"
+                              action="{{ path('admin_user_delete', {id: user.id}) }}"
+                              data-action="submit->modal#open"
+                              data-modal-title-param="{{ 'delete.confirm-title'|trans|e('html_attr') }}"
+                              data-modal-message-param="{{ 'admin.user.delete.confirm'|trans({'%email%': user.email})|e('html_attr') }}">
+                            <input type="hidden" name="_token" value="{{ csrf_token('delete_user_' ~ user.id) }}">
+                            <button type="submit"
+                                    class="inline-flex items-center px-3 py-1.5 text-sm text-red-700 dark:text-red-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30">
+                                {{ ux_icon('heroicons:trash', {class: 'w-4 h-4 mr-1'}) }} {{ 'admin.user.actions.delete'|trans }}
+                            </button>
+                        </form>
+                    {% endif %}
+                </div>
+
+                {# Warning banners #}
+                {% if stats.password_compromised %}
+                    <div class="mb-4 p-4 bg-amber-50 dark:bg-amber-950/50 border border-amber-300 dark:border-amber-700 rounded-lg">
+                        <div class="flex items-center">
+                            {{ ux_icon('heroicons:exclamation-triangle', {class: 'w-5 h-5 text-amber-600 dark:text-amber-400 mr-2 shrink-0'}) }}
+                            <p class="text-sm font-medium text-amber-800 dark:text-amber-200">{{ 'admin.user.show.password_compromised'|trans }}</p>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if user.passwordChangeRequired %}
+                    <div class="mb-4 p-4 bg-amber-50 dark:bg-amber-950/50 border border-amber-300 dark:border-amber-700 rounded-lg">
+                        <div class="flex items-center">
+                            {{ ux_icon('heroicons:exclamation-triangle', {class: 'w-5 h-5 text-amber-600 dark:text-amber-400 mr-2 shrink-0'}) }}
+                            <p class="text-sm font-medium text-amber-800 dark:text-amber-200">{{ 'admin.user.show.password_change_required_warning'|trans }}</p>
+                        </div>
+                    </div>
+                {% endif %}
+
+                {# User properties — compact info bar #}
+                <div class="mb-6 grid grid-cols-2 sm:grid-cols-4 divide-x divide-gray-200 dark:divide-gray-600 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.status'|trans }}</dt>
+                        <dd class="mt-1">
+                            {% if user.deleted %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ 'admin.user.status.deleted'|trans }}</span>
+                            {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'admin.user.status.active'|trans }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.twofactor'|trans }}</dt>
+                        <dd class="mt-1">
+                            {% if user.totpAuthenticationEnabled %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'admin.user.show.enabled'|trans }}</span>
+                            {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">{{ 'admin.user.show.disabled'|trans }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.mailcrypt'|trans }}</dt>
+                        <dd class="mt-1">
+                            {% if user.mailCryptEnabled %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'admin.user.show.enabled'|trans }}</span>
+                            {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">{{ 'admin.user.show.disabled'|trans }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.recovery_token'|trans }}</dt>
+                        <dd class="mt-1">
+                            {% if user.recoverySecretBox %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">{{ 'admin.user.show.recovery_token_yes'|trans }}</span>
+                            {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">{{ 'admin.user.show.recovery_token_no'|trans }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
+                </div>
+
+                {# Activity: Last Login, Created, Invited By #}
+                <div class="mb-6 grid grid-cols-1 sm:grid-cols-3 divide-x divide-gray-200 dark:divide-gray-600 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.last_login'|trans }}</dt>
+                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ user.lastLoginTime ? user.lastLoginTime|format_datetime('short', 'short') : 'admin.user.show.never'|trans }}</dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.created'|trans }}</dt>
+                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ user.creationTime ? user.creationTime|format_datetime('short', 'short') : '—' }}</dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.invited_by'|trans }}</dt>
+                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ user.invitationVoucher and user.invitationVoucher.user ? user.invitationVoucher.user.email : '—' }}</dd>
+                    </div>
+                </div>
+
+                {# Configuration: Roles, Quota, SMTP Limits #}
+                <div class="mb-6 grid grid-cols-1 sm:grid-cols-3 divide-x divide-gray-200 dark:divide-gray-600 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.roles'|trans }}</dt>
+                        <dd class="mt-1 flex flex-wrap justify-center gap-1">
+                            {% for role in user.roles %}
+                                {% if role == 'ROLE_SPAM' %}
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200">{{ role }}</span>
+                                {% elseif role == 'ROLE_SUSPICIOUS' %}
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-200">{{ role }}</span>
+                                {% else %}
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300">{{ role }}</span>
+                                {% endif %}
+                            {% endfor %}
+                        </dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.quota'|trans }}</dt>
+                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ user.quota ? user.quota : 'admin.user.show.quota_default'|trans }}</dd>
+                    </div>
+                    <div class="text-center px-3">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ 'admin.user.show.smtp_limits'|trans }}</dt>
+                        <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
+                            {% if user.smtpQuotaLimits and (user.smtpQuotaLimits.per_hour is not null or user.smtpQuotaLimits.per_day is not null) %}
+                                {{ 'admin.user.show.smtp_limits_format'|trans({'%per_hour%': user.smtpQuotaLimits.per_hour, '%per_day%': user.smtpQuotaLimits.per_day}) }}
+                            {% else %}
+                                {{ 'admin.user.show.smtp_limits_default'|trans }}
+                            {% endif %}
+                        </dd>
+                    </div>
+                </div>
+
+                {# Related entities #}
+                <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-4">{{ 'admin.user.show.related_data'|trans }}</h4>
+
+                <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                    {# Aliases #}
+                    <a href="{{ path('admin_alias_index', {search: user.email}) }}"
+                       class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600 hover:border-blue-300 dark:hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors group">
+                        <div class="flex items-center mb-2">
+                            {{ ux_icon('heroicons:at-symbol', {class: 'w-5 h-5 text-green-500 dark:text-green-400 mr-2'}) }}
+                            <span class="text-sm font-medium text-gray-600 dark:text-gray-300 group-hover:text-blue-600 dark:group-hover:text-blue-400">{{ 'admin.user.show.aliases'|trans }}</span>
+                        </div>
+                        <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.aliases }}</p>
+                    </a>
+
+                    {# Vouchers #}
+                    <a href="{{ path('admin_voucher_index', {search: user.email}) }}"
+                       class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600 hover:border-blue-300 dark:hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors group">
+                        <div class="flex items-center mb-2">
+                            {{ ux_icon('heroicons:ticket', {class: 'w-5 h-5 text-orange-500 dark:text-orange-400 mr-2'}) }}
+                            <span class="text-sm font-medium text-gray-600 dark:text-gray-300 group-hover:text-blue-600 dark:group-hover:text-blue-400">{{ 'admin.user.show.vouchers'|trans }}</span>
+                        </div>
+                        <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.vouchers }}</p>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ 'admin.user.show.vouchers_redeemed'|trans({'%count%': stats.vouchers_redeemed}) }}</p>
+                    </a>
+
+                    {# OpenPGP Keys #}
+                    <a href="{{ path('admin_openpgp_key_index', {search: user.email}) }}"
+                       class="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-5 border border-gray-200 dark:border-gray-600 hover:border-blue-300 dark:hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors group">
+                        <div class="flex items-center mb-2">
+                            {{ ux_icon('heroicons:finger-print', {class: 'w-5 h-5 text-rose-500 dark:text-rose-400 mr-2'}) }}
+                            <span class="text-sm font-medium text-gray-600 dark:text-gray-300 group-hover:text-blue-600 dark:group-hover:text-blue-400">{{ 'admin.user.show.openpgp_keys'|trans }}</span>
+                        </div>
+                        <p class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.openpgp_keys }}</p>
+                    </a>
+                </div>
+            </div>
+
+        {% include 'Admin/_confirm_modal.html.twig' %}
+    </div>
+{% endblock %}

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -193,6 +193,9 @@ class FeatureContext extends MinkContext
                     case 'totpSecret':
                         $user->setTotpSecret($value);
                         break;
+                    case 'deleted':
+                        $user->setDeleted((bool) $value);
+                        break;
                     case 'passwordChangeRequired':
                         $user->setPasswordChangeRequired((bool) $value);
                         break;

--- a/tests/Service/UserManagerTest.php
+++ b/tests/Service/UserManagerTest.php
@@ -12,7 +12,11 @@ use App\Form\Model\UserAdminModel;
 use App\Handler\DeleteHandler;
 use App\Handler\MailCryptKeyHandler;
 use App\Helper\PasswordUpdater;
+use App\Repository\AliasRepository;
+use App\Repository\OpenPgpKeyRepository;
+use App\Repository\UserNotificationRepository;
 use App\Repository\UserRepository;
+use App\Repository\VoucherRepository;
 use App\Service\DomainGuesser;
 use App\Service\SettingsService;
 use App\Service\UserManager;
@@ -32,6 +36,10 @@ class UserManagerTest extends TestCase
     private DomainGuesser&Stub $domainGuesser;
     private UserResetService&Stub $userResetService;
     private DeleteHandler&Stub $deleteHandler;
+    private AliasRepository&Stub $aliasRepository;
+    private VoucherRepository&Stub $voucherRepository;
+    private OpenPgpKeyRepository&Stub $openPgpKeyRepository;
+    private UserNotificationRepository&Stub $userNotificationRepository;
     private UserManager $manager;
     private Domain $domain;
 
@@ -45,6 +53,10 @@ class UserManagerTest extends TestCase
         $this->domainGuesser = $this->createStub(DomainGuesser::class);
         $this->userResetService = $this->createStub(UserResetService::class);
         $this->deleteHandler = $this->createStub(DeleteHandler::class);
+        $this->aliasRepository = $this->createStub(AliasRepository::class);
+        $this->voucherRepository = $this->createStub(VoucherRepository::class);
+        $this->openPgpKeyRepository = $this->createStub(OpenPgpKeyRepository::class);
+        $this->userNotificationRepository = $this->createStub(UserNotificationRepository::class);
 
         $this->domain = new Domain();
         $this->domain->setName('example.org');
@@ -61,6 +73,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $this->userResetService,
             $this->deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
     }
 
@@ -130,6 +146,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $this->userResetService,
             $this->deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
 
         $model = new UserAdminModel();
@@ -163,6 +183,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $this->userResetService,
             $this->deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
 
         $model = new UserAdminModel();
@@ -199,6 +223,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $this->userResetService,
             $this->deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
 
         $model = new UserAdminModel();
@@ -223,6 +251,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $this->userResetService,
             $this->deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
 
         $user = new User('user@example.org');
@@ -261,6 +293,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $userResetService,
             $this->deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
 
         $user = new User('user@example.org');
@@ -295,6 +331,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $this->userResetService,
             $this->deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
 
         $user = new User('user@example.org');
@@ -324,6 +364,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $this->userResetService,
             $this->deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
 
         $user = new User('user@example.org');
@@ -359,6 +403,10 @@ class UserManagerTest extends TestCase
             $this->domainGuesser,
             $this->userResetService,
             $deleteHandler,
+            $this->aliasRepository,
+            $this->voucherRepository,
+            $this->openPgpKeyRepository,
+            $this->userNotificationRepository,
         );
 
         $manager->delete($user);


### PR DESCRIPTION
## Summary

Adds a dedicated **show page** for users in the admin panel (`/admin/users/{id}`), providing a structured overview of user details, security status, and related data — similar to the existing domain show page.

### Features

- **Warning banners** for compromised passwords and password change requirements
- **Info bars** organized into Security, Activity, and Configuration sections with details like 2FA status, MailCrypt, recovery token, roles, quota, SMTP limits, last login, creation date, and invited-by reference
- **Related data grid** with counts and links to Aliases, Vouchers, and OpenPGP Keys
- **Delete button** with confirmation modal directly on the show page
- **Show icon** added to the user index page actions column
- **Back-to-user link** replaces the removed info bar on the edit form page
- Full **EN/DE translations** with gender-inclusive German language
- **7 Behat scenarios** covering admin access, domain admin access control, warning banners, and delete-via-modal

<img width="2880" height="1800" alt="Bildschirmfoto am 2026-04-10 um 20 09 14" src="https://github.com/user-attachments/assets/4ac72a76-5cb3-46ec-bb8e-0f04f818ba17" />
<img width="2880" height="1800" alt="Bildschirmfoto am 2026-04-10 um 20 08 56" src="https://github.com/user-attachments/assets/27c6f612-796d-4422-b618-2021aaf9fd79" />


### Technical Details

- `UserManager::getUserStats()` aggregates counts from `AliasRepository`, `VoucherRepository`, `OpenPgpKeyRepository`, and `UserNotificationRepository`
- `DomainVoter` already supports `view` on `User` entities — no new voter needed
- Handles deleted users, null `smtpQuotaLimits`, and domain admin cross-domain 404 behavior

---
<sub>The changes and the PR were generated by OpenCode.</sub>