### PR TITLE
🔒 Reject filter-DSL metacharacters in GpgKeyParser email argument

### DIFF
--- a/src/Service/GpgKeyParser.php
+++ b/src/Service/GpgKeyParser.php
@@ -23,6 +23,14 @@ use const DIRECTORY_SEPARATOR;
 
 class GpgKeyParser
 {
+    /**
+     * Characters outside this allowlist must not be interpolated into the
+     * GnuPG `--import-filter` expression. Reject at the sink rather than
+     * mutating the admin email-validation rules, which legitimately accept
+     * a broader RFC 5321 atext set than this sink can safely embed.
+     */
+    private const string SAFE_EMAIL_PATTERN = '/^[A-Za-z0-9._+@-]+$/';
+
     protected function createGpg(string $homedir): Crypt_GPG
     {
         return new Crypt_GPG(['homedir' => $homedir]);
@@ -36,6 +44,10 @@ class GpgKeyParser
      */
     public function parse(string $email, string $data): GpgKeyResult
     {
+        if (1 !== preg_match(self::SAFE_EMAIL_PATTERN, $email)) {
+            throw new GpgKeyParserException(sprintf('Email "%s" contains characters not allowed in a GnuPG key lookup.', $email));
+        }
+
         $tempDir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'userli_'.mt_rand().microtime(true);
         if (!mkdir($concurrentDirectory = $tempDir) && !is_dir($concurrentDirectory)) {
             throw new GpgKeyParserException('Failed to create directory: '.$concurrentDirectory);

--- a/tests/Service/GpgKeyParserTest.php
+++ b/tests/Service/GpgKeyParserTest.php
@@ -18,6 +18,7 @@ use Crypt_GPG_KeyNotFoundException;
 use Crypt_GPG_NoDataException;
 use Crypt_GPG_SubKey;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
@@ -277,6 +278,28 @@ zg5FDph+OpdBuInEpzFyovIpSMF67TAY1b96p8doFaWQ0g==
         $this->expectException(NoGpgDataException::class);
 
         new GpgKeyParser()->parse($this->email, $this->brokenKeyAscii);
+    }
+
+    #[DataProvider('emailWithFilterOperatorsProvider')]
+    public function testParseRejectsEmailWithFilterOperators(string $email): void
+    {
+        $this->expectException(GpgKeyParserException::class);
+        $this->expectExceptionMessage('contains characters not allowed in a GnuPG key lookup');
+
+        new GpgKeyParser()->parse($email, $this->validKeyAscii);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function emailWithFilterOperatorsProvider(): iterable
+    {
+        yield 'pipe (or-operator)' => ['a||b@example.org'];
+        yield 'ampersand (and-operator)' => ['a&&b@example.org'];
+        yield 'parenthesis (grouping)' => ['a(b)c@example.org'];
+        yield 'bang (negation)' => ['a!b@example.org'];
+        yield 'backslash' => ['a\\b@example.org'];
+        yield 'single pipe' => ['a|b@example.org'];
     }
 
     public function testOtherKey(): void


### PR DESCRIPTION
## Summary

- `GpgKeyParser::parse()` now validates its `$email` argument against `/^[A-Za-z0-9._+@-]+$/` and throws `GpgKeyParserException` before invoking GPG if the email contains characters that GnuPG's filter DSL treats as operators (`|`, `&`, `(`, `)`, `!`, `\`, …).
- Six data-provider cases added to `GpgKeyParserTest` covering the concerning operator classes.

## Why

`GpgKeyParser::parse()` interpolates the email into `--import-filter keep-uid="uid =~ <%s> || uid = %s"`. An attacker who can store a crafted email and later upload a PGP key for that address can inject operators that alter the `keep-uid` filter semantics (extra `||` clauses, negations, groupings) — a filter-bypass that lets an imported key retain UIDs unrelated to the attacker.

The admin user-creation form deliberately accepts a broader RFC 5321 atext set than self-registration (`+` tagging, legacy mailboxes, etc.), so **the right place to guard is at the sink**, not by narrowing admin email validation — that would be a product regression. This PR only changes the sink.

## Not in scope

- This is not an OS command-injection fix. Modern `pear/crypt_gpg` uses array argv in `proc_open`, so shell metacharacters don't escape into a shell command. This PR addresses the filter-DSL injection specifically.
- `UserAdminType` is intentionally untouched — admin-created emails can still use the broader email charset.

## Test plan

- [x] 6 new data-provider cases in `GpgKeyParserTest::testParseRejectsEmailWithFilterOperators` — red before fix (wrong exception message), green after.
- [x] Existing `testParseSuccessWith*` / `testParseThrows*` mocked unit tests still pass.
- [x] `composer psalm` / `composer cs-check` / `composer rector-check` clean.
- [ ] CI integration tests (`testValidKey`, `testBrokenKey`, `testOtherKey`, `testTwoKeys`) require `gpg` at `/usr/bin/gpg`, which my local env lacks; I verified identical pre-existing failures on `main` to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)