### PR TITLE
✨ Add domain filter to all admin entity lists

### DIFF
--- a/assets/controllers/ajax_autocomplete_controller.ts
+++ b/assets/controllers/ajax_autocomplete_controller.ts
@@ -78,6 +78,7 @@ export default class extends Controller {
   private input!: HTMLInputElement;
   private dropdown!: HTMLUListElement;
   private tagContainer!: HTMLDivElement;
+  private clearButton: HTMLButtonElement | null = null;
   private isOpen = false;
   private activeIndex = -1;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -118,7 +119,7 @@ export default class extends Controller {
     this.input.type = "text";
     this.input.autocomplete = "off";
     this.input.className = this.compactValue
-      ? "w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg " +
+      ? "w-full h-9 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg " +
         "focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 " +
         "transition-colors bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 " +
         "placeholder-gray-400 dark:placeholder-gray-500"
@@ -161,6 +162,34 @@ export default class extends Controller {
     this.dropdown.setAttribute("role", "listbox");
     this.wrapper.appendChild(this.dropdown);
 
+    // Filter mode: render inline clear button (hidden until a value is selected)
+    if (this.filterParamValue) {
+      this.clearButton = document.createElement("button");
+      this.clearButton.type = "button";
+      this.clearButton.className =
+        "absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded " +
+        "text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 " +
+        "transition-colors cursor-pointer hidden";
+      this.clearButton.setAttribute("aria-label", "Clear filter");
+      this.clearButton.innerHTML =
+        '<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+        '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>' +
+        "</svg>";
+      this.clearButton.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        const url = new URL(globalThis.location.href);
+        url.searchParams.delete(this.filterParamValue);
+        url.searchParams.delete("page");
+        globalThis.location.href = url.toString();
+      });
+      this.wrapper.appendChild(this.clearButton);
+
+      // Show immediately if a value is already selected
+      if (this.hiddenTarget.value && this.hiddenTarget.value !== "0") {
+        this.showClearButton();
+      }
+    }
+
     // Insert wrapper after hidden input
     this.hiddenTarget.parentNode!.insertBefore(this.wrapper, this.hiddenTarget.nextSibling);
   }
