### PR TITLE
🐛 Fix stale SMTP quota cache on user/alias update and global settings change

### DIFF
--- a/src/Controller/Api/PostfixController.php
+++ b/src/Controller/Api/PostfixController.php
@@ -97,26 +97,20 @@ final class PostfixController extends AbstractController
     #[Route(path: '/api/postfix/smtp_quota/{email}', name: 'api_postfix_get_smtp_quota', methods: ['GET'], stateless: true)]
     public function getSmtpQuota(string $email): Response
     {
-        $result = $this->cache->get(UserCacheKey::POSTFIX_QUOTA->key($email), function (ItemInterface $item) use ($email) {
+        $limits = $this->cache->get(UserCacheKey::POSTFIX_QUOTA->key($email), function (ItemInterface $item) use ($email) {
             $item->expiresAfter(UserCacheKey::TTL);
 
-            $limits = $this->userRepository->findSmtpQuotaLimitsByEmail($email)
+            return $this->userRepository->findSmtpQuotaLimitsByEmail($email)
                 ?? $this->aliasRepository->findSmtpQuotaLimitsBySource($email);
-
-            if ($limits === null) {
-                return null;
-            }
-
-            return [
-                'per_hour' => $limits['per_hour'] ?? (int) $this->settingsService->get('smtp_quota_limit_per_hour', 0),
-                'per_day' => $limits['per_day'] ?? (int) $this->settingsService->get('smtp_quota_limit_per_day', 0),
-            ];
         });
 
-        if ($result === null) {
+        if ($limits === null) {
             return $this->json(['error' => 'User not found'], Response::HTTP_NOT_FOUND);
         }
 
-        return $this->json($result);
+        return $this->json([
+            'per_hour' => $limits['per_hour'] ?? (int) $this->settingsService->get('smtp_quota_limit_per_hour', 0),
+            'per_day' => $limits['per_day'] ?? (int) $this->settingsService->get('smtp_quota_limit_per_day', 0),
+        ]);
     }
 }

--- a/src/EntityListener/InvalidateAliasCacheListener.php
+++ b/src/EntityListener/InvalidateAliasCacheListener.php
@@ -10,14 +10,15 @@ use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\Events;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[AsEntityListener(event: Events::postPersist, method: 'postPersist', entity: Alias::class)]
+#[AsEntityListener(event: Events::postPersist, method: 'invalidate', entity: Alias::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidate', entity: Alias::class)]
 final readonly class InvalidateAliasCacheListener
 {
     public function __construct(private MessageBusInterface $bus)
     {
     }
 
-    public function postPersist(Alias $alias): void
+    public function invalidate(Alias $alias): void
     {
         $this->bus->dispatch(new InvalidateAliasCache($alias->getSource()));
     }

--- a/src/EntityListener/InvalidateUserCacheListener.php
+++ b/src/EntityListener/InvalidateUserCacheListener.php
@@ -10,14 +10,15 @@ use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\Events;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[AsEntityListener(event: Events::postPersist, method: 'postPersist', entity: User::class)]
+#[AsEntityListener(event: Events::postPersist, method: 'invalidate', entity: User::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidate', entity: User::class)]
 final readonly class InvalidateUserCacheListener
 {
     public function __construct(private MessageBusInterface $bus)
     {
     }
 
-    public function postPersist(User $user): void
+    public function invalidate(User $user): void
     {
         $this->bus->dispatch(new InvalidateUserCache($user->getEmail()));
     }

--- a/tests/EntityListener/InvalidateAliasCacheListenerTest.php
+++ b/tests/EntityListener/InvalidateAliasCacheListenerTest.php
@@ -7,7 +7,6 @@ namespace App\Tests\EntityListener;
 use App\Entity\Alias;
 use App\EntityListener\InvalidateAliasCacheListener;
 use App\Message\InvalidateAliasCache;
-use Doctrine\ORM\Event\PostPersistEventArgs;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -28,9 +27,25 @@ class InvalidateAliasCacheListenerTest extends TestCase
             }))
             ->willReturn(new Envelope(new InvalidateAliasCache($source)));
 
-        $args = $this->createStub(PostPersistEventArgs::class);
+        $listener = new InvalidateAliasCacheListener($bus);
+        $listener->invalidate($alias);
+    }
+
+    public function testPostUpdate(): void
+    {
+        $source = 'alias@example.org';
+        $alias = new Alias();
+        $alias->setSource($source);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(static function (InvalidateAliasCache $message) use ($source): bool {
+                return $message->source === $source;
+            }))
+            ->willReturn(new Envelope(new InvalidateAliasCache($source)));
 
         $listener = new InvalidateAliasCacheListener($bus);
-        $listener->postPersist($alias, $args);
+        $listener->invalidate($alias);
     }
 }

--- a/tests/EntityListener/InvalidateUserCacheListenerTest.php
+++ b/tests/EntityListener/InvalidateUserCacheListenerTest.php
@@ -7,7 +7,6 @@ namespace App\Tests\EntityListener;
 use App\Entity\User;
 use App\EntityListener\InvalidateUserCacheListener;
 use App\Message\InvalidateUserCache;
-use Doctrine\ORM\Event\PostPersistEventArgs;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -27,9 +26,24 @@ class InvalidateUserCacheListenerTest extends TestCase
             }))
             ->willReturn(new Envelope(new InvalidateUserCache($email)));
 
-        $args = $this->createStub(PostPersistEventArgs::class);
+        $listener = new InvalidateUserCacheListener($bus);
+        $listener->invalidate($user);
+    }
+
+    public function testPostUpdate(): void
+    {
+        $email = 'user@example.org';
+        $user = new User($email);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(static function (InvalidateUserCache $message) use ($email): bool {
+                return $message->email === $email;
+            }))
+            ->willReturn(new Envelope(new InvalidateUserCache($email)));
 
         $listener = new InvalidateUserCacheListener($bus);
-        $listener->postPersist($user, $args);
+        $listener->invalidate($user);
     }
 }


### PR DESCRIPTION
## Summary

The Postfix API endpoint `/api/postfix/smtp_quota/{email}` could return stale SMTP quota limits for up to 24 hours (cache TTL) in three scenarios:

1. **User quota update**: `InvalidateUserCacheListener` only listened on `postPersist`, so updating an existing user's `smtpQuotaLimits` did not invalidate the cache.
2. **Alias quota update**: Same issue with `InvalidateAliasCacheListener`.
3. **Global settings change**: The global fallback values (`smtp_quota_limit_per_hour`/`smtp_quota_limit_per_day`) were resolved *inside* the cache callback and baked into the cached result. Changing these settings had no effect until cache expiry.

## Fix

- **PostfixController**: Move global settings fallback outside the cache callback. The cache now only stores the per-user/alias DB values; the global fallback is applied on every request.
- **InvalidateUserCacheListener / InvalidateAliasCacheListener**: Add `postUpdate` event listener alongside the existing `postPersist`.

---
<sub>The changes and the PR were generated by OpenCode.</sub>