### PR TITLE
✨ Add deep link to cancel recovery process in notification mail

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -342,9 +342,12 @@ mail:
     %app_url%/recovery eingegeben.
 
     Wenn du das nicht selbst warst, hat jemand anderes Zugang zu deinem
-    Wiederherstellungscode. Öffne diesen Link, um den Vorgang abzubrechen
-    und den Code in einem Schritt ungültig zu machen:
+    Wiederherstellungscode. Öffne den folgenden Link und logge dich ein,
+    um einen neuen Wiederherstellungscode zu erstellen. Dadurch wird der
+    alte Code ungültig und der Vorgang in einem Schritt abgebrochen:
     %reset_link%
+
+    Denke daran, den neuen Wiederherstellungscode sicher aufzubewahren.
 
     Hast du den Vorgang selbst ausgelöst, startet nun die 48-stündige Wartezeit.
     Diese geht bis zum %time%. Anschließend kannst du mit einem

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -341,11 +341,10 @@ mail:
     E-Mail-Addresse und der zugehörige Wiederherstellungscode unter
     %app_url%/recovery eingegeben.
 
-    Wenn du das nicht selbst warst, versucht jemand anderes mit Zugang zu
-    deinem Wiederherstellungscode, Kontrolle über dein Konto zu bekommen.
-    Gehe schnellstmöglich zu %app_url%/user/recovery_token
-    und erstelle dir einen neuen Wiederherstellungscode. Dadurch wird der
-    alte Code ungültig und der Vorgang abgebrochen.
+    Wenn du das nicht selbst warst, hat jemand anderes Zugang zu deinem
+    Wiederherstellungscode. Öffne diesen Link, um den Vorgang abzubrechen
+    und den Code in einem Schritt ungültig zu machen:
+    %reset_link%
 
     Hast du den Vorgang selbst ausgelöst, startet nun die 48-stündige Wartezeit.
     Diese geht bis zum %time%. Anschließend kannst du mit einem

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -344,11 +344,9 @@ mail:
     your  e-mail address and corresponding recovery code at
     %app_url%/recovery.
 
-    If this wasn't you, then somebody else with access to your recovery
-    token tried to get ahold of your account. Go to
-    %app_url%/user/recovery_token immediately and create a
-    new recovery token. This will invalidate the old recovery token and stop
-    the process.
+    If this wasn't you, somebody else has your recovery token. Open this
+    link to cancel the process and invalidate the leaked token in one step:
+    %reset_link%
 
     If you did trigger the process yourself, the 48 hour waiting period started
     now. It will end at %time%. Afterwards, you can set a new password at

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -344,9 +344,12 @@ mail:
     your  e-mail address and corresponding recovery code at
     %app_url%/recovery.
 
-    If this wasn't you, somebody else has your recovery token. Open this
-    link to cancel the process and invalidate the leaked token in one step:
+    If this wasn't you, somebody else has your recovery token. Open the
+    following link and log in to create a new recovery token. This will
+    invalidate the leaked token and cancel the recovery process in one step:
     %reset_link%
+
+    Make sure to store your new recovery token in a safe place.
 
     If you did trigger the process yourself, the 48 hour waiting period started
     now. It will end at %time%. Afterwards, you can set a new password at

--- a/src/Mail/RecoveryProcessMailer.php
+++ b/src/Mail/RecoveryProcessMailer.php
@@ -33,13 +33,16 @@ final readonly class RecoveryProcessMailer
 
     private function buildBody(string $locale, string $email, string $time): string
     {
+        $appUrl = (string) $this->settingsService->get('app_url');
+
         return $this->translator->trans(
             'mail.recovery-body',
             [
-                '%app_url%' => $this->settingsService->get('app_url'),
+                '%app_url%' => $appUrl,
                 '%project_name%' => $this->settingsService->get('project_name'),
                 '%email%' => $email,
                 '%time%' => $time,
+                '%reset_link%' => rtrim($appUrl, '/').'/account/recovery-token',
             ],
             null,
             $locale

--- a/tests/Mail/RecoveryProcessMailerTest.php
+++ b/tests/Mail/RecoveryProcessMailerTest.php
@@ -100,4 +100,40 @@ class RecoveryProcessMailerTest extends TestCase
         $mailer = new RecoveryProcessMailer($handler, $translator, $settingsService);
         $mailer->send($user, 'en');
     }
+
+    public function testSendPassesResetLinkToTranslator(): void
+    {
+        $user = new User('user@example.org');
+        $user->setRecoveryStartTime(new DateTimeImmutable('2026-01-15 10:00:00'));
+
+        $settingsService = $this->createStub(SettingsService::class);
+        $settingsService->method('get')
+            ->willReturnMap([
+                ['app_url', null, 'https://mail.example.com/'],
+                ['project_name', null, 'Example Mail'],
+            ]);
+
+        $capturedResetLink = null;
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')
+            ->willReturnCallback(static function (string $id, array $parameters) use (&$capturedResetLink): string {
+                if ('mail.recovery-body' === $id) {
+                    self::assertArrayHasKey('%reset_link%', $parameters);
+                    $capturedResetLink = $parameters['%reset_link%'];
+                }
+
+                return 'translated';
+            });
+
+        $handler = $this->createStub(MailHandler::class);
+
+        $mailer = new RecoveryProcessMailer($handler, $translator, $settingsService);
+        $mailer->send($user, 'en');
+
+        self::assertSame(
+            'https://mail.example.com/account/recovery-token',
+            $capturedResetLink,
+            'Reset link should point at the account recovery-token page (login + password invalidates the old token and stops the recovery process)',
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #97

The recovery notification mail now contains a deep link to `/account/recovery-token`. Opening the link (which requires login + password confirmation) regenerates the recovery token — and because `RecoveryTokenHandler::create` also erases `recoveryStartTime`, this cancels the recovery process and invalidates the leaked token in one step.

No new route, controller action, or handler method was introduced — the existing authenticated flow already does the right thing. This PR just surfaces it from the mail.

## Changes

- `src/Mail/RecoveryProcessMailer.php` — passes a new `%reset_link%` placeholder (= `app_url` + `/account/recovery-token`) to the translator
- `default_translations/en/messages.en.yml` + `default_translations/de/messages.de.yml` — recovery mail body rewritten to explain the one-click cancellation and reference `%reset_link%`
- `tests/Mail/RecoveryProcessMailerTest.php` — new `testSendPassesResetLinkToTranslator` asserting the placeholder and its value

Developed with red-green TDD.

## Test plan

- [ ] `./bin/phpunit --filter RecoveryProcessMailerTest` — all green
- [ ] Trigger a recovery process via `/recovery`, open the notification in Mailcatcher, verify the `%reset_link%` URL is correct
- [ ] Click the link while logged out → redirected to login, then to `/account/recovery-token`
- [ ] Submit the password confirmation → new recovery token shown, `recoveryStartTime` cleared in DB, old recovery token rejected by `/recovery`
- [ ] Verify the German translation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)