@@ -187,6 +216,7 @@ export default class extends Controller {
     if (!this.multipleValue && this.selectedLabel && this.input.value !== this.selectedLabel) {
       this.hiddenTarget.value = "";
       this.selectedLabel = "";
+      this.hideClearButton();
     }
 
     if (query.length < this.minCharsValue) {
@@ -210,7 +240,7 @@ export default class extends Controller {
     this.abortController = new AbortController();
 
     try {
-      const url = new URL(this.urlValue, window.location.origin);
+      const url = new URL(this.urlValue, globalThis.location.origin);
       url.searchParams.set("q", query);
 
       const response = await fetch(url.toString(), {
@@ -353,11 +383,11 @@ export default class extends Controller {
 
     // Filter mode: navigate instead of storing
     if (this.filterParamValue) {
-      const url = new URL(window.location.href);
+      const url = new URL(globalThis.location.href);
       url.searchParams.set(this.filterParamValue, String(result.id));
       // Reset to page 1 when changing filter
       url.searchParams.delete("page");
-      window.location.href = url.toString();
+      globalThis.location.href = url.toString();
       return;
     }
 
@@ -427,6 +457,18 @@ export default class extends Controller {
     if (this.selectedItems.length > 0) {
       this.removeTag(this.selectedItems[this.selectedItems.length - 1].id);
     }
+  }
+
+  private showClearButton(): void {
+    if (!this.clearButton) return;
+    this.clearButton.classList.remove("hidden");
+    this.input.classList.add("pr-8");
+  }
+
+  private hideClearButton(): void {
+    if (!this.clearButton) return;
+    this.clearButton.classList.add("hidden");
+    this.input.classList.remove("pr-8");
   }
 
   private _onOutsideClick(event: Event): void {

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -556,6 +556,8 @@ admin:
       button: Inaktive entfernen
     unknown_task: Unbekannte Wartungsaufgabe.
     dispatched: Wartungsaufgabe erfolgreich gestartet.
+  filter:
+    domain: Domain
   table:
     id: ID
     actions: Aktionen
@@ -828,12 +830,10 @@ admin:
       empty-title: Keine Einladungscodes
       empty-description: Es sind noch keine Einladungscodes vorhanden. Erstelle einen Einladungscode, um neue Benutzer einzuladen.
     filter:
-      domain: Domain
       status: Status
       all: Alle
       redeemed: Eingelöst
       unredeemed: Nicht eingelöst
-      clear: Filter zurücksetzen
     status:
       redeemed: Eingelöst
       unredeemed: Nicht eingelöst

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -556,6 +556,8 @@ admin:
   page_title: Admin
   page_subtitle: Administration and configuration
   coming-soon: Coming Soon
+  filter:
+    domain: Domain
   table:
     id: ID
     actions: Actions
@@ -830,12 +832,10 @@ admin:
       empty-title: No invite codes
       empty-description: There are no invite codes yet. Create an invite code to invite new users.
     filter:
-      domain: Domain
       status: Status
       all: All
       redeemed: Redeemed
       unredeemed: Unredeemed
-      clear: Clear filter
     status:
       redeemed: Redeemed
       unredeemed: Unredeemed

--- a/src/Controller/Admin/AliasController.php
+++ b/src/Controller/Admin/AliasController.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Entity\Alias;
+use App\Entity\Domain;
 use App\Enum\Roles;
 use App\Exception\ValidationException;
 use App\Form\AliasAdminType;
 use App\Form\Model\AliasAdminModel;
 use App\Service\AliasManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityNotFoundException;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -22,6 +24,7 @@ final class AliasController extends AbstractController
 {
     public function __construct(
         private readonly AliasManager $manager,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 
@@ -30,11 +33,23 @@ final class AliasController extends AbstractController
     {
         $search = $request->query->getString('search', '');
         $deleted = $request->query->getString('deleted', 'active');
+        $domainId = $request->query->getInt('domain', 0);
+
+        $domain = null;
+        $selectedDomainName = '';
+        if ($domainId > 0) {
+            $domain = $this->em->getRepository(Domain::class)->find($domainId);
+            if ($domain instanceof Domain) {
+                $selectedDomainName = $domain->getName() ?? '';
+            }
+        }
 
         return $this->render('Admin/Alias/index.html.twig', [
-            'pagination' => $this->manager->findPaginated($request->query->getInt('page', 1), $search, $deleted),
+            'pagination' => $this->manager->findPaginated($request->query->getInt('page', 1), $search, $domain, $deleted),
             'search' => $search,
             'deleted' => $deleted,
+            'selectedDomain' => $domainId,
+            'selectedDomainName' => $selectedDomainName,
         ]);
     }
 

--- a/src/Controller/Admin/OpenPgpKeyController.php
+++ b/src/Controller/Admin/OpenPgpKeyController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Controller\Admin;
 
+use App\Entity\Domain;
 use App\Service\OpenPgpKeyManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,6 +16,7 @@ final class OpenPgpKeyController extends AbstractController
 {
     public function __construct(
         private readonly OpenPgpKeyManager $manager,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 
@@ -21,10 +24,22 @@ final class OpenPgpKeyController extends AbstractController
     public function index(Request $request): Response
     {
         $search = $request->query->getString('search', '');
+        $domainId = $request->query->getInt('domain', 0);
+
+        $domain = null;
+        $selectedDomainName = '';
+        if ($domainId > 0) {
+            $domain = $this->em->getRepository(Domain::class)->find($domainId);
+            if ($domain instanceof Domain) {
+                $selectedDomainName = $domain->getName() ?? '';
+            }
+        }
 
         return $this->render('Admin/OpenPgpKey/index.html.twig', [
-            'pagination' => $this->manager->findPaginated($request->query->getInt('page', 1), $search),
+            'pagination' => $this->manager->findPaginated($request->query->getInt('page', 1), $search, $domain),
             'search' => $search,
+            'selectedDomain' => $domainId,
+            'selectedDomainName' => $selectedDomainName,
         ]);
     }
 }

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Controller\Admin;
 
+use App\Entity\Domain;
 use App\Entity\User;
 use App\Enum\Roles;
 use App\Form\Model\UserAdminModel;
 use App\Form\UserAdminType;
 use App\Service\UserManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -20,6 +22,7 @@ final class UserController extends AbstractController
 {
     public function __construct(
         private readonly UserManager $manager,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 
@@ -31,15 +34,27 @@ final class UserController extends AbstractController
         $role = $request->query->getString('role', '');
         $mailCrypt = $request->query->getString('mailCrypt', '');
         $twofactor = $request->query->getString('twofactor', '');
+        $domainId = $request->query->getInt('domain', 0);
+
+        $domain = null;
+        $selectedDomainName = '';
+        if ($domainId > 0) {
+            $domain = $this->em->getRepository(Domain::class)->find($domainId);
+            if ($domain instanceof Domain) {
+                $selectedDomainName = $domain->getName() ?? '';
+            }
+        }
 
         return $this->render('Admin/User/index.html.twig', [
-            'pagination' => $this->manager->findPaginated($request->query->getInt('page', 1), $search, $deleted, $role, $mailCrypt, $twofactor),
+            'pagination' => $this->manager->findPaginated($request->query->getInt('page', 1), $search, $domain, $deleted, $role, $mailCrypt, $twofactor),
             'search' => $search,
             'deleted' => $deleted,
             'role' => $role,
             'mailCrypt' => $mailCrypt,
             'twofactor' => $twofactor,
             'all_roles' => Roles::getAll(),
+            'selectedDomain' => $domainId,
+            'selectedDomainName' => $selectedDomainName,
         ]);
     }
 

--- a/src/Repository/OpenPgpKeyRepository.php
+++ b/src/Repository/OpenPgpKeyRepository.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Domain;
 use App\Entity\OpenPgpKey;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Override;
 
@@ -56,15 +58,7 @@ final class OpenPgpKeyRepository extends ServiceEntityRepository implements Sear
     #[Override]
     public function countBySearch(string $search = ''): int
     {
-        $qb = $this->createQueryBuilder('k')
-            ->select('COUNT(k.id)');
-
-        if ('' !== $search) {
-            $qb->andWhere('k.email LIKE :search')
-                ->setParameter('search', '%'.$search.'%');
-        }
-
-        return (int) $qb->getQuery()->getSingleScalarResult();
+        return $this->countByFilters($search);
     }
 
     /**
@@ -73,16 +67,44 @@ final class OpenPgpKeyRepository extends ServiceEntityRepository implements Sear
     #[Override]
     public function findPaginatedBySearch(string $search, int $limit, int $offset): array
     {
+        return $this->findPaginatedByFilters($search, null, $limit, $offset);
+    }
+
+    public function countByFilters(string $search = '', ?Domain $domain = null): int
+    {
+        $qb = $this->createQueryBuilder('k')
+            ->select('COUNT(k.id)');
+
+        $this->applyFilters($qb, $search, $domain);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @return array<OpenPgpKey>
+     */
+    public function findPaginatedByFilters(string $search = '', ?Domain $domain = null, int $limit = 20, int $offset = 0): array
+    {
         $qb = $this->createQueryBuilder('k')
             ->orderBy('k.id', 'DESC')
             ->setMaxResults($limit)
             ->setFirstResult($offset);
 
+        $this->applyFilters($qb, $search, $domain);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    private function applyFilters(QueryBuilder $qb, string $search, ?Domain $domain): void
+    {
         if ('' !== $search) {
             $qb->andWhere('k.email LIKE :search')
                 ->setParameter('search', '%'.$search.'%');
         }
 
-        return $qb->getQuery()->getResult();
+        if (null !== $domain) {
+            $qb->andWhere('k.domain = :domain')
+                ->setParameter('domain', $domain);
+        }
     }
 }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -241,12 +241,12 @@ final class UserRepository extends ServiceEntityRepository implements PasswordUp
             ->getSingleScalarResult();
     }
 
-    public function countByFilters(string $search = '', string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = ''): int
+    public function countByFilters(string $search = '', ?Domain $domain = null, string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = ''): int
     {
         $qb = $this->createQueryBuilder('u')
             ->select('COUNT(u.id)');
 
-        $this->applyFilters($qb, $search, $deleted, $role, $mailCrypt, $twofactor);
+        $this->applyFilters($qb, $search, $domain, $deleted, $role, $mailCrypt, $twofactor);
 
         return (int) $qb->getQuery()->getSingleScalarResult();
     }
@@ -254,23 +254,28 @@ final class UserRepository extends ServiceEntityRepository implements PasswordUp
     /**
      * @return User[]
      */
-    public function findPaginatedByFilters(string $search = '', string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = '', int $limit = 20, int $offset = 0): array
+    public function findPaginatedByFilters(string $search = '', ?Domain $domain = null, string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = '', int $limit = 20, int $offset = 0): array
     {
         $qb = $this->createQueryBuilder('u')
             ->orderBy('u.id', 'DESC')
             ->setMaxResults($limit)
             ->setFirstResult($offset);
 
-        $this->applyFilters($qb, $search, $deleted, $role, $mailCrypt, $twofactor);
+        $this->applyFilters($qb, $search, $domain, $deleted, $role, $mailCrypt, $twofactor);
 
         return $qb->getQuery()->getResult();
     }
 
-    private function applyFilters(QueryBuilder $qb, string $search, string $deleted, string $role, string $mailCrypt, string $twofactor): void
+    private function applyFilters(QueryBuilder $qb, string $search, ?Domain $domain, string $deleted, string $role, string $mailCrypt, string $twofactor): void
     {
         if ('' !== $search) {
             $qb->andWhere('u.email LIKE :search')
                 ->setParameter('search', '%'.$search.'%');
+        }
+
+        if (null !== $domain) {
+            $qb->andWhere('u.domain = :domain')
+                ->setParameter('domain', $domain);
         }
 
         if ('active' === $deleted) {

--- a/src/Service/AliasManager.php
+++ b/src/Service/AliasManager.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Dto\PaginatedResult;
 use App\Entity\Alias;
+use App\Entity\Domain;
 use App\Entity\User;
 use App\Enum\Roles;
 use App\Exception\ValidationException;
@@ -35,13 +36,13 @@ final readonly class AliasManager
      *
      * @return PaginatedResult<Alias>
      */
-    public function findPaginated(int $page = 1, string $search = '', string $deleted = 'active'): PaginatedResult
+    public function findPaginated(int $page = 1, string $search = '', ?Domain $domain = null, string $deleted = 'active'): PaginatedResult
     {
         $page = max(1, $page);
         $offset = ($page - 1) * self::PAGE_SIZE;
-        $total = $this->repository->countByFilters($search, null, $deleted);
+        $total = $this->repository->countByFilters($search, $domain, $deleted);
         $totalPages = max(1, (int) ceil($total / self::PAGE_SIZE));
-        $items = $this->repository->findPaginatedByFilters($search, null, $deleted, self::PAGE_SIZE, $offset);
+        $items = $this->repository->findPaginatedByFilters($search, $domain, $deleted, self::PAGE_SIZE, $offset);
 
         return new PaginatedResult($items, $page, $totalPages, $total);
     }

--- a/src/Service/OpenPgpKeyManager.php
+++ b/src/Service/OpenPgpKeyManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Dto\PaginatedResult;
+use App\Entity\Domain;
 use App\Entity\OpenPgpKey;
 use App\Entity\User;
 use App\Exception\MultipleGpgKeysForUserException;
@@ -30,9 +31,15 @@ final readonly class OpenPgpKeyManager
     /**
      * @return PaginatedResult<OpenPgpKey>
      */
-    public function findPaginated(int $page = 1, string $search = ''): PaginatedResult
+    public function findPaginated(int $page = 1, string $search = '', ?Domain $domain = null): PaginatedResult
     {
-        return PaginatedResult::fromSearchableRepository($this->repository, $page, self::PAGE_SIZE, $search);
+        $page = max(1, $page);
+        $offset = ($page - 1) * self::PAGE_SIZE;
+        $total = $this->repository->countByFilters($search, $domain);
+        $totalPages = max(1, (int) ceil($total / self::PAGE_SIZE));
+        $items = $this->repository->findPaginatedByFilters($search, $domain, self::PAGE_SIZE, $offset);
+
+        return new PaginatedResult($items, $page, $totalPages, $total);
     }
 
     /**

--- a/src/Service/UserManager.php
+++ b/src/Service/UserManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Dto\PaginatedResult;
+use App\Entity\Domain;
 use App\Entity\User;
 use App\Enum\MailCrypt;
 use App\Enum\Roles;
@@ -45,13 +46,13 @@ final readonly class UserManager
      *
      * @return PaginatedResult<User>
      */
-    public function findPaginated(int $page = 1, string $search = '', string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = ''): PaginatedResult
+    public function findPaginated(int $page = 1, string $search = '', ?Domain $domain = null, string $deleted = 'active', string $role = '', string $mailCrypt = '', string $twofactor = ''): PaginatedResult
     {
         $page = max(1, $page);
         $offset = ($page - 1) * self::PAGE_SIZE;
-        $total = $this->repository->countByFilters($search, $deleted, $role, $mailCrypt, $twofactor);
+        $total = $this->repository->countByFilters($search, $domain, $deleted, $role, $mailCrypt, $twofactor);
         $totalPages = max(1, (int) ceil($total / self::PAGE_SIZE));
-        $items = $this->repository->findPaginatedByFilters($search, $deleted, $role, $mailCrypt, $twofactor, self::PAGE_SIZE, $offset);
+        $items = $this->repository->findPaginatedByFilters($search, $domain, $deleted, $role, $mailCrypt, $twofactor, self::PAGE_SIZE, $offset);
 
         return new PaginatedResult($items, $page, $totalPages, $total);
     }

--- a/templates/Admin/Alias/index.html.twig
+++ b/templates/Admin/Alias/index.html.twig
@@ -26,20 +26,25 @@
                     placeholder_key: 'admin.alias.search.placeholder',
                     submit_key: 'admin.alias.search.submit',
                     search: search,
-                    extra_params: {deleted: deleted}|filter(v => v and v not in ['active', 'all']),
+                    extra_params: {deleted: deleted, domain: selectedDomain}|filter(v => v and v not in ['active', 'all']),
                 } %}
             </div>
 
-            <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
-                <div class="flex items-center gap-2">
-                    <label for="deleted-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'admin.alias.filter.status'|trans }}:</label>
+            <div class="mb-4 flex flex-wrap items-end gap-4">
+                {% include 'Admin/_domain_filter.html.twig' with {
+                    selectedDomain: selectedDomain,
+                    selectedDomainName: selectedDomainName,
+                } %}
+
+                <div>
+                    <label for="deleted-filter" class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-0.5">{{ 'admin.alias.filter.status'|trans }}</label>
                     <select id="deleted-filter"
                             data-controller="navigate"
                             data-action="change->navigate#go"
-                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                        <option value="{{ path('admin_alias_index', {search: search, deleted: 'active'}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'admin.alias.filter.active'|trans }}</option>
-                        <option value="{{ path('admin_alias_index', {search: search, deleted: 'deleted'}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'admin.alias.filter.deleted'|trans }}</option>
-                        <option value="{{ path('admin_alias_index', {search: search, deleted: 'all'}|filter(v => v)) }}"{% if deleted == 'all' %} selected{% endif %}>{{ 'admin.alias.filter.all'|trans }}</option>
+                            class="h-9 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('admin_alias_index', {search: search, deleted: 'active', domain: selectedDomain}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'admin.alias.filter.active'|trans }}</option>
+                        <option value="{{ path('admin_alias_index', {search: search, deleted: 'deleted', domain: selectedDomain}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'admin.alias.filter.deleted'|trans }}</option>
+                        <option value="{{ path('admin_alias_index', {search: search, deleted: 'all', domain: selectedDomain}|filter(v => v)) }}"{% if deleted == 'all' %} selected{% endif %}>{{ 'admin.alias.filter.all'|trans }}</option>
                     </select>
                 </div>
             </div>
@@ -117,7 +122,7 @@
                     page_key: 'admin.alias.pagination.page',
                     pagination: pagination,
                     search: search,
-                    extra_params: {deleted: deleted}|filter(v => v and v not in ['active', 'all']),
+                    extra_params: {deleted: deleted, domain: selectedDomain}|filter(v => v and v not in ['active', 'all']),
                 } %}
             {% endif %}
         </div>

--- a/templates/Admin/OpenPgpKey/index.html.twig
+++ b/templates/Admin/OpenPgpKey/index.html.twig
@@ -11,14 +11,20 @@
                 description_key: 'admin.openpgp-key.description',
             } %}
 
-            <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                <div></div>
+            <div class="mb-6 flex flex-wrap items-end justify-between gap-4">
+                <div class="flex flex-wrap items-end gap-4">
+                    {% include 'Admin/_domain_filter.html.twig' with {
+                        selectedDomain: selectedDomain,
+                        selectedDomainName: selectedDomainName,
+                    } %}
+                </div>
 
                 {% include 'Admin/_search_form.html.twig' with {
                     index_route: 'admin_openpgp_key_index',
                     placeholder_key: 'admin.openpgp-key.search.placeholder',
                     submit_key: 'admin.openpgp-key.search.submit',
                     search: search,
+                    extra_params: {domain: selectedDomain}|filter(v => v),
                 } %}
             </div>
 
@@ -65,6 +71,7 @@
                     page_key: 'admin.openpgp-key.pagination.page',
                     pagination: pagination,
                     search: search,
+                    extra_params: {domain: selectedDomain}|filter(v => v),
                 } %}
             {% endif %}
         </div>

--- a/templates/Admin/User/index.html.twig
+++ b/templates/Admin/User/index.html.twig
@@ -26,51 +26,62 @@
                     placeholder_key: 'admin.user.search.placeholder',
                     submit_key: 'admin.user.search.submit',
                     search: search,
-                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v not in ['active', 'all']),
+                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor, domain: selectedDomain}|filter(v => v and v not in ['active', 'all']),
                 } %}
             </div>
 
-            <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
-                <div class="flex flex-wrap items-center gap-2">
-                    <label for="deleted-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'admin.user.filter.status'|trans }}:</label>
+            <div class="mb-4 flex flex-wrap items-end gap-4">
+                {% include 'Admin/_domain_filter.html.twig' with {
+                    selectedDomain: selectedDomain,
+                    selectedDomainName: selectedDomainName,
+                } %}
+
+                <div>
+                    <label for="deleted-filter" class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-0.5">{{ 'admin.user.filter.status'|trans }}</label>
                     <select id="deleted-filter"
                             data-controller="navigate"
                             data-action="change->navigate#go"
-                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                        <option value="{{ path('admin_user_index', {search: search, deleted: 'active', role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'admin.user.filter.active'|trans }}</option>
-                        <option value="{{ path('admin_user_index', {search: search, deleted: 'deleted', role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'admin.user.filter.deleted'|trans }}</option>
-                        <option value="{{ path('admin_user_index', {search: search, deleted: 'all', role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v)) }}"{% if deleted == 'all' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
+                            class="h-9 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('admin_user_index', {search: search, deleted: 'active', role: role, mailCrypt: mailCrypt, twofactor: twofactor, domain: selectedDomain}|filter(v => v)) }}"{% if deleted == 'active' %} selected{% endif %}>{{ 'admin.user.filter.active'|trans }}</option>
+                        <option value="{{ path('admin_user_index', {search: search, deleted: 'deleted', role: role, mailCrypt: mailCrypt, twofactor: twofactor, domain: selectedDomain}|filter(v => v)) }}"{% if deleted == 'deleted' %} selected{% endif %}>{{ 'admin.user.filter.deleted'|trans }}</option>
+                        <option value="{{ path('admin_user_index', {search: search, deleted: 'all', role: role, mailCrypt: mailCrypt, twofactor: twofactor, domain: selectedDomain}|filter(v => v)) }}"{% if deleted == 'all' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
                     </select>
+                </div>
 
-                    <label for="role-filter" class="text-sm text-gray-600 dark:text-gray-400 ml-2">{{ 'admin.user.filter.role'|trans }}:</label>
+                <div>
+                    <label for="role-filter" class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-0.5">{{ 'admin.user.filter.role'|trans }}</label>
                     <select id="role-filter"
                             data-controller="navigate"
                             data-action="change->navigate#go"
-                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if role == '' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
+                            class="h-9 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, mailCrypt: mailCrypt, twofactor: twofactor, domain: selectedDomain}|filter(v => v and v != 'active')) }}"{% if role == '' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
                         {% for role_key, role_value in all_roles %}
-                            <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role_value, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if role == role_value %} selected{% endif %}>{{ role_value }}</option>
+                            <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role_value, mailCrypt: mailCrypt, twofactor: twofactor, domain: selectedDomain}|filter(v => v and v != 'active')) }}"{% if role == role_value %} selected{% endif %}>{{ role_value }}</option>
                         {% endfor %}
                     </select>
