### PR TITLE
:bug: Make LoadReservedNameData fixture idempotent

### DIFF
--- a/src/DataFixtures/LoadReservedNameData.php
+++ b/src/DataFixtures/LoadReservedNameData.php
@@ -23,7 +23,15 @@ final class LoadReservedNameData extends Fixture implements FixtureGroupInterfac
     #[Override]
     public function load(ObjectManager $manager): void
     {
+        $repository = $manager->getRepository(ReservedName::class);
+
         foreach (self::RESERVED_NAMES as $name) {
+            // Skip names already present (e.g. seeded by migrations) so the
+            // fixture stays idempotent when loaded with --append.
+            if (null !== $repository->findOneBy(['name' => $name])) {
+                continue;
+            }
+
             $reservedName = new ReservedName();
             $reservedName->setName($name);
             $manager->persist($reservedName);


### PR DESCRIPTION
## Problem

`make fixtures` fails on any migrated database:

```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'postmaster' for key 'UNIQ_E40F23B05E237E06'
```

Migration `Version20260418120000` ("Migrate postmaster aliases to settings and ensure reserved names exist") seeds the `postmaster` and `abuse` reserved names. `LoadReservedNameData` (group `basic`) inserts `admin, root, postmaster, abuse, webmaster`. Since `make fixtures` loads with `--append` (no purge), the overlapping names collide → duplicate-key crash.

## Fix

`LoadReservedNameData::load` now skips names already present before persisting, keeping the fixture idempotent under `--append`.

## Verification

- `doctrine:fixtures:load --group=basic --append` succeeds against a DB already seeded by the migration
- `reserved_names` ends with exactly one row per name (admin, root, postmaster, abuse, webmaster)
- `composer cs-fix` (no changes), `composer psalm` (no errors), `composer rector-check` (OK)

Found while setting up local env for #1293; unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)