### PR TITLE
🐛 fix: Only resolve RFC aliases for managed domains

### DIFF
--- a/features/api_postfix.feature
+++ b/features/api_postfix.feature
@@ -73,6 +73,19 @@ Feature: Postfix API
             """
 
     @alias
+    Scenario: Get postmaster alias for unmanaged domain returns empty
+        Given the following Setting exists:
+            | name                | value              |
+            | postmaster_address  | admin@example.org  |
+        And I have a valid API token "postfix-test-123"
+        When I send a GET request to "/api/postfix/alias/postmaster@unmanaged.org"
+        Then the response status code should equal 200
+        And the JSON response should be:
+            """
+            []
+            """
+
+    @alias
     Scenario: Get postmaster alias without setting returns empty
         Given I have a valid API token "postfix-test-123"
         When I send a GET request to "/api/postfix/alias/postmaster@example.org"

--- a/src/Service/RfcAliasResolver.php
+++ b/src/Service/RfcAliasResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Repository\AliasRepository;
+use App\Repository\DomainRepository;
 
 final readonly class RfcAliasResolver
 {
@@ -15,18 +16,23 @@ final readonly class RfcAliasResolver
 
     public function __construct(
         private AliasRepository $aliasRepository,
+        private DomainRepository $domainRepository,
         private SettingsService $settingsService,
     ) {
     }
 
     /**
-     * Check if the source address matches an RFC address prefix.
+     * Check if the source address matches an RFC address prefix on a managed domain.
      */
     public function isRfcAddress(string $source): bool
     {
         $localPart = strstr($source, '@', true);
 
-        return false !== $localPart && isset(self::RFC_ADDRESS_SETTINGS[$localPart]);
+        if (false === $localPart || !isset(self::RFC_ADDRESS_SETTINGS[$localPart])) {
+            return false;
+        }
+
+        return $this->domainRepository->existsByName(substr($source, strlen($localPart) + 1));
     }
 
     /**
@@ -38,9 +44,8 @@ final readonly class RfcAliasResolver
      */
     public function resolveDestinations(string $source): array
     {
-        $localPart = strstr($source, '@', true);
-
-        if (false !== $localPart && isset(self::RFC_ADDRESS_SETTINGS[$localPart])) {
+        if ($this->isRfcAddress($source)) {
+            $localPart = strstr($source, '@', true);
             $settingKey = self::RFC_ADDRESS_SETTINGS[$localPart];
             $destination = (string) $this->settingsService->get($settingKey, '');
 

--- a/tests/Service/RfcAliasResolverTest.php
+++ b/tests/Service/RfcAliasResolverTest.php
@@ -5,12 +5,22 @@ declare(strict_types=1);
 namespace App\Tests\Service;
 
 use App\Repository\AliasRepository;
+use App\Repository\DomainRepository;
 use App\Service\RfcAliasResolver;
 use App\Service\SettingsService;
 use PHPUnit\Framework\TestCase;
 
 class RfcAliasResolverTest extends TestCase
 {
+    private function createDomainRepository(array $managedDomains = ['example.org']): DomainRepository
+    {
+        $domainRepository = $this->createMock(DomainRepository::class);
+        $domainRepository->method('existsByName')
+            ->willReturnCallback(static fn (string $name): bool => in_array($name, $managedDomains, true));
+
+        return $domainRepository;
+    }
+
     public function testReturnsSettingDestinationForPostmaster(): void
     {
         $settingsService = $this->createMock(SettingsService::class);
@@ -21,7 +31,7 @@ class RfcAliasResolverTest extends TestCase
         $aliasRepository = $this->createMock(AliasRepository::class);
         $aliasRepository->expects(self::never())->method('findDestinationsBySource');
 
-        $resolver = new RfcAliasResolver($aliasRepository, $settingsService);
+        $resolver = new RfcAliasResolver($aliasRepository, $this->createDomainRepository(), $settingsService);
 
         self::assertSame(['admin@example.org'], $resolver->resolveDestinations('postmaster@example.org'));
     }
@@ -36,7 +46,7 @@ class RfcAliasResolverTest extends TestCase
         $aliasRepository = $this->createMock(AliasRepository::class);
         $aliasRepository->expects(self::never())->method('findDestinationsBySource');
 
-        $resolver = new RfcAliasResolver($aliasRepository, $settingsService);
+        $resolver = new RfcAliasResolver($aliasRepository, $this->createDomainRepository(), $settingsService);
 
         self::assertSame(['abuse-team@example.org'], $resolver->resolveDestinations('abuse@example.org'));
     }
@@ -54,7 +64,7 @@ class RfcAliasResolverTest extends TestCase
             ->with('postmaster@example.org')
             ->willReturn(['fallback@example.org']);
 
-        $resolver = new RfcAliasResolver($aliasRepository, $settingsService);
+        $resolver = new RfcAliasResolver($aliasRepository, $this->createDomainRepository(), $settingsService);
 
         self::assertSame(['fallback@example.org'], $resolver->resolveDestinations('postmaster@example.org'));
     }
@@ -70,9 +80,25 @@ class RfcAliasResolverTest extends TestCase
             ->with('info@example.org')
             ->willReturn(['user@example.org']);
 
-        $resolver = new RfcAliasResolver($aliasRepository, $settingsService);
+        $resolver = new RfcAliasResolver($aliasRepository, $this->createDomainRepository(), $settingsService);
 
         self::assertSame(['user@example.org'], $resolver->resolveDestinations('info@example.org'));
+    }
+
+    public function testDelegatesUnmanagedDomainToRepository(): void
+    {
+        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService->expects(self::never())->method('get');
+
+        $aliasRepository = $this->createMock(AliasRepository::class);
+        $aliasRepository->expects(self::once())
+            ->method('findDestinationsBySource')
+            ->with('postmaster@unmanaged.org')
+            ->willReturn([]);
+
+        $resolver = new RfcAliasResolver($aliasRepository, $this->createDomainRepository(), $settingsService);
+
+        self::assertSame([], $resolver->resolveDestinations('postmaster@unmanaged.org'));
     }
 
     public function testHandlesSourceWithoutAtSign(): void
@@ -85,7 +111,7 @@ class RfcAliasResolverTest extends TestCase
             ->with('nodomain')
             ->willReturn([]);
 
-        $resolver = new RfcAliasResolver($aliasRepository, $settingsService);
+        $resolver = new RfcAliasResolver($aliasRepository, $this->createDomainRepository(), $settingsService);
 
         self::assertSame([], $resolver->resolveDestinations('nodomain'));
     }
@@ -94,6 +120,7 @@ class RfcAliasResolverTest extends TestCase
     {
         $resolver = new RfcAliasResolver(
             $this->createMock(AliasRepository::class),
+            $this->createDomainRepository(),
             $this->createMock(SettingsService::class),
         );
 
@@ -105,10 +132,23 @@ class RfcAliasResolverTest extends TestCase
     {
         $resolver = new RfcAliasResolver(
             $this->createMock(AliasRepository::class),
+            $this->createDomainRepository(),
             $this->createMock(SettingsService::class),
         );
 
         self::assertFalse($resolver->isRfcAddress('info@example.org'));
         self::assertFalse($resolver->isRfcAddress('nodomain'));
+    }
+
+    public function testIsRfcAddressReturnsFalseForUnmanagedDomain(): void
+    {
+        $resolver = new RfcAliasResolver(
+            $this->createMock(AliasRepository::class),
+            $this->createDomainRepository(),
+            $this->createMock(SettingsService::class),
+        );
+
+        self::assertFalse($resolver->isRfcAddress('postmaster@unmanaged.org'));
+        self::assertFalse($resolver->isRfcAddress('abuse@unmanaged.org'));
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #1252: the Postfix alias endpoint resolved `postmaster@` and `abuse@` addresses from the RFC address settings for **any** domain — including domains not managed by this instance. When Postfix queried an alias like `postmaster@unmanaged.example`, the API returned the configured RFC destination, making the instance appear responsible for mail it should not handle.

## Changes

- `RfcAliasResolver::isRfcAddress()` now also verifies that the domain part of the source address is a managed domain (via `DomainRepository::existsByName()`). Addresses on unmanaged domains fall back to the regular alias lookup, which yields an empty result.
- Unit tests extended with cases for unmanaged domains.
- New Behat scenario asserting that `postmaster@unmanaged.org` returns `[]` even when `postmaster_address` is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)