+                </div>
 
-                    <label for="mailcrypt-filter" class="text-sm text-gray-600 dark:text-gray-400 ml-2">{{ 'admin.user.filter.mailcrypt'|trans }}:</label>
+                <div>
+                    <label for="mailcrypt-filter" class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-0.5">{{ 'admin.user.filter.mailcrypt'|trans }}</label>
                     <select id="mailcrypt-filter"
                             data-controller="navigate"
                             data-action="change->navigate#go"
-                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if mailCrypt == '' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
-                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: 'enabled', twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if mailCrypt == 'enabled' %} selected{% endif %}>{{ 'admin.user.filter.enabled'|trans }}</option>
-                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: 'disabled', twofactor: twofactor}|filter(v => v and v != 'active')) }}"{% if mailCrypt == 'disabled' %} selected{% endif %}>{{ 'admin.user.filter.disabled'|trans }}</option>
+                            class="h-9 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, twofactor: twofactor, domain: selectedDomain}|filter(v => v and v != 'active')) }}"{% if mailCrypt == '' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
+                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: 'enabled', twofactor: twofactor, domain: selectedDomain}|filter(v => v and v != 'active')) }}"{% if mailCrypt == 'enabled' %} selected{% endif %}>{{ 'admin.user.filter.enabled'|trans }}</option>
+                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: 'disabled', twofactor: twofactor, domain: selectedDomain}|filter(v => v and v != 'active')) }}"{% if mailCrypt == 'disabled' %} selected{% endif %}>{{ 'admin.user.filter.disabled'|trans }}</option>
                     </select>
