### PR TITLE
✨ Add admin UI for restoring deleted users

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -983,6 +983,24 @@ admin:
       show: Anzeigen
       edit: Bearbeiten
       delete: Löschen
+      restore: Wiederherstellen
+    restore:
+      title: Benutzer:in wiederherstellen
+      success: Benutzer:in wurde erfolgreich wiederhergestellt.
+      warning: "Die Wiederherstellung setzt ein neues Passwort, setzt die Zwei-Faktor-Authentifizierung und die Postfachverschlüsselung zurück. Die:der Benutzer:in erhält eine Willkommens-E-Mail."
+      recovery_token_headline: Recovery-Token für diese:n Benutzer:in
+      recovery_token_info: >
+        Für diese:n Benutzer:in wurde ein neuer Recovery-Token erstellt.
+        Bitte gib ihn auf sicherem Weg an die Person weiter — sie benötigt ihn, um ihr Konto wiederherzustellen, falls sie ihr Passwort vergisst.
+      recovery_token_displayed_once: >
+        Aus Sicherheitsgründen wird dieser Recovery-Token nur einmal angezeigt und kann später nicht erneut abgerufen werden.
+      form:
+        title: Benutzer:in wiederherstellen
+        password:
+          label: Neues Passwort
+        password_confirmation:
+          label: Passwort bestätigen
+        submit: Wiederherstellen
     show:
       description: Kontodetails und Statistiken
       back: Zurück zu Benutzer:innen

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -985,6 +985,24 @@ admin:
       show: Show
       edit: Edit
       delete: Delete
+      restore: Restore
+    restore:
+      title: Restore User
+      success: User has been restored successfully.
+      warning: "Restoring this user will set a new password, reset two-factor authentication and mailbox encryption. The user will receive a welcome email."
+      recovery_token_headline: Recovery token for this user
+      recovery_token_info: >
+        A new recovery token has been generated for this user.
+        Please pass it on to the user securely — they will need it to recover their account if they forget their password.
+      recovery_token_displayed_once: >
+        For security reasons, this recovery token is displayed only once and cannot be retrieved later.
+      form:
+        title: Restore User
+        password:
+          label: New Password
+        password_confirmation:
+          label: Confirm Password
+        submit: Restore
     show:
       description: User details and statistics
       back: Back to Users

--- a/features/admin_users.feature
+++ b/features/admin_users.feature
@@ -298,3 +298,87 @@ Feature: Settings (Users)
     When I click "Delete" in the modal
 
     Then I wait for text "User has been deleted successfully" to appear
+
+  @settings-users
+  Scenario: Admin can access restore form for deleted user
+    Given the following User exists:
+      | email               | password | roles     | deleted |
+      | deleted@example.org | asdasd   | ROLE_USER | true    |
+    And I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "deleted@example.org"
+    When I am on "/admin/users/restore/__user_id__"
+
+    Then the response status code should be 200
+    And I should see "deleted@example.org"
+    And I should see "Restore User"
+
+  @settings-users
+  Scenario: Restore form returns 404 for active user
+    Given I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/admin/users/restore/__user_id__"
+
+    Then the response status code should be 404
+
+  @settings-users
+  Scenario: Admin can restore a deleted user
+    Given the following User exists:
+      | email               | password | roles     | deleted |
+      | deleted@example.org | asdasd   | ROLE_USER | true    |
+    And I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "deleted@example.org"
+    When I am on "/admin/users/restore/__user_id__"
+    And I fill in "user_restore_plainPassword_first" with "newSecurePassword123!"
+    And I fill in "user_restore_plainPassword_second" with "newSecurePassword123!"
+    And I press "Restore"
+
+    Then I should see "User has been restored successfully"
+
+  @settings-users
+  Scenario: Restore fails with mismatched passwords
+    Given the following User exists:
+      | email               | password | roles     | deleted |
+      | deleted@example.org | asdasd   | ROLE_USER | true    |
+    And I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "deleted@example.org"
+    When I am on "/admin/users/restore/__user_id__"
+    And I fill in "user_restore_plainPassword_first" with "newSecurePassword123!"
+    And I fill in "user_restore_plainPassword_second" with "differentPassword456!"
+    And I press "Restore"
+
+    Then the response status code should be 422
+
+  @settings-users
+  Scenario: Admin sees restore button on show page of deleted user
+    Given the following User exists:
+      | email               | password | roles     | deleted |
+      | deleted@example.org | asdasd   | ROLE_USER | true    |
+    And I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "deleted@example.org"
+    When I am on "/admin/users/__user_id__"
+
+    Then the response status code should be 200
+    And I should see "Restore"
+
+  @settings-users
+  Scenario: Admin does not see restore button for active users on show page
+    Given I am authenticated as "admin@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "user@example.org"
+    When I am on "/admin/users/__user_id__"
+
+    Then the response status code should be 200
+    And I should not see "Restore"
+
+  @settings-users
+  Scenario: Domain admin cannot restore user from another domain
+    Given the following Domain exists:
+      | name      |
+      | other.org |
+    And the following User exists:
+      | email              | password | roles     | deleted |
+      | deleted@other.org  | asdasd   | ROLE_USER | true    |
+    And I am authenticated as "support@example.org"
+    And I set the placeholder "__user_id__" with property "id" for "deleted@other.org"
+    When I am on "/admin/users/restore/__user_id__"
+
+    Then the response status code should be 404

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -9,7 +9,9 @@ use App\Entity\User;
 use App\Enum\Roles;
 use App\Form\Model\UserAdminModel;
 use App\Form\UserAdminType;
