### PR TITLE
:recycle: Allow alias deletion without password confirmation

### DIFF
--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -286,6 +286,7 @@ flashes:
   voucher-creation-successful: Neuer Einladungscode erstellt.
   alias-creation-successful: Deine neue Alias-Adresse wurde erstellt.
   alias-deletion-successful: Deine Alias-Adresse wurde gelöscht.
+  alias-deletion-failed: Deine Alias-Adresse konnte nicht gelöscht werden. Bitte versuche es erneut.
   recovery-token-invalid: E-Mail-Adresse oder Wiederherstellungscode sind falsch!
   recovery-token-ack: Du hast einen Wiederherstellungscode erzeugt.
   recovery-reauthenticate: Etwas ist schief gelaufen. Bitte erneut authentifizieren!

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -290,6 +290,7 @@ flashes:
   voucher-creation-successful: New invite code created.
   alias-creation-successful: Your new alias address was created.
   alias-deletion-successful: Your alias address was deleted.
+  alias-deletion-failed: Your alias address could not be deleted. Please try again.
   recovery-token-invalid: E-mail address and/or recovery token are wrong!
   recovery-token-ack: You generated a recovery token.
   recovery-reauthenticate: Something went wrong. Please re-authenticate!

--- a/features/user.feature
+++ b/features/user.feature
@@ -95,7 +95,6 @@ Feature: User
 
     When I press the "Delete alias random_alias_4@example.org" button
     And I wait for the modal to appear
-    And I fill in "password_confirmation[password]" with "asdasd" in the modal
     And I click "Delete alias address" in the modal
     And I wait for text "Your alias address was deleted." to appear
 

--- a/src/Controller/Account/AliasController.php
+++ b/src/Controller/Account/AliasController.php
@@ -9,8 +9,6 @@ use App\Entity\User;
 use App\Exception\ValidationException;
 use App\Form\CustomAliasCreateType;
 use App\Form\Model\AliasCreate;
-use App\Form\Model\PasswordConfirmation;
-use App\Form\PasswordConfirmationType;
 use App\Form\RandomAliasCreateType;
 use App\Handler\DeleteHandler;
 use App\Service\AliasManager;