+                </div>
 
-                    <label for="twofactor-filter" class="text-sm text-gray-600 dark:text-gray-400 ml-2">{{ 'admin.user.filter.twofactor'|trans }}:</label>
+                <div>
+                    <label for="twofactor-filter" class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-0.5">{{ 'admin.user.filter.twofactor'|trans }}</label>
                     <select id="twofactor-filter"
                             data-controller="navigate"
                             data-action="change->navigate#go"
-                            class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt}|filter(v => v and v != 'active')) }}"{% if twofactor == '' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
-                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: 'enabled'}|filter(v => v and v != 'active')) }}"{% if twofactor == 'enabled' %} selected{% endif %}>{{ 'admin.user.filter.enabled'|trans }}</option>
-                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: 'disabled'}|filter(v => v and v != 'active')) }}"{% if twofactor == 'disabled' %} selected{% endif %}>{{ 'admin.user.filter.disabled'|trans }}</option>
+                            class="h-9 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt, domain: selectedDomain}|filter(v => v and v != 'active')) }}"{% if twofactor == '' %} selected{% endif %}>{{ 'admin.user.filter.all'|trans }}</option>
+                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: 'enabled', domain: selectedDomain}|filter(v => v and v != 'active')) }}"{% if twofactor == 'enabled' %} selected{% endif %}>{{ 'admin.user.filter.enabled'|trans }}</option>
+                        <option value="{{ path('admin_user_index', {search: search, deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: 'disabled', domain: selectedDomain}|filter(v => v and v != 'active')) }}"{% if twofactor == 'disabled' %} selected{% endif %}>{{ 'admin.user.filter.disabled'|trans }}</option>
                     </select>
                 </div>
             </div>