+use App\Form\UserRestoreType;
 use App\Service\UserManager;
+use App\Service\UserRestoreService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -22,6 +24,7 @@ final class UserController extends AbstractController
 {
     public function __construct(
         private readonly UserManager $manager,
+        private readonly UserRestoreService $restoreService,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -173,6 +176,55 @@ final class UserController extends AbstractController
         return $this->render('Admin/User/show.html.twig', [
             'user' => $user,
             'stats' => $this->manager->getUserStats($user),
+        ]);
+    }
+
+    #[Route('/admin/users/restore/{id}', name: 'admin_user_restore', methods: ['GET'])]
+    public function restore(#[MapEntity] User $user): Response
+    {
+        if (!$user->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
+        $this->denyAccessUnlessGranted('edit', $user);
+
+        $form = $this->createForm(UserRestoreType::class, null, [
+            'action' => $this->generateUrl('admin_user_restore_post', ['id' => $user->getId()]),
+            'method' => 'POST',
+        ]);
+
+        return $this->render('Admin/User/restore.html.twig', [
+            'form' => $form,
+            'user' => $user,
+        ]);
+    }
+
+    #[Route('/admin/users/restore/{id}', name: 'admin_user_restore_post', methods: ['POST'])]
+    public function restoreSubmit(#[MapEntity] User $user, Request $request): Response
+    {
+        if (!$user->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
+        $this->denyAccessUnlessGranted('edit', $user);
+
+        $form = $this->createForm(UserRestoreType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $recoveryToken = $this->restoreService->restoreUser($user, $form->get('plainPassword')->getData());
+            $this->addFlash('success', 'admin.user.restore.success');
+
+            return $this->render('Admin/User/show.html.twig', [
+                'user' => $user,
+                'stats' => $this->manager->getUserStats($user),
+                'recovery_token' => $recoveryToken,
+            ]);
+        }
+
+        return $this->render('Admin/User/restore.html.twig', [
+            'form' => $form,
+            'user' => $user,
         ]);
     }
 

--- a/src/Event/UserEvent.php
+++ b/src/Event/UserEvent.php
@@ -17,6 +17,8 @@ final class UserEvent extends Event
 
     public const string PASSWORD_CHANGED = 'user.password_changed';
 
+    public const string USER_RESTORED = 'user.restored';
+
     public const string RECOVERY_PROCESS_STARTED = 'recovery_process_started';
 
     public function __construct(private readonly User $user)

--- a/src/EventListener/WelcomeMailListener.php
+++ b/src/EventListener/WelcomeMailListener.php
@@ -25,6 +25,7 @@ final readonly class WelcomeMailListener implements EventSubscriberInterface
     {
         return [
             UserEvent::USER_CREATED => 'onUserCreated',
+            UserEvent::USER_RESTORED => 'onUserCreated',
         ];
     }
 

--- a/src/Form/UserRestoreType.php
+++ b/src/Form/UserRestoreType.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use Override;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @extends AbstractType<null>
+ */
+final class UserRestoreType extends AbstractType
+{
+    #[Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('plainPassword', RepeatedType::class, [
+            'type' => PasswordType::class,
+            'required' => true,
+            'first_options' => [
+                'label' => 'form.password',
+            ],
+            'second_options' => [
+                'label' => 'form.password_confirmation',
+            ],
+            'invalid_message' => 'different-password',
+            'constraints' => [
+                new Assert\NotBlank(),
+                new Assert\Length(min: 12, minMessage: 'form.weak_password'),
+                new Assert\NotCompromisedPassword(skipOnError: true),
+            ],
+        ]);
+
+        $builder->add('submit', SubmitType::class);
+    }
+}

--- a/src/Service/UserRestoreService.php
+++ b/src/Service/UserRestoreService.php
@@ -31,7 +31,7 @@ final readonly class UserRestoreService
 
         $this->manager->flush();
 
-        $this->eventDispatcher->dispatch(new UserEvent($user), UserEvent::USER_CREATED);
+        $this->eventDispatcher->dispatch(new UserEvent($user), UserEvent::USER_RESTORED);
 
         return $recoveryToken;
     }

--- a/templates/Admin/User/index.html.twig
+++ b/templates/Admin/User/index.html.twig
@@ -173,6 +173,14 @@
                                                     <span class="sr-only">{{ 'admin.user.actions.delete'|trans }}</span>
                                                 </button>
                                             </form>
+                                        {% else %}
+                                            <a href="{{ path('admin_user_restore', {id: user.id}) }}"
+                                               title="{{ 'admin.user.actions.restore'|trans }}"
+                                               data-controller="tooltip"
+                                               class="inline-flex items-center justify-center p-1.5 text-gray-500 dark:text-gray-400 hover:text-green-700 dark:hover:text-green-200 hover:bg-green-100 dark:hover:bg-green-700 border border-gray-200 dark:border-gray-600 rounded-lg transition-colors">
+                                                {{ ux_icon('heroicons:arrow-path', {class: 'w-4 h-4'}) }}
+                                                <span class="sr-only">{{ 'admin.user.actions.restore'|trans }}</span>
+                                            </a>
                                         {% endif %}
                                     </div>
                                 </td>

--- a/templates/Admin/User/restore.html.twig
+++ b/templates/Admin/User/restore.html.twig
@@ -1,0 +1,85 @@
+{% set current_section = 'users' %}
+{% extends 'Admin/base_admin.html.twig' %}
+
+{% form_theme form 'Form/fields.html.twig' %}
+
+{% block title %}
+    {{ setting('app_name') }} - {{ 'admin.user.restore.title'|trans }}
+{% endblock %}
+
+{% block admin_content %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div class="p-6 sm:p-8">
+            <div class="flex items-center mb-6">
+                <div class="w-12 h-12 bg-green-100 dark:bg-green-900/50 rounded-xl flex items-center justify-center mr-4">
+                    {{ ux_icon('heroicons:arrow-path', {class: 'w-6 h-6 text-green-600 dark:text-green-400'}) }}
+                </div>
+                <div>
+                    <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                        {{ 'admin.user.restore.form.title'|trans }}
+                    </h3>
+                    <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ user.email }}</p>
+                </div>
+            </div>
+
+            <div class="mb-6">
+                <a href="{{ path('admin_user_show', {id: user.id}) }}"
+                   class="inline-flex items-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600">
+                    {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-1'}) }} {{ 'admin.user.show.back_to_user'|trans }}
+                </a>
+            </div>
+
+            <div class="mb-6 p-4 bg-amber-50 dark:bg-amber-950/50 border border-amber-300 dark:border-amber-700 rounded-lg">
+                <div class="flex items-start">
+                    {{ ux_icon('heroicons:exclamation-triangle', {class: 'w-5 h-5 text-amber-600 dark:text-amber-400 mr-2 mt-0.5 shrink-0'}) }}
+                    <p class="text-sm text-amber-800 dark:text-amber-200">
+                        {{ 'admin.user.restore.warning'|trans }}
+                    </p>
+                </div>
+            </div>
+
+            {{ form_start(form) }}
+            {{ form_errors(form) }}
+
+            <div class="space-y-6">
+                <div data-controller="password-strength"
+                     data-password-strength-strong-label-value="{{ "form.password-strong"|trans }}"
+                     data-password-strength-min-length-value="12"
+                     data-password-strength-min-length-label-value="{{ "form.password-min-length"|trans({'%min%': 12}) }}"
+                >
+                    {{ form_label(form.plainPassword.first, 'admin.user.restore.form.password.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_errors(form.plainPassword) }}
+                    {{ form_widget(form.plainPassword.first, {'attr': {'data-password-strength-target': 'input', 'data-action': 'focus->password-strength#loadAndEvaluate:once input->password-strength#evaluate', 'autocomplete': 'new-password'}}) }}
+                    {# Password strength meter #}
+                    <div class="flex gap-1 mt-2" data-password-strength-meter aria-hidden="true">
+                        <div class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-600 transition-colors duration-300" data-password-strength-target="segment"></div>
+                        <div class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-600 transition-colors duration-300" data-password-strength-target="segment"></div>
+                        <div class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-600 transition-colors duration-300" data-password-strength-target="segment"></div>
+                        <div class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-600 transition-colors duration-300" data-password-strength-target="segment"></div>
+                    </div>
+                    <p class="text-xs text-gray-500 dark:text-gray-400 hidden mt-1" data-password-strength-target="feedback" aria-live="polite"></p>
+                </div>
+
+                <div>
+                    {{ form_label(form.plainPassword.second, 'admin.user.restore.form.password_confirmation.label', {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+                    {{ form_widget(form.plainPassword.second) }}
+                </div>
+
+                <div class="flex items-center justify-between pt-6">
+                    <a href="{{ path('admin_user_show', {id: user.id}) }}"
+                       class="inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                        {{ ux_icon('heroicons:arrow-left', {class: 'w-4 h-4 mr-2'}) }}
+                        {{ 'admin.user.form.cancel'|trans }}
+                    </a>
+                    {{ form_widget(form.submit, {
+                        label: 'admin.user.restore.form.submit',
+                        attr: {
+                            class: 'inline-flex items-center px-6 py-3 bg-green-600 dark:bg-green-500 text-white font-medium rounded-lg hover:bg-green-700 dark:hover:bg-green-600 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors'
+                        }
+                    }) }}
+                </div>
+            </div>
+            {{ form_end(form) }}
+        </div>
+    </div>
+{% endblock %}

--- a/templates/Admin/User/show.html.twig
+++ b/templates/Admin/User/show.html.twig
@@ -18,9 +18,44 @@
                                 </span>
                             {% endif %}
                         </div>
-                        <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'admin.user.show.description'|trans }}</p>
+                    <p class="text-sm text-gray-500 dark:text-gray-300 mt-1">{{ 'admin.user.show.description'|trans }}</p>
+                </div>
+            </div>
+
+            {% if recovery_token is defined and recovery_token is not null %}
+                <div class="mb-6 p-5 bg-yellow-50 dark:bg-yellow-950/50 border border-yellow-300 dark:border-yellow-700 rounded-lg">
+                    <div class="flex items-start">
+                        <div class="w-10 h-10 bg-yellow-100 dark:bg-yellow-900/50 rounded-xl flex items-center justify-center mr-4 shrink-0">
+                            {{ ux_icon('heroicons:exclamation-triangle', {class: 'w-5 h-5 text-yellow-600 dark:text-yellow-400'}) }}
+                        </div>
+                        <div class="min-w-0 flex-1">
+                            <h4 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                                {{ 'admin.user.restore.recovery_token_headline'|trans }}
+                            </h4>
+                            <p class="text-sm text-yellow-800 dark:text-yellow-200 mb-1">
+                                {{ 'admin.user.restore.recovery_token_info'|trans }}
+                            </p>
+                            <p class="text-sm text-yellow-800 dark:text-yellow-200 mb-4">
+                                {{ 'admin.user.restore.recovery_token_displayed_once'|trans }}
+                            </p>
+                            <div class="bg-white dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600">
+                                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3">
+                                    <code class="font-stretch-semi-condensed text-sm font-mono text-gray-900 dark:text-gray-100 break-all select-all min-w-0 flex-1">{{ recovery_token }}</code>
+                                    <button type="button"
+                                            class="inline-flex items-center p-2 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md hover:bg-gray-100 dark:hover:bg-gray-500 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-700 transition-colors duration-200 self-end sm:self-auto flex-shrink-0"
+                                            data-controller="clipboard tooltip"
+                                            data-clipboard-content-value="{{ recovery_token }}"
+                                            data-action="clipboard#copy"
+                                            title="{{ 'copy-to-clipboard'|trans }}"
+                                            aria-label="{{ 'copy-to-clipboard'|trans }}">
+                                        {{ ux_icon('heroicons:clipboard', {class: 'w-4 h-4'}) }}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
+            {% endif %}
 
                 <div class="mb-6 flex gap-2">
                     <a href="{{ path('admin_user_index') }}"
@@ -43,6 +78,11 @@
                                 {{ ux_icon('heroicons:trash', {class: 'w-4 h-4 mr-1'}) }} {{ 'admin.user.actions.delete'|trans }}
                             </button>
                         </form>
+                    {% elseif user.deleted and is_granted('edit', user) %}
+                        <a href="{{ path('admin_user_restore', {id: user.id}) }}"
+                           class="inline-flex items-center px-3 py-1.5 text-sm text-green-700 dark:text-green-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-green-50 dark:hover:bg-green-900/30">
+                            {{ ux_icon('heroicons:arrow-path', {class: 'w-4 h-4 mr-1'}) }} {{ 'admin.user.actions.restore'|trans }}
+                        </a>
                     {% endif %}
                 </div>
 

--- a/tests/EventListener/WelcomeMailListenerTest.php
+++ b/tests/EventListener/WelcomeMailListenerTest.php
@@ -20,7 +20,9 @@ class WelcomeMailListenerTest extends TestCase
     {
         $events = WelcomeMailListener::getSubscribedEvents();
         self::assertArrayHasKey(UserEvent::USER_CREATED, $events);
+        self::assertArrayHasKey(UserEvent::USER_RESTORED, $events);
         self::assertEquals('onUserCreated', $events[UserEvent::USER_CREATED]);
+        self::assertEquals('onUserCreated', $events[UserEvent::USER_RESTORED]);
     }
 
     public function testOnUserCreatedDispatchesWelcomeMailWithLocale(): void

--- a/tests/Service/UserRestoreServiceTest.php
+++ b/tests/Service/UserRestoreServiceTest.php
@@ -106,7 +106,7 @@ class UserRestoreServiceTest extends TestCase
         $service->restoreUser($user, 'password123');
     }
 
-    public function testRestoreUserDispatchesUserCreatedEvent(): void
+    public function testRestoreUserDispatchesUserRestoredEvent(): void
     {
         $user = new User('deleted@example.org');
         $user->setDeleted(true);
@@ -117,7 +117,7 @@ class UserRestoreServiceTest extends TestCase
             ->method('dispatch')
             ->with(
                 $this->callback(static fn ($event) => $event instanceof UserEvent && $event->getUser() === $user),
-                UserEvent::USER_CREATED
+                UserEvent::USER_RESTORED
             );
 
         $service = new UserRestoreService(


### PR DESCRIPTION
## Summary

Adds a restore action to the admin user management, allowing admins to restore soft-deleted users directly from the admin interface. Previously, restoring users was only possible via the CLI command `app:users:restore`.

The restore flow sets a new password, resets two-factor authentication and mailbox encryption, generates a new recovery token, and sends a welcome email. The recovery token is displayed prominently on the user show page after a successful restore, with clear instructions to pass it on to the user.

<img alt="Bildschirmfoto am 2026-04-18 um 11 04 52" src="https://github.com/user-attachments/assets/e7ed0f10-e2ed-4f47-95f7-8be26228006d" />
<img alt="Bildschirmfoto am 2026-04-18 um 11 04 33" src="https://github.com/user-attachments/assets/54933760-b495-43a5-8173-51f445eb02ef" />

### Key changes

- **Controller**: `restore` (GET) and `restoreSubmit` (POST) actions on `UserController` following the GET/POST split pattern
- **Form**: New `UserRestoreType` with repeated password field (min 12 chars, NotCompromised)
- **Event**: New `USER_RESTORED` event constant, dispatched by `UserRestoreService` instead of reusing `USER_CREATED`
- **Listener**: `WelcomeMailListener` now also subscribes to `USER_RESTORED`
- **Templates**: Restore page with warning banner, restore buttons on index/show pages for deleted users, recovery token display block with copy button
- **Translations**: Dedicated EN/DE translations including admin-context recovery token wording (instructs admin to pass the token to the user)
- **Tests**: 7 new Behat scenarios, updated unit tests for event and listener changes

---
<sub>The changes and the PR were generated by OpenCode.</sub>