### PR TITLE
🐛 Fix admin status filter "All" option always reverting to "Active"

### DIFF
--- a/templates/Admin/Alias/index.html.twig
+++ b/templates/Admin/Alias/index.html.twig
@@ -26,7 +26,7 @@
                     placeholder_key: 'admin.alias.search.placeholder',
                     submit_key: 'admin.alias.search.submit',
                     search: search,
-                    extra_params: {deleted: deleted}|filter(v => v and v != 'active'),
+                    extra_params: {deleted: deleted}|filter(v => v and v not in ['active', 'all']),
                 } %}
             </div>
 
@@ -39,7 +39,7 @@
                             class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                         <option value="{{ path('admin_alias_index', {search: search, deleted: 'active'}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'admin.alias.filter.active'|trans }}</option>
                         <option value="{{ path('admin_alias_index', {search: search, deleted: 'deleted'}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'admin.alias.filter.deleted'|trans }}</option>
-                        <option value="{{ path('admin_alias_index', {search: search}|filter(v => v)) }}"{% if deleted == '' %} selected{% endif %}>{{ 'admin.alias.filter.all'|trans }}</option>
+                        <option value="{{ path('admin_alias_index', {search: search, deleted: 'all'}|filter(v => v)) }}"{% if deleted == 'all' %} selected{% endif %}>{{ 'admin.alias.filter.all'|trans }}</option>
                     </select>
                 </div>
             </div>
@@ -117,7 +117,7 @@
                     page_key: 'admin.alias.pagination.page',
                     pagination: pagination,
                     search: search,
-                    extra_params: {deleted: deleted}|filter(v => v and v != 'active'),
+                    extra_params: {deleted: deleted}|filter(v => v and v not in ['active', 'all']),
                 } %}
             {% endif %}
         </div>

--- a/templates/Admin/User/index.html.twig
+++ b/templates/Admin/User/index.html.twig
@@ -26,7 +26,7 @@
                     placeholder_key: 'admin.user.search.placeholder',
                     submit_key: 'admin.user.search.submit',
                     search: search,
-                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v != 'active'),
+                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v not in ['active', 'all']),
                 } %}
             </div>
 
@@ -39,7 +39,7 @@
                             class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                         <option value="{{ path('admin_user_index', {search: search, deleted: 'active', role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'admin.user.filter.active'|trans }}</option>
                         <option value="{{ path('admin_user_index', {search: search, deleted: 'deleted', role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'admin.user.filter.deleted'|trans }}</option>
-                        <option value="{{ path('admin_user_index', {search: search, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == '' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
+                        <option value="{{ path('admin_user_index', {search: search, deleted: 'all', role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == 'all' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
                     </select>
 
                     <label for="role-filter" class="text-sm text-gray-600 dark:text-gray-400 ml-2">{{ 'admin.user.filter.role'|trans }}:</label>
@@ -171,7 +171,7 @@
                     page_key: 'admin.user.pagination.page',
                     pagination: pagination,
                     search: search,
-                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v != 'active'),
+                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v not in ['active', 'all']),
                 } %}
             {% endif %}
         </div>


### PR DESCRIPTION
## Summary

The "All" option in the status filter dropdown on the admin user and alias list pages did not work — selecting it always reverted to "Active", making it impossible to view deleted entries or all entries together.

## Root Cause

The "All" `<option>` omitted the `deleted` query parameter from the URL entirely. Since the controller defaults to `'active'` when the parameter is absent (`$request->query->getString('deleted', 'active')`), selecting "All" was indistinguishable from selecting "Active". Additionally, the `selected` check (`deleted == ''`) could never be true because the controller always provided at least `'active'`.

## Fix

- Send `deleted=all` explicitly in the "All" option URL (instead of omitting the parameter)
- Update the `selected` check from `deleted == ''` to `deleted == 'all'`
- Update `extra_params` filters to treat `'all'` as a default value alongside `'active'` (so it doesn't appear as a redundant query parameter in search/pagination URLs)

No backend changes were needed — the repositories already handle unknown `deleted` values by skipping the filter (only `'active'` and `'deleted'` add a WHERE clause).

---
<sub>The changes and the PR were generated by OpenCode.</sub>