@@ -178,7 +189,7 @@
                     page_key: 'admin.user.pagination.page',
                     pagination: pagination,
                     search: search,
-                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor}|filter(v => v and v not in ['active', 'all']),
+                    extra_params: {deleted: deleted, role: role, mailCrypt: mailCrypt, twofactor: twofactor, domain: selectedDomain}|filter(v => v and v not in ['active', 'all']),
                 } %}
             {% endif %}
         </div>

--- a/templates/Admin/Voucher/index.html.twig
+++ b/templates/Admin/Voucher/index.html.twig
@@ -44,41 +44,22 @@
                 } %}
             </div>
 
-            <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
-                <div class="flex flex-wrap items-center gap-4">
-                    <div class="flex items-center gap-2">
-                        <label class="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ 'admin.voucher.filter.domain'|trans }}:</label>
-                        <div class="min-w-[200px]"
-                             data-controller="ajax-autocomplete"
-                             data-ajax-autocomplete-url-value="{{ path('admin_domain_search') }}"
-                             data-ajax-autocomplete-label-field-value="name"
-                             data-ajax-autocomplete-min-chars-value="0"
-                             data-ajax-autocomplete-filter-param-value="domain"
-                             data-ajax-autocomplete-compact-value="true">
-                            <input type="hidden"
-                                   data-ajax-autocomplete-target="hidden"
-                                   value="{{ selectedDomain }}"
-                                   data-label="{{ selectedDomainName }}">
-                        </div>
-                        {% if selectedDomain %}
-                            <a href="{{ path('admin_voucher_index', {search: search, status: status}|filter(v => v)) }}"
-                               class="inline-flex items-center px-2 py-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-                               title="{{ 'admin.voucher.filter.clear'|trans }}">
-                                {{ ux_icon('heroicons:x-mark', {class: 'w-3 h-3'}) }}
-                            </a>
-                        {% endif %}
-                    </div>
-                    <div class="flex items-center gap-2">
-                        <label for="status-filter" class="text-sm text-gray-600 dark:text-gray-400">{{ 'admin.voucher.filter.status'|trans }}:</label>
-                        <select id="status-filter"
-                                data-controller="navigate"
-                                data-action="change->navigate#go"
-                                class="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
-                            <option value="{{ path('admin_voucher_index', {search: search, domain: selectedDomain}|filter(v => v)) }}"{% if status == '' %} selected{% endif %}>{{ 'admin.voucher.filter.all'|trans }}</option>
-                            <option value="{{ path('admin_voucher_index', {search: search, domain: selectedDomain, status: 'redeemed'}|filter(v => v)) }}"{% if status == 'redeemed' %} selected{% endif %}>{{ 'admin.voucher.filter.redeemed'|trans }}</option>
-                            <option value="{{ path('admin_voucher_index', {search: search, domain: selectedDomain, status: 'unredeemed'}|filter(v => v)) }}"{% if status == 'unredeemed' %} selected{% endif %}>{{ 'admin.voucher.filter.unredeemed'|trans }}</option>
-                        </select>
-                    </div>
+            <div class="mb-4 flex flex-wrap items-end gap-4">
+                {% include 'Admin/_domain_filter.html.twig' with {
+                    selectedDomain: selectedDomain,
+                    selectedDomainName: selectedDomainName,
+                } %}
+
+                <div>
+                    <label for="status-filter" class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-0.5">{{ 'admin.voucher.filter.status'|trans }}</label>
+                    <select id="status-filter"
+                            data-controller="navigate"
+                            data-action="change->navigate#go"
+                            class="h-9 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
+                        <option value="{{ path('admin_voucher_index', {search: search, domain: selectedDomain}|filter(v => v)) }}"{% if status == '' %} selected{% endif %}>{{ 'admin.voucher.filter.all'|trans }}</option>
+                        <option value="{{ path('admin_voucher_index', {search: search, domain: selectedDomain, status: 'redeemed'}|filter(v => v)) }}"{% if status == 'redeemed' %} selected{% endif %}>{{ 'admin.voucher.filter.redeemed'|trans }}</option>
+                        <option value="{{ path('admin_voucher_index', {search: search, domain: selectedDomain, status: 'unredeemed'}|filter(v => v)) }}"{% if status == 'unredeemed' %} selected{% endif %}>{{ 'admin.voucher.filter.unredeemed'|trans }}</option>
+                    </select>
                 </div>
             </div>
 

