### PR TITLE
✨ Add weekly and monthly active user metrics for Prometheus

### DIFF
--- a/src/Command/MetricsCommand.php
+++ b/src/Command/MetricsCommand.php
@@ -9,6 +9,8 @@ use App\Repository\DomainRepository;
 use App\Repository\OpenPgpKeyRepository;
 use App\Repository\UserRepository;
 use App\Repository\VoucherRepository;
+use DateInterval;
+use DateTimeImmutable;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -71,6 +73,17 @@ final class MetricsCommand extends Command
         $output->writeln('# HELP userli_users_twofactor_total Total number of users with enabled two factor authentication');
         $output->writeln('# TYPE userli_users_twofactor_total gauge');
         $output->writeln('userli_users_twofactor_total '.$usersTwofactorTotal);
+
+        $now = new DateTimeImmutable();
+        $weeklyActiveUsers = $this->userRepository->countActiveUsersSince($now->sub(new DateInterval('P7D')));
+        $output->writeln('# HELP userli_users_weekly_active_total Number of users who logged in within the last 7 days');
+        $output->writeln('# TYPE userli_users_weekly_active_total gauge');
+        $output->writeln('userli_users_weekly_active_total '.$weeklyActiveUsers);
+
+        $monthlyActiveUsers = $this->userRepository->countActiveUsersSince($now->sub(new DateInterval('P30D')));
+        $output->writeln('# HELP userli_users_monthly_active_total Number of users who logged in within the last 30 days');
+        $output->writeln('# TYPE userli_users_monthly_active_total gauge');
+        $output->writeln('userli_users_monthly_active_total '.$monthlyActiveUsers);
 
         $redeemedVouchersTotal = $this->voucherRepository->countRedeemedVouchers();
         $unredeemedVouchersTotal = $this->voucherRepository->countUnredeemedVouchers();

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -228,6 +228,18 @@ final class UserRepository extends ServiceEntityRepository implements PasswordUp
             ->getOneOrNullResult();
     }
 
+    public function countActiveUsersSince(DateTimeImmutable $since): int
+    {
+        return (int) $this->createQueryBuilder('u')
+            ->select('COUNT(u.id)')
+            ->where('u.deleted = :deleted')
+            ->andWhere('u.lastLoginTime >= :since')
+            ->setParameter('deleted', false)
+            ->setParameter('since', $since)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
     public function countUsersWithTwofactor(): int
     {
         return (int) $this->createQueryBuilder('u')

--- a/tests/Command/MetricsCommandTest.php
+++ b/tests/Command/MetricsCommandTest.php
@@ -23,6 +23,7 @@ class MetricsCommandTest extends TestCase
         $userRepository->method('countUsersWithRecoveryToken')->willReturn(5);
         $userRepository->method('countUsersWithMailCrypt')->willReturn(7);
         $userRepository->method('countUsersWithTwofactor')->willReturn(9);
+        $userRepository->method('countActiveUsersSince')->willReturn(42);
 
         $openPgpKeyRepository = $this->createStub(OpenPgpKeyRepository::class);
         $openPgpKeyRepository->method('countKeys')->willReturn(2);
@@ -50,6 +51,8 @@ class MetricsCommandTest extends TestCase
         self::assertStringContainsString('userli_users_recovery_token_total 5', $output);
         self::assertStringContainsString('userli_users_mailcrypt_total 7', $output);
         self::assertStringContainsString('userli_users_twofactor_total 9', $output);
+        self::assertStringContainsString('userli_users_weekly_active_total 42', $output);
+        self::assertStringContainsString('userli_users_monthly_active_total 42', $output);
         self::assertStringContainsString('userli_vouchers_total{type="unredeemed"} 7', $output);
         self::assertStringContainsString('userli_vouchers_total{type="redeemed"} 1', $output);
         self::assertStringContainsString('userli_domains_total 6', $output);


### PR DESCRIPTION
## Summary

Add WAU (Weekly Active Users) and MAU (Monthly Active Users) Prometheus metrics based on `lastLoginTime`, providing visibility into user engagement trends.

### Changes

- New `UserRepository::countActiveUsersSince()` method counts non-deleted users with a login since a given date
- `MetricsCommand` now exports `userli_users_weekly_active_total` (7 days) and `userli_users_monthly_active_total` (30 days)
- Test updated to cover new metrics output

---
<sub>The changes and the PR were generated by OpenCode.</sub>