### PR TITLE
✨ Add signed deep link for recovery-token regeneration (#97)

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -108,6 +108,7 @@ form:
   twofactor-login: Zwei-Faktor-Authentifizierung
   twofactor-login-placeholder: 6-stelliger Code
   twofactor-login-auth-code: Authentifizierungs-Code
+  twofactor-code: Authentifizierungs-Code (oder Backup-Code)
   twofactor-backup-code-confirm: Backup-Codes sicher abgelegt
   twofactor-login-desc: Öffne deine Zwei-Faktor (TOTP) App für den Code.
   twofactor-login-cancel: Login abbrechen
@@ -278,6 +279,11 @@ recovery-token:
   created-subtitle: Bitte kopiere und speicher dein Wiederherstellungscode sicher.
   created-info: Mit dem Wiederherstellungscode kannst du jederzeit dein Passwort zurücksetzen, wenn du dieses vergessen hast. Notiere ihn dir und speichere ihn an einem sicheren Ort ab.
   displayed-once: Der Wiederherstellungscode wird aus Sicherheitsgründen nur einmal angezeigt. Wir können ihn nicht für dich wiederherstellen.
+recovery-token-regenerate:
+  headline: Neuen Wiederherstellungscode erstellen
+  lead: >
+    Gib das Passwort für %email% ein, um den aktuellen Wiederherstellungscode
+    sofort zu entwerten und einen neuen zu erzeugen.
 flashes:
   dismiss: Schließen
   logout-successful: Du bist jetzt abgemeldet.
@@ -299,6 +305,8 @@ flashes:
   openpgp-key-upload-error-multiple-keys: Die hochgeladene Datei enhält mehr als einen Schlüssel für deine E-Mail-Adresse. Bitte lade nur einen Schlüssel hoch.
   openpgp-key-unauthorized: Du bist nicht berechtigt, Schlüssel für diese Adresse zu verwalten.
   password-confirmation-failed: Das eingegebene Passwort ist falsch. Bitte versuche es erneut.
+  recovery-token-regenerated: Dein neuer Wiederherstellungscode wurde erzeugt.
+  twofactor-code-invalid: Der eingegebene Zwei-Faktor-Code ist ungültig.
 flash_batch_remove_vouchers_success: Nicht eingelöste Einladungscodes gelöscht.
 error:
   title: Oops, es ist ein Fehler passiert.

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -112,6 +112,7 @@ form:
   twofactor-login: Two-factor authentication
   twofactor-login-placeholder: 6-digit code
   twofactor-login-auth-code: Authentication code
+  twofactor-code: Authentication code (or backup code)
   twofactor-backup-code-confirm: Backup codes stored securely
   twofactor-login-desc: Open your two-factor authenticator (TOTP) app to view your authentication code.
   twofactor-login-cancel: Cancel login
@@ -282,6 +283,11 @@ recovery-token:
   displayed-once: >
     For security reasons, the recovery token gets displayed only once.
     We can't recover this token for you.
+recovery-token-regenerate:
+  headline: Create a new recovery token
+  lead: >
+    Enter the password for %email% to immediately invalidate the current recovery
+    token and generate a new one.
 flashes:
   dismiss: Dismiss
   logout-successful: You are now logged out.
@@ -303,6 +309,8 @@ flashes:
   openpgp-key-upload-error-multiple-keys: More than one key for your mail address found in uploaded data. Please upload only one key.
   openpgp-key-unauthorized: You are not authorized to manage this identity.
   password-confirmation-failed: The password you entered is incorrect. Please try again.
+  recovery-token-regenerated: Your new recovery token has been generated.
+  twofactor-code-invalid: The two-factor authentication code you entered is invalid.
 flash_batch_remove_vouchers_success: Unredeemed invite codes deleted.
 error:
   title: Oops, an error occured.

--- a/features/mail_links.feature
+++ b/features/mail_links.feature
@@ -26,4 +26,4 @@ Feature: Mail links
 
     Then I should see text matching "Second step starts at"
     And the last sent mail body should contain "https://mail.example.org/recovery"
-    And the last sent mail body should contain "https://mail.example.org/account/recovery-token"
+    And the last sent mail body should contain "https://mail.example.org/recovery/token/regenerate?"

--- a/features/recovery.feature
+++ b/features/recovery.feature
@@ -136,3 +136,58 @@ Feature: Recovery
   Scenario: Deep-link regeneration rejects tampered signatures
     When I am on "/recovery/token/regenerate?user=1&_expiration=9999999999&_hash=invalid"
     Then the response status code should be 403
+
+  @recovery
+  Scenario: Deep-link regeneration re-encrypts an existing mailcrypt key
+    Given the User "user@example.org" has a mailcrypt secret box for password "passwordtest"
+    And I have a signed recovery-token regenerate URL for "user@example.org" as placeholder "regenerate_url"
+    When I am on "regenerate_url"
+    And I fill in "recovery_token_regenerate[password]" with "passwordtest"
+    And I press "recovery_token_regenerate[submit]"
+
+    Then I should be on "/recovery/recovery_token/ack"
+    And I should see text matching "Your new recovery token has been generated."
+
+  @recovery
+  Scenario: Deep-link regeneration rejects wrong password when a mailcrypt box exists
+    Given the User "user@example.org" has a mailcrypt secret box for password "passwordtest"
+    And I have a signed recovery-token regenerate URL for "user@example.org" as placeholder "regenerate_url"
+    When I am on "regenerate_url"
+    And I fill in "recovery_token_regenerate[password]" with "wrong-password"
+    And I press "recovery_token_regenerate[submit]"
+
+    Then I should see text matching "The password you entered is incorrect"
+
+  @recovery
+  Scenario: Deep-link regeneration requires TOTP when two-factor auth is enabled
+    Given the following User exists:
+      | email             | password     | roles     | totpConfirmed | totpSecret       | recoverySecretBox                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | recoveryStartTime | totp_backup_codes |
+      | twofa@example.org | passwordtest | ROLE_USER | 1             | JBSWY3DPEHPK3PXP | jsMdwp9tMK+6x1wuaWbtW67pJxSCYZTWOGhFL12LVMPAIWnR5Zjoe8pAdkUcg/J/S16xEqAvD6uWaBSw43aUk03TXdGKb1mW67dTSf/1UcG98meaIuyY+RrvhQn7KRKQ97PYb40T9BHP77GQkO0EajaNUBSodQpNDoZ3flZHe5wxfiZs6822HRe1hNtuURv/8sRSQG859ff0w4cdaqcd2hBbo0nQT1wDtjLN7t2rbtUeXemI+1tfMXiEK+wTu22Zkv/LiyZSBrhW8hdZBYri1O4nB4XwFsRILDj6ei7gZkebcoT0YwdZE1KNmKmjOxTjG78UJrCyp0uw+HuI2A3iA3wAbxCTJODkGuMVdJdG0fFF/k5PgAUt2rWrLmQEQs3jJQNKh5uy6bCoVnSmmfaRAWBj7klDgV98PJWr4D+K1ZrWngS/wCO4AuM7NiStGUR3IUZKhfLrAA5KBBva5LOrxyn+u8TVY6K9gaOvKLfl0DIYHKJtntiMRjNvoAHlaCpO9F2VZBjwIOsybVh6Dul+vclFMWNMtm10aHS9fRyk9t0j4rTELCV65ORKWHQLirlyhdUjDpQ/wy867h9aiNP2QfgRrQG3t5Dyh9Xg6b0b+RpqHQ5FJIxsL2ZNm73JoAXYnMbqep0idBXUZkdeOD++ezg7e+qsl6Zkvm6dqj+Cp8UHV0sNY5o0E3rMxZeh79Tu6TxvADNnRPdMnMWPssjppU3jHzdvGEkXViDGN3V2X140cy6RqH79Wg== | NOW               | true              |
+    And I have a signed recovery-token regenerate URL for "twofa@example.org" as placeholder "regenerate_url"
+    When I am on "regenerate_url"
+    Then I should see text matching "Authentication code"
+
+    When I fill in "recovery_token_regenerate[password]" with "passwordtest"
+    And I fill in "recovery_token_regenerate[totpCode]" with "000000"
+    And I press "recovery_token_regenerate[submit]"
+    Then I should see text matching "two-factor authentication code you entered is invalid"
+
+  @recovery
+  Scenario: Deep-link regeneration accepts a TOTP backup code and consumes it
+    Given the following User exists:
+      | email               | password     | roles     | totpConfirmed | totpSecret       | recoverySecretBox                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | recoveryStartTime | totp_backup_codes |
+      | backups@example.org | passwordtest | ROLE_USER | 1             | JBSWY3DPEHPK3PXP | jsMdwp9tMK+6x1wuaWbtW67pJxSCYZTWOGhFL12LVMPAIWnR5Zjoe8pAdkUcg/J/S16xEqAvD6uWaBSw43aUk03TXdGKb1mW67dTSf/1UcG98meaIuyY+RrvhQn7KRKQ97PYb40T9BHP77GQkO0EajaNUBSodQpNDoZ3flZHe5wxfiZs6822HRe1hNtuURv/8sRSQG859ff0w4cdaqcd2hBbo0nQT1wDtjLN7t2rbtUeXemI+1tfMXiEK+wTu22Zkv/LiyZSBrhW8hdZBYri1O4nB4XwFsRILDj6ei7gZkebcoT0YwdZE1KNmKmjOxTjG78UJrCyp0uw+HuI2A3iA3wAbxCTJODkGuMVdJdG0fFF/k5PgAUt2rWrLmQEQs3jJQNKh5uy6bCoVnSmmfaRAWBj7klDgV98PJWr4D+K1ZrWngS/wCO4AuM7NiStGUR3IUZKhfLrAA5KBBva5LOrxyn+u8TVY6K9gaOvKLfl0DIYHKJtntiMRjNvoAHlaCpO9F2VZBjwIOsybVh6Dul+vclFMWNMtm10aHS9fRyk9t0j4rTELCV65ORKWHQLirlyhdUjDpQ/wy867h9aiNP2QfgRrQG3t5Dyh9Xg6b0b+RpqHQ5FJIxsL2ZNm73JoAXYnMbqep0idBXUZkdeOD++ezg7e+qsl6Zkvm6dqj+Cp8UHV0sNY5o0E3rMxZeh79Tu6TxvADNnRPdMnMWPssjppU3jHzdvGEkXViDGN3V2X140cy6RqH79Wg== | NOW               | true              |
+    And I have a signed recovery-token regenerate URL for "backups@example.org" as placeholder "regenerate_url"
+    When I am on "regenerate_url"
+    And I fill in "recovery_token_regenerate[password]" with "passwordtest"
+    And I fill field "recovery_token_regenerate[totpCode]" with the first TOTP backup code
+    And I press "recovery_token_regenerate[submit]"
+
+    Then I should be on "/recovery/recovery_token/ack"
+
+  @recovery
+  Scenario: Deep-link regeneration returns 404 for a soft-deleted user
+    Given I have a signed recovery-token regenerate URL for "user@example.org" as placeholder "regenerate_url"
+    And the User "user@example.org" is soft-deleted
+    When I am on "regenerate_url"
+    Then the response status code should be 404

--- a/features/recovery.feature
+++ b/features/recovery.feature
@@ -108,3 +108,31 @@ Feature: Recovery
 
     Then I should be on "/recovery"
     And I should see text matching "This token has an invalid format."
+
+  @recovery
+  Scenario: Regenerate recovery token via signed mail link in a single password entry
+    Given I have a signed recovery-token regenerate URL for "user@example.org" as placeholder "regenerate_url"
+    When I am on "regenerate_url"
+    Then the response status code should be 200
+    And I should see text matching "Create a new recovery token"
+    When I fill in "recovery_token_regenerate[password]" with "passwordtest"
+    And I press "recovery_token_regenerate[submit]"
+
+    Then I should be on "/recovery/recovery_token/ack"
+    And I should see text matching "Your new recovery token has been generated."
+    And the response status code should be 200
+
+  @recovery
+  Scenario: Deep-link regeneration rejects a wrong password without generating a new token
+    Given I have a signed recovery-token regenerate URL for "user@example.org" as placeholder "regenerate_url"
+    When I am on "regenerate_url"
+    And I fill in "recovery_token_regenerate[password]" with "wrong-password"
+    And I press "recovery_token_regenerate[submit]"
+
+    Then I should see text matching "The password you entered is incorrect"
+    And the response status code should be 200
+
+  @recovery
+  Scenario: Deep-link regeneration rejects tampered signatures
+    When I am on "/recovery/token/regenerate?user=1&_expiration=9999999999&_hash=invalid"
+    Then the response status code should be 403

--- a/src/Controller/RecoveryTokenRegenerateController.php
+++ b/src/Controller/RecoveryTokenRegenerateController.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Form\Model\RecoveryTokenRegenerate;
+use App\Form\RecoveryTokenRegenerateType;
+use App\Handler\MailCryptKeyHandler;
+use App\Handler\RecoveryTokenHandler;
+use App\Handler\UserAuthenticationHandler;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use LogicException;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class RecoveryTokenRegenerateController extends AbstractController
+{
+    public function __construct(
+        private readonly UriSigner $uriSigner,
+        private readonly UserRepository $userRepository,
+        private readonly UserAuthenticationHandler $authenticationHandler,
+        private readonly TotpAuthenticatorInterface $totpAuthenticator,
+        private readonly MailCryptKeyHandler $mailCryptKeyHandler,
+        private readonly RecoveryTokenHandler $recoveryTokenHandler,
+        private readonly EntityManagerInterface $manager,
+    ) {
+    }
+
+    #[Route(
+        path: '/recovery/token/regenerate',
+        name: 'recovery_token_regenerate',
+        methods: ['GET'],
+    )]
+    public function show(Request $request): Response
+    {
+        $user = $this->verifyRequestAndLoadUser($request);
+
+        $form = $this->createForm(
+            RecoveryTokenRegenerateType::class,
+            new RecoveryTokenRegenerate(),
+            [
+                'action' => $request->getRequestUri(),
+                'method' => 'post',
+                'requires_totp' => $user->isTotpAuthenticationEnabled(),
+            ],
+        );
+
+        return $this->render('Recovery/token_regenerate.html.twig', [
+            'form' => $form,
+            'user' => $user,
+        ]);
+    }
+
+    #[Route(
+        path: '/recovery/token/regenerate',
+        name: 'recovery_token_regenerate_submit',
+        methods: ['POST'],
+    )]
+    public function submit(Request $request): Response
+    {
+        $user = $this->verifyRequestAndLoadUser($request);
+        $requiresTotp = $user->isTotpAuthenticationEnabled();
+
+        $data = new RecoveryTokenRegenerate();
+        $form = $this->createForm(
+            RecoveryTokenRegenerateType::class,
+            $data,
+            ['requires_totp' => $requiresTotp],
+        );
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            if (null === $this->authenticationHandler->authenticate($user, $data->getPassword())) {
+                $this->addFlash('error', 'flashes.password-confirmation-failed');
+
+                return $this->render('Recovery/token_regenerate.html.twig', [
+                    'form' => $form,
+                    'user' => $user,
+                ]);
+            }
+
+            if ($requiresTotp && !$this->verifyTotp($user, (string) $data->getTotpCode())) {
+                $this->addFlash('error', 'flashes.twofactor-code-invalid');
+
+                return $this->render('Recovery/token_regenerate.html.twig', [
+                    'form' => $form,
+                    'user' => $user,
+                ]);
+            }
+
+            try {
+                $this->regenerateRecoveryToken($user, $data->getPassword());
+            } catch (Exception) {
+                $this->addFlash('error', 'flashes.password-confirmation-failed');
+
+                return $this->render('Recovery/token_regenerate.html.twig', [
+                    'form' => $form,
+                    'user' => $user,
+                ]);
+            }
+
+            if (null === $recoveryToken = $user->getPlainRecoveryToken()) {
+                throw new LogicException('plainRecoveryToken should not be null');
+            }
+
+            $user->eraseCredentials();
+            $this->addFlash('success', 'flashes.recovery-token-regenerated');
+
+            return $this->redirectToRoute('recovery_recovery_token_ack', [
+                'recoveryToken' => $recoveryToken,
+            ]);
+        }
+
+        return $this->render('Recovery/token_regenerate.html.twig', [
+            'form' => $form,
+            'user' => $user,
+        ]);
+    }
+
+    private function verifyRequestAndLoadUser(Request $request): User
+    {
+        if (!$this->uriSigner->check($request->getRequestUri())) {
+            throw new AccessDeniedHttpException('Invalid or expired recovery link.');
+        }
+
+        $userId = $request->query->getInt('user');
+        if ($userId <= 0) {
+            throw new AccessDeniedHttpException('Invalid recovery link.');
+        }
+
+        $user = $this->userRepository->find($userId);
+        if (!$user instanceof User || $user->isDeleted()) {
+            throw new NotFoundHttpException('User not found.');
+        }
+
+        return $user;
+    }
+
+    private function verifyTotp(User $user, string $code): bool
+    {
+        if ('' === $code) {
+            return false;
+        }
+
+        if ($this->totpAuthenticator->checkCode($user, $code)) {
+            return true;
+        }
+
+        if ($user->isBackupCode($code)) {
+            $user->invalidateBackupCode($code);
+            $this->manager->flush();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Rotate the recovery token, re-encrypting the MailCrypt private key when present.
+     *
+     * @throws Exception on password mismatch against an existing MailCrypt secret box
+     */
+    private function regenerateRecoveryToken(User $user, string $password): void
+    {
+        if ($user->hasMailCryptSecretBox()) {
+            $user->setPlainMailCryptPrivateKey($this->mailCryptKeyHandler->decrypt($user, $password));
+        } else {
+            $this->mailCryptKeyHandler->create($user, $password);
+        }
+
+        $this->recoveryTokenHandler->create($user);
+    }
+}

--- a/src/Form/Model/RecoveryTokenRegenerate.php
+++ b/src/Form/Model/RecoveryTokenRegenerate.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Model;
+
+final class RecoveryTokenRegenerate
+{
+    private string $password = '';
+
+    private ?string $totpCode = null;
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): void
+    {
+        $this->password = $password;
+    }
+
+    public function getTotpCode(): ?string
+    {
+        return $this->totpCode;
+    }
+
+    public function setTotpCode(?string $totpCode): void
+    {
+        $this->totpCode = $totpCode;
+    }
+}