--- a/templates/Admin/_domain_filter.html.twig
+++ b/templates/Admin/_domain_filter.html.twig
@@ -1,0 +1,25 @@
+{# Domain autocomplete filter — only shown to full admins (domain admins are automatically scoped).
+   The clear button is rendered inline by the ajax-autocomplete Stimulus controller
+   (filter mode removes the URL parameter automatically on clear).
+
+   Parameters:
+     - selectedDomain (int): Selected domain ID (0 = none)
+     - selectedDomainName (string): Display name of selected domain
+#}
+{% if is_granted('ROLE_ADMIN') %}
+    <div>
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-0.5">{{ 'admin.filter.domain'|trans }}</label>
+        <div class="min-w-[200px]"
+             data-controller="ajax-autocomplete"
+             data-ajax-autocomplete-url-value="{{ path('admin_domain_search') }}"
+             data-ajax-autocomplete-label-field-value="name"
+             data-ajax-autocomplete-min-chars-value="0"
+             data-ajax-autocomplete-filter-param-value="domain"
+             data-ajax-autocomplete-compact-value="true">
+            <input type="hidden"
+                   data-ajax-autocomplete-target="hidden"
+                   value="{{ selectedDomain }}"
+                   data-label="{{ selectedDomainName }}">
+        </div>
+    </div>
+{% endif %}

--- a/tests/Service/AliasManagerTest.php
+++ b/tests/Service/AliasManagerTest.php
@@ -69,7 +69,7 @@ class AliasManagerTest extends TestCase
             new Alias(),
         ]);
 