@@ -148,22 +146,17 @@ final class AliasController extends AbstractController
         #[MapEntity(class: Alias::class, expr: 'repository.findOneBy({id: id, deleted: false})')]
         Alias $alias): RedirectResponse
     {
-        $form = $this->createForm(
-            PasswordConfirmationType::class,
-            new PasswordConfirmation(),
-            ['submit_label' => 'form.delete-alias'],
-        );
-        $form->handleRequest($request);
-
-        if ($form->isValid()) {
-            $this->deleteHandler->deleteAlias($alias, $this->getUser());
-
-            $this->addFlash('success', 'flashes.alias-deletion-successful');
+        // Access is gated by the delete voter (random alias owner, or admin).
+        // Authorized deletions only need a CSRF-protected confirmation — no
+        // password re-entry.
+        if (!$this->isCsrfTokenValid('delete_alias_'.$alias->getId(), (string) $request->request->get('_token'))) {
+            $this->addFlash('error', 'flashes.alias-deletion-failed');
 
             return $this->redirectToRoute('aliases');
         }
 
-        $this->addFlash('error', 'flashes.password-confirmation-failed');
+        $this->deleteHandler->deleteAlias($alias, $this->getUser());
+        $this->addFlash('success', 'flashes.alias-deletion-successful');
 
         return $this->redirectToRoute('aliases');
     }

--- a/templates/Alias/show.html.twig
+++ b/templates/Alias/show.html.twig
@@ -10,7 +10,7 @@
 {% block page_subtitle %}{{ "index.alias-subtitle"|trans }}{% endblock %}
 
 {% block page_content %}
-    <div class="max-w-4xl mx-auto" data-controller="modal">
+    <div class="max-w-4xl mx-auto" data-controller="delete-modal">
         {# Brief motivational explanation #}
                 <div class="mb-8 text-center">
                     <p class="text-lg text-gray-600 dark:text-gray-300 leading-relaxed max-w-3xl mx-auto">
@@ -131,16 +131,21 @@
                                                     {{ ux_icon('heroicons:clipboard', {class: 'w-4 h-4'}) }}
                                                 </button>
                                                 {% if is_granted('delete', alias) %}
-                                                    <button type="button"
-                                                            data-action="modal#open"
-                                                            data-modal-action-param="{{ path('alias_delete_submit', {'id': alias.id}) }}"
-                                                            data-modal-message-param="{{ 'delete.alias.lead_specific'|trans({'%alias%': alias.source}) }}"
-                                                            class="inline-flex items-center p-2 text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/50 rounded hover:bg-red-200 dark:hover:bg-red-900 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 dark:focus:ring-offset-gray-700 transition-colors"
-                                                            title="{{ "alias.delete"|trans }}"
-                                                            aria-label="{{ "alias.delete"|trans }} {{ alias.source }}"
-                                                            data-controller="tooltip">
-                                                        {{ ux_icon('heroicons:x-mark', {class: 'w-4 h-4'}) }}
-                                                    </button>
+                                                    <form method="post"
+                                                          action="{{ path('alias_delete_submit', {'id': alias.id}) }}"
+                                                          data-action="submit->delete-modal#open"
+                                                          data-delete-modal-title-param="{{ 'delete.alias.headline_generic'|trans|e('html_attr') }}"
+                                                          data-delete-modal-message-param="{{ 'delete.alias.lead_specific'|trans({'%alias%': alias.source})|e('html_attr') }}"
+                                                          class="inline-flex">
+                                                        <input type="hidden" name="_token" value="{{ csrf_token('delete_alias_' ~ alias.id) }}">
+                                                        <button type="submit"
+                                                                class="inline-flex items-center p-2 text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/50 rounded hover:bg-red-200 dark:hover:bg-red-900 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 dark:focus:ring-offset-gray-700 transition-colors"
+                                                                title="{{ "alias.delete"|trans }}"
+                                                                aria-label="{{ "alias.delete"|trans }} {{ alias.source }}"
+                                                                data-controller="tooltip">
+                                                            {{ ux_icon('heroicons:x-mark', {class: 'w-4 h-4'}) }}
+                                                        </button>
+                                                    </form>
                                                 {% endif %}
                                             </div>
                                         </div>
@@ -261,16 +266,21 @@
                                                         aria-label="{{ "copy-to-clipboard"|trans }}">
                                                 {{ ux_icon('heroicons:clipboard', {'class': 'w-4 h-4'}) }}
                                                 </button>
-                                                <button type="button"
-                                                        data-action="modal#open"
-                                                        data-modal-action-param="{{ path('alias_delete_submit', {'id': alias.id}) }}"
-                                                        data-modal-message-param="{{ 'delete.alias.lead_specific'|trans({'%alias%': alias.source}) }}"
-                                                        class="inline-flex items-center p-2 text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/50 rounded hover:bg-red-200 dark:hover:bg-red-900 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 dark:focus:ring-offset-gray-700 transition-colors"
-                                                        title="{{ "alias.delete"|trans }}"
-                                                        aria-label="{{ "alias.delete"|trans }} {{ alias.source }}"
-                                                        data-controller="tooltip">
-                                                    {{ ux_icon('heroicons:x-mark', {'class': 'w-4 h-4'}) }}
-                                                </button>
+                                                <form method="post"
+                                                      action="{{ path('alias_delete_submit', {'id': alias.id}) }}"
+                                                      data-action="submit->delete-modal#open"
+                                                      data-delete-modal-title-param="{{ 'delete.alias.headline_generic'|trans|e('html_attr') }}"
+                                                      data-delete-modal-message-param="{{ 'delete.alias.lead_specific'|trans({'%alias%': alias.source})|e('html_attr') }}"
+                                                      class="inline-flex">
+                                                    <input type="hidden" name="_token" value="{{ csrf_token('delete_alias_' ~ alias.id) }}">
+                                                    <button type="submit"
+                                                            class="inline-flex items-center p-2 text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/50 rounded hover:bg-red-200 dark:hover:bg-red-900 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 dark:focus:ring-offset-gray-700 transition-colors"
+                                                            title="{{ "alias.delete"|trans }}"
+                                                            aria-label="{{ "alias.delete"|trans }} {{ alias.source }}"
+                                                            data-controller="tooltip">
+                                                        {{ ux_icon('heroicons:x-mark', {'class': 'w-4 h-4'}) }}
+                                                    </button>
+                                                </form>
                                             </div>
                                         </div>
                                     {% endfor %}
@@ -280,11 +290,10 @@
                     </div>
                 </div>
 
-        {# Delete alias modal #}
-        {% include '_delete_password_modal.html.twig' with {
-            modal_title: 'delete.alias.headline_generic'|trans,
-            modal_description: 'delete.alias.lead_generic'|trans,
-            modal_submit_label: 'form.delete-alias'|trans,
+        {# Delete alias modal (confirm only, no password) #}
+        {% include '_confirm_modal.html.twig' with {
+            controller_name: 'delete-modal',
+            confirm_label: 'form.delete-alias',
         } %}
     </div>
 {% endblock %}

--- a/templates/_confirm_modal.html.twig
+++ b/templates/_confirm_modal.html.twig
@@ -1,0 +1,102 @@
+{#
+    Reusable confirmation modal (no password).
+
+    Unlike _delete_password_modal.html.twig, this modal asks only for a yes/no
+    confirmation — use it for disposable actions that don't warrant password
+    re-entry (e.g. deleting a random alias). The triggering element must be a
+    real form whose submit is intercepted by `<ctrl>#open`; the confirm button
+    re-submits that form via `<ctrl>#confirm`.
+
+    Usage:
+        Wrap your page content and this include in a single element carrying the
+        controller, then point each delete form at it:
+
+            <div data-controller="delete-modal">
+              <form method="post" action="..."
+                    data-action="submit->delete-modal#open"
+                    data-delete-modal-title-param="..."
+                    data-delete-modal-message-param="...">
+                <input type="hidden" name="_token" value="...">
+                <button type="submit">Delete</button>
+              </form>
+              {% include '_confirm_modal.html.twig' with { controller_name: 'delete-modal' } %}
+            </div>
+
+    Customization (via `with`):
+        - controller_name: Stimulus controller name (default: 'modal') — use
+                           'delete-modal' when a second modal instance is needed
+                           on the same page
+        - variant:         'danger' (default) or 'info' — controls icon/button colors
+        - cancel_label:    Translation key for the cancel button (default: 'delete.cancel')
+        - confirm_label:   Translation key for the confirm button (default: 'delete.confirm')
+        - modal_id:        Unique ID for aria-labelledby (default: 'confirm-modal-title')
+#}
+{% set ctrl = controller_name|default('modal') %}
+{% set variant = variant|default('danger') %}
+{% set cancel_label = cancel_label|default('delete.cancel') %}
+{% set confirm_label = confirm_label|default('delete.confirm') %}
+{% set modal_id = modal_id|default('confirm-modal-title') %}
+
+{% if variant == 'info' %}
+    {% set icon_bg = 'bg-blue-100 dark:bg-blue-900/50' %}
+    {% set icon_color = 'text-blue-600 dark:text-blue-400' %}
+    {% set icon_name = 'heroicons:arrow-path' %}
+    {% set btn_bg = 'bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 focus:ring-blue-500' %}
+{% else %}
+    {% set icon_bg = 'bg-red-100 dark:bg-red-900/50' %}
+    {% set icon_color = 'text-red-600 dark:text-red-400' %}
+    {% set icon_name = 'heroicons:exclamation-triangle' %}
+    {% set btn_bg = 'bg-red-600 dark:bg-red-500 hover:bg-red-700 dark:hover:bg-red-600 focus:ring-red-500' %}
+{% endif %}
+
+<div data-{{ ctrl }}-target="overlay"
+     data-action="click->{{ ctrl }}#backdropClose"
+     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm opacity-0 transition-opacity duration-200"
+     aria-modal="true"
+     role="dialog"
+     aria-labelledby="{{ modal_id }}">
+
+    <div data-{{ ctrl }}-target="dialog"
+         class="relative w-full max-w-md mx-4 bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-xl opacity-0 scale-95 transition-all duration-200 transform">
+
+        <div class="p-6 sm:p-8">
+            {# Modal header #}
+            <div class="flex items-center justify-between mb-4">
+                <div class="flex items-center">
+                    <div class="w-10 h-10 {{ icon_bg }} rounded-xl flex items-center justify-center mr-3">
+                        {{ ux_icon(icon_name, {'class': 'w-5 h-5 ' ~ icon_color}) }}
+                    </div>
+                    <h3 id="{{ modal_id }}"
+                        data-{{ ctrl }}-target="title"
+                        class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    </h3>
+                </div>
+                <button type="button"
+                        data-action="{{ ctrl }}#close"
+                        class="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-200">
+                    {{ ux_icon('heroicons:x-mark', {'class': 'w-5 h-5'}) }}
+                </button>
+            </div>
+
+            {# Description #}
+            <p data-{{ ctrl }}-target="description"
+               class="text-sm text-gray-600 dark:text-gray-400 mb-6">
+            </p>
+
+            {# Action buttons #}
+            <div class="flex justify-end gap-3">
+                <button type="button"
+                        data-action="{{ ctrl }}#close"
+                        class="px-5 py-2.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-medium rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800">
+                    {{ cancel_label|trans }}
+                </button>
+                <button type="button"
+                        data-action="{{ ctrl }}#confirm"
+                        data-{{ ctrl }}-target="autofocus"
+                        class="px-5 py-2.5 {{ btn_bg }} text-white font-medium rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800">
+                    {{ confirm_label|trans }}
+                </button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Goal

Closes #1293 (follow-up to #1168). Deleting an alias no longer requires re-entering the account password.

The `AliasVoter` already restricts deletion: random aliases by their owner, and any alias by an admin / domain admin. Normal users cannot delete custom aliases at all — so the password prompt added friction without security value.

## Changes

- **Controller** (`AliasController::deleteSubmit`): drops the password-confirmation flow entirely. Validates only the `delete_alias_<id>` CSRF token; authorization stays with `AliasVoter`. Applies to both random and custom aliases.
- **New `_confirm_modal.html.twig`**: reusable, parameterised confirm modal with no password field, driven by the `delete-modal` Stimulus controller. Delete buttons are now CSRF-protected POST forms whose submit is intercepted to show the confirm dialog.
- **Translations**: added `flashes.alias-deletion-failed` (EN + DE) for the CSRF-invalid case.
- **Behat**: the alias deletion scenario no longer fills in a password.

## Verification

- `composer cs-fix` — no changes
- `composer psalm` — no errors
- `composer rector-check` — OK
- `bin/console lint:twig` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

Alias with delete button:

![alias list with delete button](https://github.com/user-attachments/assets/21e7e405-140a-4f4d-ab06-ccd892a06375)

Confirm dialog — no password field:

![confirm modal without password](https://github.com/user-attachments/assets/b9d1a68e-a533-4b08-8b75-c85508cf1057)