--- a/src/Form/RecoveryTokenRegenerateType.php
+++ b/src/Form/RecoveryTokenRegenerateType.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Form\Model\RecoveryTokenRegenerate;
+use Override;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @extends AbstractType<RecoveryTokenRegenerate>
+ */
+final class RecoveryTokenRegenerateType extends AbstractType
+{
+    public const string NAME = 'recovery_token_regenerate';
+
+    #[Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('password', PasswordType::class, [
+                'label' => 'form.password',
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'form.generate-recovery-token',
+            ]);
+
+        if ($options['requires_totp']) {
+            $builder->add('totpCode', TextType::class, [
+                'label' => 'form.twofactor-code',
+                'required' => true,
+                'attr' => [
+                    'autocomplete' => 'one-time-code',
+                    'inputmode' => 'numeric',
+                ],
+            ]);
+        }
+    }
+
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => RecoveryTokenRegenerate::class,
+            'requires_totp' => false,
+        ]);
+        $resolver->setAllowedTypes('requires_totp', 'bool');
+    }
+
+    #[Override]
+    public function getBlockPrefix(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Mail/RecoveryProcessMailer.php
+++ b/src/Mail/RecoveryProcessMailer.php
@@ -9,16 +9,25 @@ use App\Handler\MailHandler;
 use App\Service\SettingsService;
 use DateInterval;
 use IntlDateFormatter;
+use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class RecoveryProcessMailer
 {
+    /**
+     * Expiry window for the one-click recovery-token regeneration link.
+     * Matches RecoveryHandler::PROCESS_EXPIRE so the link stays usable
+     * as long as the recovery process itself is still valid.
+     */
+    private const string REGENERATE_LINK_TTL = 'P30D';
+
     public function __construct(
         private MailHandler $handler,
         private TranslatorInterface $translator,
         private SettingsService $settingsService,
         private UrlGeneratorInterface $urlGenerator,
+        private UriSigner $uriSigner,
     ) {
     }
 
@@ -28,12 +37,12 @@ final readonly class RecoveryProcessMailer
         $formatter = IntlDateFormatter::create($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
         $time = $formatter->format($user->getRecoveryStartTime()->add(new DateInterval('P2D')));
 
-        $body = $this->buildBody($locale, $email, $time);
+        $body = $this->buildBody($user, $locale, $email, $time);
         $subject = $this->buildSubject($locale, $email);
         $this->handler->send($email, $body, $subject);
     }
 
-    private function buildBody(string $locale, string $email, string $time): string
+    private function buildBody(User $user, string $locale, string $email, string $time): string
     {
         // Host from the admin-editable `app_url` setting, path from the router. This keeps
         // a single source of truth for the host and works in background workers where no
@@ -47,11 +56,22 @@ final readonly class RecoveryProcessMailer
                 '%email%' => $email,
                 '%time%' => $time,
                 '%recovery_url%' => $appUrl.$this->urlGenerator->generate('recovery', [], UrlGeneratorInterface::ABSOLUTE_PATH),
-                '%recovery_token_url%' => $appUrl.$this->urlGenerator->generate('account_recovery_token', [], UrlGeneratorInterface::ABSOLUTE_PATH),
+                '%recovery_token_url%' => $appUrl.$this->buildSignedRegeneratePath($user),
             ],
             null,
             $locale
         );
+    }
+
+    private function buildSignedRegeneratePath(User $user): string
+    {
+        $path = $this->urlGenerator->generate(
+            'recovery_token_regenerate',
+            ['user' => $user->getId()],
+            UrlGeneratorInterface::ABSOLUTE_PATH,
+        );
+
+        return $this->uriSigner->sign($path, new DateInterval(self::REGENERATE_LINK_TTL));
     }
 
     private function buildSubject(string $locale, string $email): string