-        $result = $this->manager->findPaginated(1, '', 'active');
+        $result = $this->manager->findPaginated(1, '', null, 'active');
 
         self::assertInstanceOf(PaginatedResult::class, $result);
         self::assertSame(1, $result->page);
@@ -85,7 +85,7 @@ class AliasManagerTest extends TestCase
             new Alias(),
         ]);
 
-        $result = $this->manager->findPaginated(1, 'test', 'deleted');
+        $result = $this->manager->findPaginated(1, 'test', null, 'deleted');
 
         self::assertSame(1, $result->page);
         self::assertSame(1, $result->totalPages);

--- a/tests/Service/OpenPgpKeyManagerTest.php
+++ b/tests/Service/OpenPgpKeyManagerTest.php
@@ -62,12 +62,12 @@ class OpenPgpKeyManagerTest extends TestCase
     {
         $repo = $this->createMock(OpenPgpKeyRepository::class);
         $repo->expects($this->once())
-            ->method('countBySearch')
-            ->with('')
+            ->method('countByFilters')
+            ->with('', null)
             ->willReturn(2);
         $repo->expects($this->once())
-            ->method('findPaginatedBySearch')
-            ->with('', 20, 0)
+            ->method('findPaginatedByFilters')
+            ->with('', null, 20, 0)
             ->willReturn(['item1', 'item2']);
 
         $em = $this->createStub(EntityManagerInterface::class);
@@ -87,12 +87,12 @@ class OpenPgpKeyManagerTest extends TestCase
     {
         $repo = $this->createMock(OpenPgpKeyRepository::class);
         $repo->expects($this->once())
-            ->method('countBySearch')
-            ->with('user@example.org')
+            ->method('countByFilters')
+            ->with('user@example.org', null)
             ->willReturn(1);
         $repo->expects($this->once())
-            ->method('findPaginatedBySearch')
-            ->with('user@example.org', 20, 0)
+            ->method('findPaginatedByFilters')
+            ->with('user@example.org', null, 20, 0)
             ->willReturn(['item1']);
 
         $em = $this->createStub(EntityManagerInterface::class);
@@ -109,12 +109,12 @@ class OpenPgpKeyManagerTest extends TestCase
     {
         $repo = $this->createMock(OpenPgpKeyRepository::class);
         $repo->expects($this->once())
-            ->method('countBySearch')
-            ->with('')
+            ->method('countByFilters')
+            ->with('', null)
             ->willReturn(50);
         $repo->expects($this->once())
-            ->method('findPaginatedBySearch')
-            ->with('', 20, 20)
+            ->method('findPaginatedByFilters')
+            ->with('', null, 20, 20)
             ->willReturn([]);
 
         $em = $this->createStub(EntityManagerInterface::class);
@@ -132,11 +132,11 @@ class OpenPgpKeyManagerTest extends TestCase
     {
         $repo = $this->createMock(OpenPgpKeyRepository::class);
         $repo->expects($this->once())
-            ->method('countBySearch')
+            ->method('countByFilters')
             ->willReturn(0);
         $repo->expects($this->once())
-            ->method('findPaginatedBySearch')
-            ->with('', 20, 0)
+            ->method('findPaginatedByFilters')
+            ->with('', null, 20, 0)
             ->willReturn([]);
 
         $em = $this->createStub(EntityManagerInterface::class);

--- a/tests/Service/UserManagerTest.php
+++ b/tests/Service/UserManagerTest.php
@@ -88,7 +88,7 @@ class UserManagerTest extends TestCase
             new User('user2@example.org'),
         ]);
 
-        $result = $this->manager->findPaginated(1, '', 'active');
+        $result = $this->manager->findPaginated(1, '', null, 'active');
 
         self::assertInstanceOf(PaginatedResult::class, $result);
         self::assertSame(1, $result->page);
@@ -104,7 +104,7 @@ class UserManagerTest extends TestCase
             new User('user@example.org'),
         ]);
 
-        $result = $this->manager->findPaginated(1, 'test', 'deleted', 'ROLE_ADMIN', 'enabled', 'enabled');
+        $result = $this->manager->findPaginated(1, 'test', null, 'deleted', 'ROLE_ADMIN', 'enabled', 'enabled');
 
         self::assertSame(1, $result->page);
         self::assertSame(1, $result->totalPages);

--- a/tests/js/controllers/ajax_autocomplete_controller.test.ts
+++ b/tests/js/controllers/ajax_autocomplete_controller.test.ts
@@ -39,6 +39,32 @@ const MULTI_HTML = `
            data-selected='[{"id":1,"name":"example.org"},{"id":2,"name":"test.de"}]'>
   </div>`;
 
