### PR TITLE
fix: Handle webpack-encore 7 ESM default export in webpack config

### DIFF
--- a/src/DataFixtures/LoadReservedNameData.php
+++ b/src/DataFixtures/LoadReservedNameData.php
@@ -15,6 +15,7 @@ final class LoadReservedNameData extends Fixture implements FixtureGroupInterfac
     private const array RESERVED_NAMES = [
         'admin',
         'root',
+        'abuse',
         'webmaster',
     ];
 

--- a/src/DataFixtures/LoadReservedNameData.php
+++ b/src/DataFixtures/LoadReservedNameData.php
@@ -15,7 +15,6 @@ final class LoadReservedNameData extends Fixture implements FixtureGroupInterfac
     private const array RESERVED_NAMES = [
         'admin',
         'root',
-        'abuse',
         'webmaster',
     ];
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
-const Encore = require("@symfony/webpack-encore");
+const _encore = require("@symfony/webpack-encore");
+// webpack-encore >=7 is ESM; require() on Node 22+ returns the namespace object
+const Encore = _encore.default ?? _encore;
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 Encore


### PR DESCRIPTION
## Summary

- `webpack-encore@7.x` ships as a pure ES module (`type: module`, `export default`). On Node 22+, `require()` of an ES module returns the namespace object `{ default: EncoreProxy }` instead of `EncoreProxy` directly — causing `TypeError: Encore.setOutputPath is not a function` in CI.
- Fix uses `_encore.default ?? _encore` so the config works with both encore 6 (CJS, no `.default`) and encore 7+ (ESM, `.default` holds the proxy).
- Also resolves a local merge conflict in `LoadReservedNameData`, keeping the `'abuse'` reserved name addition.

This unblocks the dependabot PR #1309 which bumps encore to 7.1.0 (and Babel to 8.x, which encore 7 requires as a peer dependency).

---
<sub>The changes and the PR were generated by Claude.</sub>