--- a/templates/Recovery/token_regenerate.html.twig
+++ b/templates/Recovery/token_regenerate.html.twig
@@ -1,0 +1,33 @@
+{% extends 'Recovery/recovery.html.twig' %}
+
+{% block step_title %}{{ "recovery-token-regenerate.headline"|trans }}{% endblock %}
+
+{% block step_description %}
+    <p class="text-gray-600 dark:text-gray-300">
+        {{ "recovery-token-regenerate.lead"|trans({'%email%': user.email}) }}
+    </p>
+{% endblock %}
+
+{% block recovery_content %}
+    {{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
+    {{ form_errors(form) }}
+
+    <div>
+        {{ form_label(form.password, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+        {{ form_errors(form.password) }}
+        {{ form_widget(form.password, {'attr': {'placeholder': 'Password'|trans, 'autocomplete': 'current-password'}}) }}
+    </div>
+
+    {% if form.totpCode is defined %}
+        <div>
+            {{ form_label(form.totpCode, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'}}) }}
+            {{ form_errors(form.totpCode) }}
+            {{ form_widget(form.totpCode) }}
+        </div>
+    {% endif %}
+
+    <div class="pt-4">
+        {{ form_widget(form.submit, {'attr': {'class': 'w-full'}}) }}
+    </div>
+    {{ form_end(form) }}
+{% endblock %}

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -653,6 +653,47 @@ class FeatureContext extends MinkContext
     }
 
     /**
+     * @Given /^the User "([^"]*)" has a mailcrypt secret box for password "([^"]*)"$/
+     */
+    public function theUserHasAMailcryptSecretBox(string $email, string $password): void
+    {
+        $user = $this->getUserRepository()->findByEmail($email);
+        if (null === $user) {
+            throw new RuntimeException(sprintf('User "%s" does not exist', $email));
+        }
+
+        $this->getContainer()
+            ->get(\App\Handler\MailCryptKeyHandler::class)
+            ->create($user, $password);
+    }
+
+    /**
+     * @Given /^the User "([^"]*)" is soft-deleted$/
+     */
+    public function theUserIsSoftDeleted(string $email): void
+    {
+        $user = $this->getUserRepository()->findByEmail($email);
+        if (null === $user) {
+            throw new RuntimeException(sprintf('User "%s" does not exist', $email));
+        }
+
+        $user->setDeleted(true);
+        $this->manager->flush();
+    }
+
+    /**
+     * @When /^I fill field "([^"]*)" with the first TOTP backup code$/
+     */
+    public function iFillFieldWithFirstTotpBackupCode(string $fieldId): void
+    {
+        $backupCodes = $this->getPlaceholder('totp_backup_codes');
+        if (!is_array($backupCodes) || [] === $backupCodes) {
+            throw new RuntimeException('No TOTP backup codes cached');
+        }
+        $this->fillField($fieldId, $backupCodes[0]);
+    }
+
+    /**
      * @When /^I generate a TOTP code from "([^"]*)" and fill to field "([^"]*)"/
      */
     public function iGenerateTotpCodeFromSecret(string $placeholder, string $field): void

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -28,6 +28,7 @@ use Behat\Mink\Driver\BrowserKitDriver;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
+use DateInterval;
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\EntityManagerInterface;
@@ -626,6 +627,29 @@ class FeatureContext extends MinkContext
                 }
             }
         }
+    }
+
+    /**
+     * @Given /^I have a signed recovery-token regenerate URL for "([^"]*)" as placeholder "([^"]*)"$/
+     */
+    public function iHaveASignedRecoveryTokenRegenerateUrl(string $email, string $placeholder): void
+    {
+        $user = $this->getUserRepository()->findByEmail($email);
+        if (null === $user) {
+            throw new RuntimeException(sprintf('User "%s" does not exist', $email));
+        }
+
+        $container = $this->getContainer();
+        $urlGenerator = $container->get('router');
+        $uriSigner = $container->get('uri_signer');
+
+        $path = $urlGenerator->generate(
+            'recovery_token_regenerate',
+            ['user' => $user->getId()],
+            \Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_PATH,
+        );
+
+        $this->setPlaceholder($placeholder, $uriSigner->sign($path, new DateInterval('P30D')));
     }
 
     /**

--- a/tests/Form/RecoveryTokenRegenerateTypeTest.php
+++ b/tests/Form/RecoveryTokenRegenerateTypeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form;
+
+use App\Form\Model\RecoveryTokenRegenerate;
+use App\Form\RecoveryTokenRegenerateType;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class RecoveryTokenRegenerateTypeTest extends TypeTestCase
+{
+    protected function setUp(): void
+    {
+        $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
+        parent::setUp();
+    }
+
+    public function testOmitsTotpFieldByDefault(): void
+    {
+        $form = $this->factory->create(RecoveryTokenRegenerateType::class);
+
+        $children = $form->createView()->children;
+
+        self::assertArrayHasKey('password', $children);
+        self::assertArrayHasKey('submit', $children);
+        self::assertArrayNotHasKey('totpCode', $children);
+    }
+
+    public function testIncludesTotpFieldWhenRequested(): void
+    {
+        $form = $this->factory->create(RecoveryTokenRegenerateType::class, null, [
+            'requires_totp' => true,
+        ]);
+
+        $children = $form->createView()->children;
+
+        self::assertArrayHasKey('totpCode', $children);
+        self::assertSame('form.twofactor-code', $children['totpCode']->vars['label']);
+    }
+
+    public function testSubmitPasswordOnlyData(): void
+    {
+        $form = $this->factory->create(RecoveryTokenRegenerateType::class);
+
+        $form->submit(['password' => 's3cret']);
+
+        self::assertTrue($form->isSynchronized());
+        $data = $form->getData();
+        self::assertInstanceOf(RecoveryTokenRegenerate::class, $data);
+        self::assertSame('s3cret', $data->getPassword());
+        self::assertNull($data->getTotpCode());
+    }
+
+    public function testSubmitWithTotpBindsBothFields(): void
+    {
+        $form = $this->factory->create(RecoveryTokenRegenerateType::class, null, [
+            'requires_totp' => true,
+        ]);
+
+        $form->submit([
+            'password' => 's3cret',
+            'totpCode' => '123456',
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        $data = $form->getData();
+        self::assertInstanceOf(RecoveryTokenRegenerate::class, $data);
+        self::assertSame('s3cret', $data->getPassword());
+        self::assertSame('123456', $data->getTotpCode());
+    }
+}

--- a/tests/Mail/RecoveryProcessMailerTest.php
+++ b/tests/Mail/RecoveryProcessMailerTest.php
@@ -10,6 +10,7 @@ use App\Mail\RecoveryProcessMailer;
 use App\Service\SettingsService;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -38,7 +39,13 @@ class RecoveryProcessMailerTest extends TestCase
             ->method('send')
             ->with('user@example.org', 'Recovery body', 'Recovery subject');
 
-        $mailer = new RecoveryProcessMailer($handler, $translator, $settingsService, $this->createStub(UrlGeneratorInterface::class));
+        $mailer = new RecoveryProcessMailer(
+            $handler,
+            $translator,
+            $settingsService,
+            $this->createStub(UrlGeneratorInterface::class),
+            new UriSigner('secret'),
+        );
         $mailer->send($user, 'en');
     }
 
@@ -62,13 +69,20 @@ class RecoveryProcessMailerTest extends TestCase
         $handler = $this->createMock(MailHandler::class);
         $handler->expects(self::once())->method('send');
 
-        $mailer = new RecoveryProcessMailer($handler, $translator, $settingsService, $this->createStub(UrlGeneratorInterface::class));
+        $mailer = new RecoveryProcessMailer(
+            $handler,
+            $translator,
+            $settingsService,
+            $this->createStub(UrlGeneratorInterface::class),
+            new UriSigner('secret'),
+        );
         $mailer->send($user, 'de');
     }
 
     public function testSendPassesExpectedPlaceholdersToTranslator(): void
     {
         $user = new User('user@example.org');
+        $user->setId(42);
         $user->setRecoveryStartTime(new DateTimeImmutable('2026-01-15 10:00:00'));
 
         $settingsService = $this->createStub(SettingsService::class);
@@ -80,19 +94,27 @@ class RecoveryProcessMailerTest extends TestCase
         $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
         $urlGenerator->method('generate')->willReturnMap([
             ['recovery', [], UrlGeneratorInterface::ABSOLUTE_PATH, '/recovery'],
-            ['account_recovery_token', [], UrlGeneratorInterface::ABSOLUTE_PATH, '/account/recovery-token'],
+            ['recovery_token_regenerate', ['user' => 42], UrlGeneratorInterface::ABSOLUTE_PATH, '/recovery/token/regenerate?user=42'],
         ]);
+
+        $uriSigner = new UriSigner('secret');
 
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::exactly(2))
             ->method('trans')
-            ->willReturnCallback(static function (string $id, array $parameters) {
+            ->willReturnCallback(static function (string $id, array $parameters) use ($uriSigner) {
                 if ('mail.recovery-body' === $id) {
                     self::assertSame('Example Mail', $parameters['%project_name%']);
                     self::assertSame('user@example.org', $parameters['%email%']);
                     self::assertArrayHasKey('%time%', $parameters);
                     self::assertSame('https://mail.example.com/recovery', $parameters['%recovery_url%']);
-                    self::assertSame('https://mail.example.com/account/recovery-token', $parameters['%recovery_token_url%']);
+
+                    // The regenerate URL is signed and time-limited; verify it's valid
+                    // and points at the expected route with the user id.
+                    $regenerateUrl = $parameters['%recovery_token_url%'];
+                    self::assertStringStartsWith('https://mail.example.com/recovery/token/regenerate?', $regenerateUrl);
+                    self::assertStringContainsString('user=42', $regenerateUrl);
+                    self::assertTrue($uriSigner->check(substr($regenerateUrl, strlen('https://mail.example.com'))));
                 }
                 if ('mail.recovery-subject' === $id) {
                     self::assertSame('user@example.org', $parameters['%email%']);
@@ -101,7 +123,13 @@ class RecoveryProcessMailerTest extends TestCase
                 return 'translated';
             });
 
-        $mailer = new RecoveryProcessMailer($this->createStub(MailHandler::class), $translator, $settingsService, $urlGenerator);
+        $mailer = new RecoveryProcessMailer(
+            $this->createStub(MailHandler::class),
+            $translator,
+            $settingsService,
+            $urlGenerator,
+            $uriSigner,
+        );
         $mailer->send($user, 'en');
     }
 }


### PR DESCRIPTION
## Goal

Close #97: the recovery notification mail now carries a single-click link that lets the user kill an in-progress recovery and rotate their recovery token with **one** password entry.

## Before

`%recovery_token_url%` pointed at `/account/recovery-token`, which is firewall-gated. An anonymous user clicking the mail link had to:

1. log in (email + password), plus 2FA if configured,
2. re-enter the password on the regeneration form,
3. press the button to rotate the token.

Two password prompts for a panic action.

## After

The mail now contains a signed, time-limited URL at `/recovery/token/regenerate?user={id}&_expiration=…&_hash=…`. The landing page asks for the password **once**; on submit, the recovery token is rotated and the user is redirected to the existing public `recovery_recovery_token_ack` confirmation page. 2FA-enabled accounts additionally get a TOTP/backup-code field on the same form, so the security level of those accounts is unchanged.

### Signing

Uses Symfony's built-in `Symfony\Component\HttpFoundation\UriSigner` (HMAC over `APP_SECRET`). Expiry is 30 days, matching `RecoveryHandler::PROCESS_EXPIRE` so the link stays useful for the same window as the recovery process itself. Tampered or expired URLs return 403.

### Password / TOTP verification

- Password is verified via `UserAuthenticationHandler::authenticate()`. Wrong password → flash "password incorrect", no state change.
- If `User::isTotpAuthenticationEnabled()`, the form also validates a TOTP code or consumes a one-shot backup code via `isBackupCode()` + `invalidateBackupCode()`.

### Edge cases

- **Link clicked within the 48h waiting period:** token is rotated, `recoveryStartTime` is cleared, the attacker's in-flight recovery is dead.
- **Link clicked after the attacker already completed `/recovery/reset_password`:** the old password no longer works → generic "password incorrect" flash, no state change. We deliberately do not distinguish this from a mis-typed password because doing so would leak "this account's password has been rotated" to whoever holds the mail.
- **Link older than 30 days:** 403.

## Files

- **New:** `src/Controller/RecoveryTokenRegenerateController.php`, `src/Form/Model/RecoveryTokenRegenerate.php`, `src/Form/RecoveryTokenRegenerateType.php`, `templates/Recovery/token_regenerate.html.twig`.
- **Modified:** `src/Mail/RecoveryProcessMailer.php` — inject `UriSigner`, build the signed path; `default_translations/{en,de}/messages.*.yml` — new flash/headline/lead/2FA-label keys; `features/recovery.feature` + `tests/Behat/FeatureContext.php` — 8 new scenarios (happy path, wrong password, tampered sig, existing mailcrypt box, wrong password against mailcrypt box, TOTP wrong code, backup code, soft-deleted user) and helper steps; `tests/Mail/RecoveryProcessMailerTest.php` — updated for the new ctor, asserts the signed URL verifies; `tests/Form/RecoveryTokenRegenerateTypeTest.php` — form type coverage.

## Test plan

- [x] `bin/phpunit` — 988 tests, 3718 assertions, green.
- [x] `bin/behat --tags=@recovery` — 16 scenarios (8 existing + 8 new), green.
- [x] Full `bin/behat` suite — only unrelated chromedriver/Panther failures on this machine; no other regressions.
- [x] `bin/psalm` — no errors.
- [x] `bin/php-cs-fixer check` — no style issues.
- [x] `bin/rector --dry-run` — clean.
- [x] Manual QA via Chrome DevTools MCP: logged in as `user@example.org`, generated a token, logged out, triggered recovery, pulled the signed link from Mailcatcher, clicked it anonymously, entered the password **once** → landed on `/recovery/recovery_token/ack` with a new token. Old token rejected, new token accepted on `/recovery`.
- [x] Manual QA: tampered `_hash` → 403 "Invalid or expired recovery link.".
- [x] Manual QA: wrong password on a valid signed URL → "The password you entered is incorrect. Please try again." flash, no token change.
- [ ] Manual QA: same flow with 2FA enabled end-to-end (covered by Behat; not yet exercised in the browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)