+const FILTER_PRESELECTED_HTML = `
+  <div data-controller="ajax-autocomplete"
+       data-ajax-autocomplete-url-value="/api/domains/search"
+       data-ajax-autocomplete-label-field-value="name"
+       data-ajax-autocomplete-min-chars-value="0"
+       data-ajax-autocomplete-filter-param-value="domain"
+       data-ajax-autocomplete-compact-value="true">
+    <input type="hidden"
+           data-ajax-autocomplete-target="hidden"
+           value="5"
+           data-label="example.org">
+  </div>`;
+
+const FILTER_EMPTY_HTML = `
+  <div data-controller="ajax-autocomplete"
+       data-ajax-autocomplete-url-value="/api/domains/search"
+       data-ajax-autocomplete-label-field-value="name"
+       data-ajax-autocomplete-min-chars-value="0"
+       data-ajax-autocomplete-filter-param-value="domain"
+       data-ajax-autocomplete-compact-value="true">
+    <input type="hidden"
+           data-ajax-autocomplete-target="hidden"
+           value="0"
+           data-label="">
+  </div>`;
+
 function mockFetchResponse(data: unknown): void {
   vi.stubGlobal(
     "fetch",
@@ -593,6 +619,109 @@ describe("AjaxAutocompleteController", () => {
       const option = element.querySelector("[role='option']")!;
       expect(option.innerHTML).not.toContain("<script>");
       expect(option.innerHTML).toContain("&lt;script&gt;");
+    });
+  });
+
+  describe("filter mode clear button", () => {
+    it("renders inline clear button when filter has pre-selected value", async () => {
+      const { element } = await startController(
+        AjaxAutocompleteController,
+        FILTER_PRESELECTED_HTML,
+        "ajax-autocomplete",
+      );
+
+      const clearButton = element.querySelector(
+        "button[aria-label='Clear filter']",
+      );
+      expect(clearButton).not.toBeNull();
+
+      // Input should have right padding for the clear button
+      const textInput = element.querySelector(
+        "input[type='text']",
+      ) as HTMLInputElement;
+      expect(textInput.classList.contains("pr-8")).toBe(true);
+    });
+
+    it("does not show clear button when filter has no pre-selected value", async () => {
+      const { element } = await startController(
+        AjaxAutocompleteController,
+        FILTER_EMPTY_HTML,
+        "ajax-autocomplete",
+      );
+
+      const clearButton = element.querySelector(
+        "button[aria-label='Clear filter']",
+      ) as HTMLButtonElement;
+      expect(clearButton).not.toBeNull();
+      expect(clearButton.classList.contains("hidden")).toBe(true);
+
+      // Input should not have right padding when button is hidden
+      const textInput = element.querySelector(
+        "input[type='text']",
+      ) as HTMLInputElement;
+      expect(textInput.classList.contains("pr-8")).toBe(false);
+    });
+
+    it("navigates to URL without filter param on clear button click", async () => {
+      // Set up a URL with a domain filter parameter
+      const originalLocation = globalThis.location.href;
+      Object.defineProperty(globalThis, "location", {
+        writable: true,
+        value: new URL("http://localhost/admin/users?search=test&domain=5&page=2"),
+      });
+
+      const { element } = await startController(
+        AjaxAutocompleteController,
+        FILTER_PRESELECTED_HTML,
+        "ajax-autocomplete",
+      );
+
+      const clearButton = element.querySelector(
+        "button[aria-label='Clear filter']",
+      ) as HTMLButtonElement;
+
+      clearButton.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true }),
+      );
+
+      // Should navigate to URL without "domain" and "page" params
+      const resultUrl = new URL(globalThis.location.href);
+      expect(resultUrl.searchParams.has("domain")).toBe(false);
+      expect(resultUrl.searchParams.has("page")).toBe(false);
+      expect(resultUrl.searchParams.get("search")).toBe("test");
+
+      // Restore
+      Object.defineProperty(globalThis, "location", {
+        writable: true,
+        value: new URL(originalLocation),
+      });
+    });
+
+    it("hides clear button when user edits input after selecting", async () => {
+      const { element } = await startController(
+        AjaxAutocompleteController,
+        FILTER_PRESELECTED_HTML,
+        "ajax-autocomplete",
+      );
+
+      const textInput = element.querySelector(
+        "input[type='text']",
+      ) as HTMLInputElement;
+      const clearButton = element.querySelector(
+        "button[aria-label='Clear filter']",
+      ) as HTMLButtonElement;
+
+      // Initially visible
+      expect(clearButton.classList.contains("hidden")).toBe(false);
+      expect(textInput.classList.contains("pr-8")).toBe(true);
+
+      // User edits the input
+      textInput.value = "exam";
+      textInput.dispatchEvent(new Event("input"));
+
+      // Clear button should be hidden
+      expect(clearButton.classList.contains("hidden")).toBe(true);
+      expect(textInput.classList.contains("pr-8")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Add an autocomplete domain filter dropdown to all four admin entity list pages (Users, Aliases, OpenPGP Keys, Vouchers). The filter is only visible to `ROLE_ADMIN` users — domain admins are already scoped by the Doctrine `DomainFilter` and don't need it.

## Changes

### Backend
- **UserRepository / OpenPgpKeyRepository**: Added `?Domain $domain` parameter to filter methods (`countByFilters`, `findPaginatedByFilters`, `applyFilters`)
- **UserManager / AliasManager / OpenPgpKeyManager**: Pass domain filter through to repositories in `findPaginated()`
- **UserController / AliasController / OpenPgpKeyController**: Resolve `selectedDomain` request parameter to `Domain` entity and pass it down

### Frontend
- **`ajax_autocomplete_controller.ts`**: Added inline clear button (✕) for filter mode — appears inside the input when a value is selected, navigates to current URL without the filter param on click. Compact mode (`h-9`) for consistent height.
- **Shared partial `_domain_filter.html.twig`**: DRY template included on all 4 pages, guarded by `is_granted('ROLE_ADMIN')`

### Templates
- **Unified filter bar layout** across all 4 admin pages: stacked labels (`text-xs` above controls), `h-9` height on all controls, `items-end` alignment for flush bottom edges
- Pages with action buttons (User, Alias, Voucher): action + search on row 1, filters on row 2
- Pages without action button (OpenPGP Keys): domain filter + search in a single row

### Tests
- Updated `AliasManagerTest`, `UserManagerTest`, `OpenPgpKeyManagerTest` for the new `?Domain` parameter
- Added 3 new Vitest tests for the clear button behavior in `ajax_autocomplete_controller`

### Translations
- Added `admin.filter.domain` key (EN + DE)
- Removed unused legacy keys

---
<sub>The changes and the PR were generated by OpenCode.</sub>