### PR TITLE
✨ Add WAU and MAU stats to admin dashboard

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -534,6 +534,8 @@ admin:
     stats:
       users: Benutzer:innen
       recent_users: Neue Konten (7 Tage)
+      weekly_active_users: Aktive Benutzer:innen (7 Tage)
+      monthly_active_users: Aktive Benutzer:innen (30 Tage)
       aliases: Aliase
       domains: Domains
       vouchers_redeemed: Einladungscodes eingelöst

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -559,6 +559,8 @@ admin:
     stats:
       users: Users
       recent_users: New accounts (7 days)
+      weekly_active_users: Active users (7 days)
+      monthly_active_users: Active users (30 days)
       aliases: Aliases
       domains: Domains
       vouchers_redeemed: Invite codes redeemed

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -10,6 +10,7 @@ use App\Repository\DomainRepository;
 use App\Repository\OpenPgpKeyRepository;
 use App\Repository\UserRepository;
 use App\Repository\VoucherRepository;
+use DateTimeImmutable;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -31,6 +32,8 @@ final class DashboardController extends AbstractController
         $stats = [
             'users' => $this->userRepository->countUsers(),
             'recent_users' => $this->userRepository->countRecentUsers(),
+            'weekly_active_users' => $this->userRepository->countActiveUsersSince(new DateTimeImmutable('-7 days')),
+            'monthly_active_users' => $this->userRepository->countActiveUsersSince(new DateTimeImmutable('-30 days')),
             'aliases' => $this->aliasRepository->countByFilters(),
             'openpgp_keys' => $this->openPgpKeyRepository->countKeys(),
         ];

--- a/templates/Admin/Dashboard/index.html.twig
+++ b/templates/Admin/Dashboard/index.html.twig
@@ -32,6 +32,20 @@
                 } %}
 
                 {% include 'Admin/Dashboard/_stat_card.html.twig' with {
+                    icon: 'heroicons:arrow-trending-up',
+                    icon_color: 'cyan',
+                    label_key: 'admin.dashboard.stats.weekly_active_users',
+                    value: stats.weekly_active_users,
+                } %}
+
+                {% include 'Admin/Dashboard/_stat_card.html.twig' with {
+                    icon: 'heroicons:arrow-trending-up',
+                    icon_color: 'teal',
+                    label_key: 'admin.dashboard.stats.monthly_active_users',
+                    value: stats.monthly_active_users,
+                } %}
+
+                {% include 'Admin/Dashboard/_stat_card.html.twig' with {
                     icon: 'heroicons:at-symbol',
                     icon_color: 'indigo',
                     label_key: 'admin.dashboard.stats.aliases',


### PR DESCRIPTION
## Summary

- Display weekly active users (WAU) and monthly active users (MAU) as tiles on the admin dashboard
- Visible to all admin roles — Domain Admins see counts filtered to their domain via the existing `DomainFilter`
- Builds on top of `UserRepository::countActiveUsersSince()` introduced in #1264

---
<sub>The changes and the PR were generated by OpenCode.</sub>